### PR TITLE
feat(security): opt-in auth, CORS, rate limiting, body size limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ Your AI agents are robots. Your projects are planets. You run the galaxy.
 
 <img src="docs/screenshots/galaxy-view.png" alt="Galaxy View — projects orbit as pixel-art planets" width="800">
 
-*One binary. One SQLite file. 58 MCP tools. Zero config.*
+*One binary. One SQLite file. 58 MCP tools. Zero required config.*
 
-**100% local. No cloud, no API keys, no telemetry. Your agents, your data, your machine.**
+**100% local by default. Optional API key for team/server deployments. No cloud, no telemetry.**
 
 </div>
 
@@ -58,6 +58,40 @@ Connect any MCP client:
 ```
 
 That's it. Your agents register, talk, remember, and execute. You watch the galaxy.
+
+### Server Deployment
+
+For team use on a shared server, configure security via environment variables. **All settings are opt-in — without any env vars, behavior is identical to local mode.**
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `PORT` | `8090` | Bind port |
+| `RELAY_API_KEY` | *(none)* | Shared secret. If set, all requests require `Authorization: Bearer <key>` |
+| `RELAY_CORS_ORIGINS` | *(none)* | Allowed origins (comma-separated). `*` for all |
+| `RELAY_MAX_BODY` | `0` (unlimited) | Max request body in bytes (e.g. `1048576` for 1MB) |
+| `RELAY_RATE_LIMIT` | `0` (disabled) | Requests/minute per IP |
+
+Example:
+```bash
+RELAY_API_KEY=my-team-secret RELAY_CORS_ORIGINS=https://relay.myteam.dev ./agent-relay serve
+```
+
+MCP client config with auth:
+```json
+{
+  "mcpServers": {
+    "agent-relay": {
+      "type": "http",
+      "url": "http://your-server:8090/mcp",
+      "headers": {
+        "Authorization": "Bearer my-team-secret"
+      }
+    }
+  }
+}
+```
+
+For TLS, put a reverse proxy (Caddy, nginx) in front.
 
 ### First project setup
 

--- a/go.mod
+++ b/go.mod
@@ -18,5 +18,6 @@ require (
 	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	golang.org/x/sys v0.13.0 // indirect
+	golang.org/x/time v0.15.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -39,6 +39,8 @@ github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zI
 github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
 golang.org/x/sys v0.13.0 h1:Af8nKPmuFypiUBjVoU9V20FiaFXOcuZI21p0ycVYYGE=
 golang.org/x/sys v0.13.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/time v0.15.0 h1:bbrp8t3bGUeFOx08pvsMYRTCVSMk89u4tKbNOZbp88U=
+golang.org/x/time v0.15.0/go.mod h1:Y4YMaQmXwGQZoFaVFk4YpCt4FLQMYKZe9oeV/f4MSno=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,46 @@
+package config
+
+import (
+	"os"
+	"strconv"
+	"strings"
+)
+
+// Config holds server security settings loaded from environment variables.
+// All settings are opt-in — zero values preserve backward-compatible behavior.
+type Config struct {
+	APIKey      string   // RELAY_API_KEY: shared secret for Bearer auth
+	CORSOrigins []string // RELAY_CORS_ORIGINS: allowed origins (comma-separated)
+	MaxBody     int64    // RELAY_MAX_BODY: max request body in bytes
+	RateLimit   int      // RELAY_RATE_LIMIT: requests/minute per IP
+}
+
+// Load reads configuration from environment variables with safe defaults.
+func Load() Config {
+	cfg := Config{
+		APIKey: os.Getenv("RELAY_API_KEY"),
+	}
+
+	if v := os.Getenv("RELAY_CORS_ORIGINS"); v != "" {
+		for _, origin := range strings.Split(v, ",") {
+			origin = strings.TrimSpace(origin)
+			if origin != "" {
+				cfg.CORSOrigins = append(cfg.CORSOrigins, origin)
+			}
+		}
+	}
+
+	if v := os.Getenv("RELAY_MAX_BODY"); v != "" {
+		if n, err := strconv.ParseInt(v, 10, 64); err == nil && n > 0 {
+			cfg.MaxBody = n
+		}
+	}
+
+	if v := os.Getenv("RELAY_RATE_LIMIT"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			cfg.RateLimit = n
+		}
+	}
+
+	return cfg
+}

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -21,7 +21,7 @@ func New() (*DB, error) {
 	}
 
 	dbDir := filepath.Join(home, ".agent-relay")
-	if err := os.MkdirAll(dbDir, 0755); err != nil {
+	if err := os.MkdirAll(dbDir, 0700); err != nil {
 		return nil, fmt.Errorf("create db dir: %w", err)
 	}
 

--- a/internal/relay/api.go
+++ b/internal/relay/api.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -14,6 +15,12 @@ import (
 	"agent-relay/internal/ingest"
 	"agent-relay/internal/models"
 )
+
+// apiError logs the full error server-side and returns a safe message to the client.
+func apiError(w http.ResponseWriter, status int, msg string, err error) {
+	log.Printf("API error: %s: %v", msg, err)
+	http.Error(w, fmt.Sprintf(`{"error":"%s"}`, msg), status)
+}
 
 // ServeAPI handles REST API requests for the web UI.
 func (r *Relay) ServeAPI(w http.ResponseWriter, req *http.Request) {
@@ -706,7 +713,7 @@ func (r *Relay) apiResolveMemoryConflict(w http.ResponseWriter, req *http.Reques
 
 	mem, err := r.DB.ResolveConflict(body.Project, "user", key, body.ChosenValue, body.Scope)
 	if err != nil {
-		http.Error(w, fmt.Sprintf(`{"error":"%s"}`, err.Error()), http.StatusInternalServerError)
+		apiError(w, http.StatusInternalServerError, "failed to resolve conflict", err)
 		return
 	}
 	writeJSON(w, map[string]any{"resolved": true, "memory": mem})
@@ -963,7 +970,7 @@ func (r *Relay) apiDispatchTask(w http.ResponseWriter, req *http.Request) {
 
 	task, err := r.DB.DispatchTask(body.Project, body.Profile, "user", body.Title, body.Description, body.Priority, body.ParentTaskID, body.BoardID, body.GoalID)
 	if err != nil {
-		http.Error(w, fmt.Sprintf(`{"error":"%s"}`, err.Error()), http.StatusInternalServerError)
+		apiError(w, http.StatusInternalServerError, "failed to dispatch task", err)
 		return
 	}
 	writeJSON(w, task)
@@ -1018,7 +1025,7 @@ func (r *Relay) apiTransitionTask(w http.ResponseWriter, req *http.Request, path
 		return
 	}
 	if err != nil {
-		http.Error(w, fmt.Sprintf(`{"error":"%s"}`, err.Error()), http.StatusBadRequest)
+		apiError(w, http.StatusBadRequest, "task transition failed", err)
 		return
 	}
 	writeJSON(w, task)
@@ -1048,7 +1055,7 @@ func (r *Relay) apiUpdateTask(w http.ResponseWriter, req *http.Request, path str
 
 	task, err := r.DB.UpdateTaskFields(taskID, body.Project, body.Title, body.Description, body.Priority)
 	if err != nil {
-		http.Error(w, fmt.Sprintf(`{"error":"%s"}`, err.Error()), http.StatusBadRequest)
+		apiError(w, http.StatusBadRequest, "failed to update task", err)
 		return
 	}
 	writeJSON(w, task)
@@ -1067,7 +1074,7 @@ func (r *Relay) apiDeleteTask(w http.ResponseWriter, req *http.Request, path str
 	}
 
 	if err := r.DB.DeleteTask(taskID, project); err != nil {
-		http.Error(w, fmt.Sprintf(`{"error":"%s"}`, err.Error()), http.StatusInternalServerError)
+		apiError(w, http.StatusInternalServerError, "failed to delete task", err)
 		return
 	}
 	writeJSON(w, map[string]any{"deleted": true, "id": taskID})
@@ -1257,7 +1264,7 @@ func (r *Relay) apiCreateGoal(w http.ResponseWriter, req *http.Request) {
 
 	goal, err := r.DB.CreateGoal(body.Project, body.Type, body.Title, body.Description, "user", body.OwnerAgent, body.ParentGoalID)
 	if err != nil {
-		http.Error(w, fmt.Sprintf(`{"error":"%s"}`, err.Error()), http.StatusInternalServerError)
+		apiError(w, http.StatusInternalServerError, "failed to create goal", err)
 		return
 	}
 	writeJSON(w, goal)
@@ -1286,7 +1293,7 @@ func (r *Relay) apiUpdateGoal(w http.ResponseWriter, req *http.Request, path str
 
 	goal, err := r.DB.UpdateGoal(goalID, body.Project, body.Title, body.Description, body.Status)
 	if err != nil {
-		http.Error(w, fmt.Sprintf(`{"error":"%s"}`, err.Error()), http.StatusBadRequest)
+		apiError(w, http.StatusBadRequest, "failed to update goal", err)
 		return
 	}
 	writeJSON(w, goal)
@@ -1486,7 +1493,7 @@ func (r *Relay) apiUpdateVaultDoc(w http.ResponseWriter, req *http.Request, path
 	}
 
 	if err := os.WriteFile(absPath, []byte(newContent), 0644); err != nil {
-		http.Error(w, fmt.Sprintf(`{"error":"failed to write file: %v"}`, err), http.StatusInternalServerError)
+		apiError(w, http.StatusInternalServerError, "failed to write vault file", err)
 		return
 	}
 

--- a/internal/relay/middleware.go
+++ b/internal/relay/middleware.go
@@ -1,0 +1,142 @@
+package relay
+
+import (
+	"crypto/subtle"
+	"net"
+	"net/http"
+	"sync"
+	"time"
+
+	"golang.org/x/time/rate"
+)
+
+// authMiddleware rejects requests without a valid Bearer token.
+// If apiKey is empty, all requests pass through (local-mode).
+func authMiddleware(apiKey string, next http.Handler) http.Handler {
+	if apiKey == "" {
+		return next
+	}
+	expected := []byte(apiKey)
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		token := r.Header.Get("Authorization")
+		const prefix = "Bearer "
+		if len(token) > len(prefix) && token[:len(prefix)] == prefix {
+			token = token[len(prefix):]
+		} else {
+			token = ""
+		}
+		if subtle.ConstantTimeCompare([]byte(token), expected) != 1 {
+			http.Error(w, `{"error":"unauthorized"}`, http.StatusUnauthorized)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+// bodySizeLimitMiddleware wraps request bodies with http.MaxBytesReader.
+func bodySizeLimitMiddleware(maxBytes int64, next http.Handler) http.Handler {
+	if maxBytes <= 0 {
+		return next
+	}
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		r.Body = http.MaxBytesReader(w, r.Body, maxBytes)
+		next.ServeHTTP(w, r)
+	})
+}
+
+// rateLimitMiddleware limits requests per IP using a token bucket.
+// If reqPerMin is 0, all requests pass through.
+func rateLimitMiddleware(reqPerMin int, next http.Handler) http.Handler {
+	if reqPerMin <= 0 {
+		return next
+	}
+
+	type visitor struct {
+		limiter  *rate.Limiter
+		lastSeen time.Time
+	}
+	var mu sync.Mutex
+	visitors := make(map[string]*visitor)
+
+	// Cleanup stale entries every 10 minutes.
+	go func() {
+		for {
+			time.Sleep(10 * time.Minute)
+			mu.Lock()
+			for ip, v := range visitors {
+				if time.Since(v.lastSeen) > 15*time.Minute {
+					delete(visitors, ip)
+				}
+			}
+			mu.Unlock()
+		}
+	}()
+
+	perSecond := rate.Limit(float64(reqPerMin) / 60.0)
+	burst := reqPerMin // allow bursting up to the full per-minute quota
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ip, _, _ := net.SplitHostPort(r.RemoteAddr)
+		if ip == "" {
+			ip = r.RemoteAddr
+		}
+
+		mu.Lock()
+		v, ok := visitors[ip]
+		if !ok {
+			v = &visitor{limiter: rate.NewLimiter(perSecond, burst)}
+			visitors[ip] = v
+		}
+		v.lastSeen = time.Now()
+		mu.Unlock()
+
+		if !v.limiter.Allow() {
+			w.Header().Set("Retry-After", "60")
+			http.Error(w, `{"error":"rate limit exceeded"}`, http.StatusTooManyRequests)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+// corsMiddleware sets CORS headers for the configured origins.
+// If origins is empty, no CORS headers are added (same-origin by default).
+func corsMiddleware(origins []string, next http.Handler) http.Handler {
+	if len(origins) == 0 {
+		return next
+	}
+	allowAll := len(origins) == 1 && origins[0] == "*"
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		origin := r.Header.Get("Origin")
+		if origin == "" {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		allowed := allowAll
+		if !allowed {
+			for _, o := range origins {
+				if o == origin {
+					allowed = true
+					break
+				}
+			}
+		}
+		if !allowed {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		w.Header().Set("Access-Control-Allow-Origin", origin)
+		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, PATCH, DELETE, OPTIONS")
+		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
+		w.Header().Set("Access-Control-Max-Age", "86400")
+
+		if r.Method == http.MethodOptions {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"net/http"
 
+	"agent-relay/internal/config"
 	"agent-relay/internal/db"
 	"agent-relay/internal/ingest"
 	"agent-relay/internal/vault"
@@ -23,11 +24,12 @@ type Relay struct {
 	Ingester     *ingest.Ingester
 	VaultWatcher *vault.Watcher
 	Events       *EventBus
+	Config       config.Config
 	httpServer   *http.Server
 }
 
 // New creates a fully wired Relay with all tools registered.
-func New(database *db.DB, ingester *ingest.Ingester, vaultWatcher *vault.Watcher) *Relay {
+func New(database *db.DB, ingester *ingest.Ingester, vaultWatcher *vault.Watcher, cfg config.Config) *Relay {
 	mcpSrv := server.NewMCPServer(
 		"agent-relay",
 		"1.0.0",
@@ -127,6 +129,7 @@ func New(database *db.DB, ingester *ingest.Ingester, vaultWatcher *vault.Watcher
 		Ingester:     ingester,
 		VaultWatcher: vaultWatcher,
 		Events:       events,
+		Config:       cfg,
 	}
 }
 
@@ -150,8 +153,19 @@ func (r *Relay) ListenAndServe(addr string) error {
 	}
 	mux.Handle("/", http.FileServerFS(staticFS))
 
-	r.httpServer = &http.Server{Addr: addr, Handler: mux}
+	handler := r.buildMiddlewareChain(mux)
+	r.httpServer = &http.Server{Addr: addr, Handler: handler}
 	return r.httpServer.ListenAndServe()
+}
+
+// buildMiddlewareChain wraps the mux with security middleware.
+// Order: CORS (outermost) → RateLimit → BodyLimit → Auth → handler.
+func (r *Relay) buildMiddlewareChain(handler http.Handler) http.Handler {
+	handler = authMiddleware(r.Config.APIKey, handler)
+	handler = bodySizeLimitMiddleware(r.Config.MaxBody, handler)
+	handler = rateLimitMiddleware(r.Config.RateLimit, handler)
+	handler = corsMiddleware(r.Config.CORSOrigins, handler)
+	return handler
 }
 
 // Shutdown gracefully stops the HTTP server.

--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 
 	"agent-relay/docs"
 	"agent-relay/internal/cli"
+	"agent-relay/internal/config"
 	"agent-relay/internal/db"
 	"agent-relay/internal/ingest"
 	"agent-relay/internal/relay"
@@ -46,7 +47,8 @@ func main() {
 
 func startServer() {
 	log.SetFlags(log.LstdFlags | log.Lshortfile)
-	log.Println("agent-relay starting...")
+
+	cfg := config.Load()
 
 	database, err := db.New()
 	if err != nil {
@@ -70,7 +72,7 @@ func startServer() {
 	vaultWatcher.Start()
 	defer vaultWatcher.Stop()
 
-	r := relay.New(database, ingester, vaultWatcher)
+	r := relay.New(database, ingester, vaultWatcher, cfg)
 
 	addr := ":8090"
 	if v := os.Getenv("PORT"); v != "" {
@@ -91,6 +93,23 @@ func startServer() {
 			log.Printf("[ingest] %s session=%s tool=%s activity=%s", evt.Type, evt.SessionID, evt.Tool, evt.Activity)
 		}
 	}()
+
+	// Startup log with security status.
+	authStatus := "disabled"
+	if cfg.APIKey != "" {
+		authStatus = "enabled"
+	}
+	corsStatus := "same-origin"
+	if len(cfg.CORSOrigins) > 0 {
+		corsStatus = fmt.Sprintf("%v", cfg.CORSOrigins)
+	}
+	rateLimitStatus := "disabled"
+	if cfg.RateLimit > 0 {
+		rateLimitStatus = fmt.Sprintf("%d/min", cfg.RateLimit)
+	}
+	log.Printf("agent-relay starting on %s", addr)
+	log.Printf("  auth: %s | cors: %s | max body: %dB | rate limit: %s",
+		authStatus, corsStatus, cfg.MaxBody, rateLimitStatus)
 
 	go func() {
 		log.Printf("listening on %s (UI: http://localhost%s)", addr, addr)


### PR DESCRIPTION
## Summary

- **Auth**: Bearer token via `RELAY_API_KEY` with constant-time comparison
- **CORS**: Configurable origins via `RELAY_CORS_ORIGINS`, preflight handling
- **Rate limiting**: Per-IP via `RELAY_RATE_LIMIT` (req/min) with auto-cleanup
- **Body size limit**: `RELAY_MAX_BODY` via `MaxBytesReader`
- **Error sanitization**: 8 API endpoints no longer leak internal errors/paths to clients
- **DB permissions**: `~/.agent-relay/` directory tightened from `0755` to `0700`
- **Startup log**: Shows security config status on boot

All settings are **fully opt-in** — without any env vars, behavior is identical to local mode. Nothing blocks.

## Test plan

- [ ] `go build ./...` — compiles without errors
- [ ] Start without env vars → no auth, no CORS headers, no rate limiting
- [ ] `RELAY_API_KEY=test` → requests without `Authorization: Bearer test` get 401
- [ ] `RELAY_CORS_ORIGINS=http://localhost:3000` → CORS headers present on responses
- [ ] `RELAY_RATE_LIMIT=5` → 429 returned after burst
- [ ] `RELAY_MAX_BODY=100` → large POST bodies rejected
- [ ] Trigger a DB error → client sees generic message, server log has details

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README clarifying that the single-binary SQLite setup remains local by default; server deployment configuration now documented.

* **New Features**
  * Optional server deployment mode with security features: API key authentication, customizable CORS policies, rate limiting, and request body size controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->