### PR TITLE
feat(ui): colony agent selection redesign

### DIFF
--- a/internal/web/static/index.html
+++ b/internal/web/static/index.html
@@ -127,38 +127,84 @@
   </main>
 
   <div id="agent-detail" class="detail-panel">
-    <button id="detail-close">&times;</button>
-    <div id="detail-name" class="detail-name"></div>
-    <div id="detail-role" class="detail-field"></div>
-    <div id="detail-desc" class="detail-field"></div>
-    <div id="detail-project" class="detail-field"></div>
-    <div class="detail-section">
-      <div class="detail-label">Status</div>
-      <div id="detail-status" class="detail-value"></div>
+    <button id="detail-close" title="Close [Esc]">
+      <img src="img/ui/icons/small/x_big.png" alt="Close" class="detail-close-icon">
+    </button>
+
+    <!-- ═══ MACRO: Identity + live status at a glance ═══ -->
+    <div class="dp-hero">
+      <div class="dp-hero-identity">
+        <div id="detail-name" class="detail-name"></div>
+        <div id="detail-role" class="dp-role"></div>
+      </div>
+      <div class="dp-hero-status">
+        <span id="detail-status-dot" class="dp-status-dot"></span>
+        <span id="detail-status" class="dp-status-text"></span>
+      </div>
+      <div id="detail-activity" class="dp-activity"></div>
     </div>
-    <div class="detail-section">
-      <div class="detail-label">Last Seen</div>
-      <div id="detail-last-seen" class="detail-value"></div>
+
+    <!-- Current task — the single most important info -->
+    <div id="detail-current-task" class="dp-current-task"></div>
+
+    <div class="detail-divider"></div>
+
+    <!-- ═══ MICRO: Expandable detail sections ═══ -->
+    <div id="detail-desc" class="dp-desc"></div>
+    <div id="detail-project" class="dp-project"></div>
+
+    <!-- Stats -->
+    <div class="dp-section">
+      <div class="dp-section-header" data-toggle="dp-stats-body">COMMS</div>
+      <div id="dp-stats-body" class="dp-section-body">
+        <div class="detail-row"><span class="detail-label">Last Seen</span><span id="detail-last-seen" class="detail-value"></span></div>
+        <div class="detail-row"><span class="detail-label">Registered</span><span id="detail-registered" class="detail-value"></span></div>
+      </div>
     </div>
-    <div class="detail-section">
-      <div class="detail-label">Registered</div>
-      <div id="detail-registered" class="detail-value"></div>
+
+    <!-- Hierarchy -->
+    <div class="dp-section">
+      <div class="dp-section-header" data-toggle="dp-hierarchy-body">HIERARCHY</div>
+      <div id="dp-hierarchy-body" class="dp-section-body">
+        <div class="detail-row"><span class="detail-label">Reports To</span><span id="detail-reports-to" class="detail-value"></span></div>
+        <div class="dp-sub"><span class="detail-label">Direct Reports</span></div>
+        <div id="detail-direct-reports" class="detail-value"></div>
+      </div>
     </div>
-    <div class="detail-section">
-      <div class="detail-label">Reports To</div>
-      <div id="detail-reports-to" class="detail-value"></div>
+
+    <!-- Teams -->
+    <div class="dp-section">
+      <div class="dp-section-header" data-toggle="dp-teams-body">TEAMS</div>
+      <div id="dp-teams-body" class="dp-section-body">
+        <div id="detail-teams" class="detail-value"></div>
+      </div>
     </div>
-    <div class="detail-section">
-      <div class="detail-label">Direct Reports</div>
-      <div id="detail-direct-reports" class="detail-value"></div>
+
+    <!-- Recent comms -->
+    <div class="dp-section">
+      <div class="dp-section-header" data-toggle="dp-comms-body">RECENT COMMS</div>
+      <div id="dp-comms-body" class="dp-section-body">
+        <div id="detail-recent-msgs" class="detail-value"></div>
+      </div>
     </div>
-    <div class="detail-section">
-      <div class="detail-label">Teams</div>
-      <div id="detail-teams" class="detail-value"></div>
+
+    <!-- All tasks -->
+    <div class="dp-section">
+      <div class="dp-section-header" data-toggle="dp-tasks-body">TASKS</div>
+      <div id="dp-tasks-body" class="dp-section-body">
+        <div id="detail-tasks" class="detail-value"></div>
+      </div>
     </div>
-    <div id="detail-tasks-section" class="detail-section">
-      <div class="detail-label">Tasks</div>
-      <div id="detail-tasks" class="detail-value"></div>
+
+    <!-- Nav arrows -->
+    <div class="dp-nav">
+      <button id="dp-nav-prev" class="dp-nav-btn" title="Previous agent [←]">
+        <img src="img/ui/icons/small/arrow_left.png" class="dp-nav-icon">
+      </button>
+      <span id="dp-nav-label" class="dp-nav-label"></span>
+      <button id="dp-nav-next" class="dp-nav-btn" title="Next agent [→]">
+        <img src="img/ui/icons/small/arrow_right.png" class="dp-nav-icon">
+      </button>
     </div>
   </div>
 

--- a/internal/web/static/js/agent-view.js
+++ b/internal/web/static/js/agent-view.js
@@ -55,6 +55,8 @@ export class AgentView {
     this.glowPhase = Math.random() * Math.PI * 2;
     this.breathPhase = Math.random() * Math.PI * 2;
     this.hovered = false;
+    this.selected = false;       // Canvas selection ring
+    this._selectPhase = 0;       // Animated rotation for selection ring
     this.ripples = [];
     this._blockedPhase = 0;
     this._workingPhase = 0;
@@ -175,6 +177,10 @@ export class AgentView {
     if (this.activity && this.activity !== "idle") {
       this._activityPhase = (this._activityPhase || 0) + dt * 3;
     }
+    // Selection ring rotation
+    if (this.selected) {
+      this._selectPhase += dt * 1.2;
+    }
 
     // Ripples
     for (let i = this.ripples.length - 1; i >= 0; i--) {
@@ -210,7 +216,7 @@ export class AgentView {
       }
 
       ctx.save();
-      ctx.globalAlpha = alpha;
+      ctx.globalAlpha = dimmed ? alpha * 0.25 : alpha;
       ctx.imageSmoothingEnabled = false;
 
       // --- Executive aura (golden halo) ---
@@ -313,6 +319,56 @@ export class AgentView {
         ctx.beginPath();
         ctx.ellipse(dx, dy + 16, 18, 5, 0, 0, Math.PI * 2);
         ctx.fill();
+      }
+
+      // --- Selection ring (game-style rotating dashed circle) ---
+      if (this.selected && !dimmed) {
+        const selR = 38;
+        const pulse = 0.6 + 0.4 * Math.sin(this._selectPhase * 2.5);
+        const segments = 8;
+        const gap = Math.PI / 12;
+
+        ctx.save();
+        ctx.translate(dx, dy - 2);
+        ctx.rotate(this._selectPhase * 0.5);
+
+        // Outer glow
+        ctx.strokeStyle = `rgba(108, 92, 231, ${0.25 * pulse})`;
+        ctx.lineWidth = 5;
+        ctx.beginPath();
+        ctx.arc(0, 0, selR + 2, 0, Math.PI * 2);
+        ctx.stroke();
+
+        // Main dashed ring
+        ctx.lineWidth = 2;
+        for (let i = 0; i < segments; i++) {
+          const a0 = (i / segments) * Math.PI * 2 + gap / 2;
+          const a1 = ((i + 1) / segments) * Math.PI * 2 - gap / 2;
+          ctx.strokeStyle = i % 2 === 0
+            ? `rgba(162, 155, 254, ${0.9 * pulse})`
+            : `rgba(108, 92, 231, ${0.6 * pulse})`;
+          ctx.beginPath();
+          ctx.arc(0, 0, selR, a0, a1);
+          ctx.stroke();
+        }
+
+        // Corner chevrons (4 small arrows at cardinal points)
+        ctx.strokeStyle = `rgba(162, 155, 254, ${0.8 * pulse})`;
+        ctx.lineWidth = 1.5;
+        for (let i = 0; i < 4; i++) {
+          const angle = (i / 4) * Math.PI * 2;
+          const cx = Math.cos(angle) * (selR + 8);
+          const cy = Math.sin(angle) * (selR + 8);
+          const inward = angle + Math.PI;
+          const chevLen = 4;
+          ctx.beginPath();
+          ctx.moveTo(cx + Math.cos(inward + 0.5) * chevLen, cy + Math.sin(inward + 0.5) * chevLen);
+          ctx.lineTo(cx, cy);
+          ctx.lineTo(cx + Math.cos(inward - 0.5) * chevLen, cy + Math.sin(inward - 0.5) * chevLen);
+          ctx.stroke();
+        }
+
+        ctx.restore();
       }
 
       // Draw mech sprite

--- a/internal/web/static/js/main.js
+++ b/internal/web/static/js/main.js
@@ -1052,17 +1052,100 @@ function showUserTaskCard(task) {
 
 // --- Agent detail panel ---
 
+// Section toggle logic
+document.querySelectorAll(".dp-section-header[data-toggle]").forEach(header => {
+  // Default: all sections open
+  const bodyId = header.getAttribute("data-toggle");
+  const body = document.getElementById(bodyId);
+  if (body) { body.classList.add("open"); header.classList.add("open"); }
+  header.addEventListener("click", () => {
+    header.classList.toggle("open");
+    if (body) body.classList.toggle("open");
+  });
+});
+
+// Nav buttons
+const dpNavPrev = document.getElementById("dp-nav-prev");
+const dpNavNext = document.getElementById("dp-nav-next");
+const dpNavLabel = document.getElementById("dp-nav-label");
+if (dpNavPrev) dpNavPrev.addEventListener("click", () => {
+  const keys = getAgentKeys();
+  if (!keys.length) return;
+  navIndex = (navIndex - 1 + keys.length) % keys.length;
+  const av = agentViews.get(keys[navIndex]);
+  if (av) { av.triggerRipple(); openDetail(av); }
+});
+if (dpNavNext) dpNavNext.addEventListener("click", () => {
+  const keys = getAgentKeys();
+  if (!keys.length) return;
+  navIndex = (navIndex + 1) % keys.length;
+  const av = agentViews.get(keys[navIndex]);
+  if (av) { av.triggerRipple(); openDetail(av); }
+});
+
+const detailActivity = document.getElementById("detail-activity");
+const detailStatusDot = document.getElementById("detail-status-dot");
+const detailCurrentTask = document.getElementById("detail-current-task");
+
 function openDetail(av) {
+  // Clear previous selection ring
+  for (const [, other] of agentViews) other.selected = false;
+  av.selected = true;
+
   focusedAgent = agentKey(av.project, av.name);
   focusedTeam = null;
   detailPanel.classList.add("open");
+
+  // ── MACRO: Identity ──
   detailName.textContent = av.name;
   detailName.style.color = av.color;
-  detailRole.textContent = av.role || "\u2014";
-  detailDesc.textContent = av.description || "\u2014";
-  detailProject.textContent = av.project !== "default" ? `Project: ${av.project}` : "";
-  detailStatus.textContent = av.online ? "Online" : "Offline";
-  detailStatus.style.color = av.online ? "#00e676" : "#636e72";
+  const detailRoleEl = document.getElementById("detail-role");
+  if (detailRoleEl) detailRoleEl.textContent = av.role || "";
+
+  // Status dot + text
+  if (detailStatusDot) {
+    detailStatusDot.className = "dp-status-dot " + (av.sleeping ? "sleeping" : av.online ? "online" : "offline");
+  }
+  detailStatus.textContent = av.sleeping ? "Sleeping" : av.online ? "Online" : "Offline";
+  detailStatus.style.color = av.sleeping ? "#9b59b6" : av.online ? "#00e676" : "#636e72";
+
+  // Activity
+  if (detailActivity) {
+    if (av.activity && av.activity !== "idle") {
+      const label = av.activityTool || av.activity;
+      detailActivity.textContent = label;
+      detailActivity.style.color = av.activity === "working" ? "#00e676" : "#a29bfe";
+    } else {
+      detailActivity.textContent = "";
+    }
+  }
+
+  // ── MACRO: Current task (hero info) ──
+  if (detailCurrentTask) {
+    const agentTasks = allTasks.filter(t => {
+      const tp = t.project || "default";
+      return tp === av.project && (t.assigned_to === av.name || t.dispatched_by === av.name);
+    }).filter(t => t.status !== "done");
+    const current = agentTasks.find(t => t.status === "in-progress") || agentTasks[0];
+    if (current) {
+      const statusColors = { pending: "#ffd93d", accepted: "#74b9ff", "in-progress": "#00e676", blocked: "#ff6b6b" };
+      const c = statusColors[current.status] || "#636e72";
+      detailCurrentTask.innerHTML = `
+        <div class="dp-current-task-label">Current Task</div>
+        <div class="dp-current-task-title">${escapeHtml(current.title)}</div>
+        <div class="dp-current-task-status" style="color:${c}">${current.status} · ${current.priority}</div>
+      `;
+    } else {
+      detailCurrentTask.innerHTML = "";
+    }
+  }
+
+  // ── MICRO: Details ──
+  const detailDescEl = document.getElementById("detail-desc");
+  if (detailDescEl) detailDescEl.textContent = av.description || "";
+  const detailProjectEl = document.getElementById("detail-project");
+  if (detailProjectEl) detailProjectEl.textContent = av.project !== "default" ? av.project : "";
+
   detailLastSeen.textContent = formatTime(av._lastSeenRaw);
   detailRegistered.textContent = formatTime(av._registeredRaw);
 
@@ -1090,7 +1173,6 @@ function openDetail(av) {
       directReports.push(a.name);
     }
   }
-
   if (directReports.length > 0) {
     detailDirectReports.innerHTML = "";
     const container = document.createElement("div");
@@ -1132,28 +1214,65 @@ function openDetail(av) {
     }
   }
 
-  // Show tasks for this agent
+  // All tasks
   const detailTasksEl = document.getElementById("detail-tasks");
   if (detailTasksEl) {
     const agentTasks = allTasks.filter(t => {
       const tp = t.project || "default";
       return tp === av.project && (t.assigned_to === av.name || t.dispatched_by === av.name);
-    }).filter(t => t.status !== "done").slice(0, 5);
-
+    }).filter(t => t.status !== "done").slice(0, 8);
     if (agentTasks.length > 0) {
       detailTasksEl.innerHTML = agentTasks.map(t => {
         const statusColors = { pending: "#ffd93d", accepted: "#74b9ff", "in-progress": "#00e676", blocked: "#ff6b6b" };
         const color = statusColors[t.status] || "#636e72";
         return `<div class="detail-task-item">
           <span style="color:${color}">[${t.status}]</span>
-          <span>${escapeHtml(t.title.length > 30 ? t.title.slice(0, 28) + "..." : t.title)}</span>
-          <span style="color:#636e72">${t.priority}</span>
+          <span>${escapeHtml(t.title.length > 35 ? t.title.slice(0, 33) + "..." : t.title)}</span>
+          <span style="color:#636e72;margin-left:auto">${t.priority}</span>
         </div>`;
       }).join("");
     } else {
       detailTasksEl.textContent = "\u2014";
     }
   }
+
+  // Recent comms — last 3 messages involving this agent
+  const detailRecentMsgs = document.getElementById("detail-recent-msgs");
+  if (detailRecentMsgs) {
+    client.fetchAllMessagesAllProjects().then(allMsgs => {
+      const agentMsgs = allMsgs.filter(m => {
+        const mp = m.project || "default";
+        return mp === av.project && (m.from === av.name || m.to === av.name);
+      }).slice(-5).reverse();
+
+      if (agentMsgs.length > 0) {
+        detailRecentMsgs.innerHTML = agentMsgs.map(m => {
+          const isSent = m.from === av.name;
+          const peer = isSent ? (m.to || "broadcast") : m.from;
+          const dir = isSent ? "→" : "←";
+          const dirColor = isSent ? "#a29bfe" : "#74b9ff";
+          const preview = m.content.length > 60 ? m.content.slice(0, 58) + "..." : m.content;
+          const conv = m.conversation_id ? conversations.find(c => c.id === m.conversation_id) : null;
+          const convTag = conv ? `<span class="dp-msg-conv">${escapeHtml(conv.title || "conv")}</span>` : "";
+          return `<div class="dp-msg-item">
+            <span class="dp-msg-dir" style="color:${dirColor}">${dir}</span>
+            <span class="dp-msg-peer">${escapeHtml(peer)}</span>
+            ${convTag}
+            <div class="dp-msg-preview">${escapeHtml(preview)}</div>
+            <span class="dp-msg-time">${formatTime(m.created_at)}</span>
+          </div>`;
+        }).join("");
+      } else {
+        detailRecentMsgs.innerHTML = '<span style="color:#5a5e78">No messages</span>';
+      }
+    });
+  }
+
+  // Nav label
+  const keys = getAgentKeys();
+  const currentIdx = keys.indexOf(focusedAgent);
+  if (currentIdx >= 0) navIndex = currentIdx;
+  if (dpNavLabel) dpNavLabel.textContent = `${navIndex + 1} / ${keys.length}`;
 
   // Dim other agents
   for (const [key, other] of agentViews) {
@@ -1162,17 +1281,17 @@ function openDetail(av) {
     other.dimMode = !isFocused;
   }
 
-  // Filter messages to this agent
   loadMessages();
 }
 
 detailClose.addEventListener("click", () => {
   detailPanel.classList.remove("open");
   focusedAgent = null;
-  // Restore all agents
+  // Restore all agents + clear selection ring
   for (const [, av] of agentViews) {
     av.highlighted = true;
     av.dimMode = false;
+    av.selected = false;
   }
   loadMessages();
 });
@@ -1382,6 +1501,11 @@ canvas.addEventListener("click", (e) => {
   detailPanel.classList.remove("open");
   focusedAgent = null;
   focusedTeam = null;
+  for (const [, av] of agentViews) {
+    av.selected = false;
+    av.highlighted = true;
+    av.dimMode = false;
+  }
   loadMessages();
 });
 
@@ -2553,7 +2677,14 @@ shortcuts.register("n", "new-task", "New task", () => {
 
 // Agent navigation with arrows
 let navIndex = -1;
-function getAgentKeys() { return [...agentViews.keys()].sort(); }
+function getAgentKeys() {
+  const all = [...agentViews.keys()].sort();
+  // In colony mode, only navigate agents from the current project
+  if (viewMode === "colony" && colonyProject) {
+    return all.filter(k => k.startsWith(colonyProject + ":"));
+  }
+  return all;
+}
 
 shortcuts.register("ArrowRight", "nav-next", "Next agent", () => {
   const keys = getAgentKeys();

--- a/internal/web/static/style.css
+++ b/internal/web/static/style.css
@@ -352,67 +352,310 @@ main.mode-detail #vault-panel { display: none; }
   to { opacity: 1; transform: translateY(0); }
 }
 
-/* Agent Detail Panel */
+/* ═══ Agent Detail Panel — Civ-style macro>micro ═══ */
 .detail-panel {
   position: fixed;
-  right: -360px;
+  right: -380px;
   top: 48px;
   bottom: 0;
   width: 340px;
-  background: rgba(15, 15, 26, 0.98);
-  border-left: 1px solid rgba(108, 92, 231, 0.3);
-  padding: 20px;
-  transition: right 0.3s ease;
+  background: rgba(10, 10, 26, 0.97);
+  border-left: 2px solid rgba(108, 92, 231, 0.35);
+  padding: 14px 16px;
+  transition: right 0.25s cubic-bezier(0.22, 1, 0.36, 1);
   z-index: 20;
   overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  box-shadow:
+    inset 1px 0 0 rgba(162, 155, 254, 0.15),
+    -4px 0 20px rgba(108, 92, 231, 0.08);
 }
+.detail-panel.open { right: 0; }
 
-.detail-panel.open {
-  right: 0;
-}
-
+/* Close button */
 #detail-close {
   position: absolute;
-  top: 12px;
-  right: 12px;
-  background: none;
-  border: none;
-  color: #6a6a80;
-  font-size: 20px;
+  top: 8px;
+  right: 8px;
+  background: rgba(108, 92, 231, 0.08);
+  border: 1px solid rgba(108, 92, 231, 0.2);
+  border-radius: 2px;
   cursor: pointer;
-  font-family: 'JetBrains Mono', monospace;
+  padding: 5px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.15s;
+  z-index: 1;
 }
-
 #detail-close:hover {
-  color: #e0e0e8;
+  background: rgba(108, 92, 231, 0.25);
+  border-color: rgba(162, 155, 254, 0.5);
+}
+.detail-close-icon {
+  width: 14px;
+  height: 14px;
+  image-rendering: pixelated;
+  filter: brightness(0.7);
+  transition: filter 0.15s;
+}
+#detail-close:hover .detail-close-icon {
+  filter: brightness(1.3) drop-shadow(0 0 3px rgba(162, 155, 254, 0.6));
 }
 
-.detail-name {
-  font-size: 18px;
-  font-weight: 700;
-  margin-bottom: 8px;
-}
-
-.detail-field {
-  font-size: 11px;
-  color: #6a6a80;
+/* ── HERO: macro identity ── */
+.dp-hero {
+  padding-right: 28px;
   margin-bottom: 4px;
 }
-
-.detail-section {
-  margin-top: 16px;
+.detail-name {
+  font-size: var(--font-xl);
+  font-weight: 700;
+  margin-bottom: 1px;
+  text-shadow: 0 0 10px currentColor;
+  letter-spacing: 0.3px;
 }
-
-.detail-label {
-  font-size: 9px;
-  color: #6a6a80;
+.dp-role {
+  font-size: var(--font-xs);
+  color: #8890a4;
+  margin-bottom: 6px;
+}
+.dp-hero-status {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 2px;
+}
+.dp-status-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  display: inline-block;
+  flex-shrink: 0;
+}
+.dp-status-dot.online  { background: #00e676; box-shadow: 0 0 6px #00e676; }
+.dp-status-dot.offline { background: #636e72; }
+.dp-status-dot.sleeping { background: #9b59b6; box-shadow: 0 0 6px #9b59b6; }
+.dp-status-text {
+  font-size: 10px;
+  font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 1px;
-  margin-bottom: 4px;
 }
 
+/* Activity label (working, tool_use, etc.) */
+.dp-activity {
+  font-size: 10px;
+  color: #00e676;
+  margin-top: 2px;
+  min-height: 14px;
+}
+.dp-activity:empty { display: none; }
+
+/* ── Current task — the hero info ── */
+.dp-current-task {
+  background: rgba(108, 92, 231, 0.06);
+  border-left: 2px solid rgba(108, 92, 231, 0.4);
+  border-radius: 2px;
+  padding: 6px 10px;
+  margin: 6px 0 4px;
+  min-height: 0;
+}
+.dp-current-task:empty { display: none; }
+.dp-current-task-label {
+  font-size: 8px;
+  color: #7a7e98;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  margin-bottom: 3px;
+}
+.dp-current-task-title {
+  font-size: var(--font-sm);
+  color: #e0e4ea;
+  line-height: 1.3;
+}
+.dp-current-task-status {
+  font-size: 9px;
+  font-weight: 600;
+  margin-top: 2px;
+}
+
+/* Divider */
+.detail-divider {
+  height: 1px;
+  margin: 8px 0;
+  background: linear-gradient(90deg,
+    rgba(108, 92, 231, 0.05),
+    rgba(108, 92, 231, 0.25) 30%,
+    rgba(108, 92, 231, 0.25) 70%,
+    rgba(108, 92, 231, 0.05)
+  );
+  flex-shrink: 0;
+}
+.detail-divider img { display: none; }
+
+/* Description & project */
+.dp-desc {
+  font-size: var(--font-xs);
+  color: #8890a4;
+  line-height: 1.4;
+  margin-bottom: 2px;
+}
+.dp-desc:empty { display: none; }
+.dp-project {
+  font-size: 9px;
+  color: #5a5e78;
+  margin-bottom: 4px;
+}
+.dp-project:empty { display: none; }
+
+/* ── Collapsible sections ── */
+.dp-section {
+  margin: 2px 0;
+}
+.dp-section-header {
+  font-size: 9px;
+  font-weight: 700;
+  color: rgba(162, 155, 254, 0.85);
+  letter-spacing: 1.5px;
+  text-transform: uppercase;
+  padding: 5px 0;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  user-select: none;
+  transition: color 0.15s;
+}
+.dp-section-header:hover { color: rgba(162, 155, 254, 1); }
+.dp-section-header::before {
+  content: '▸';
+  font-size: 8px;
+  transition: transform 0.2s;
+  display: inline-block;
+}
+.dp-section-header.open::before {
+  transform: rotate(90deg);
+}
+.dp-section-header::after {
+  content: '';
+  flex: 1;
+  height: 1px;
+  background: rgba(108, 92, 231, 0.12);
+}
+.dp-section-body {
+  overflow: hidden;
+  max-height: 0;
+  opacity: 0;
+  transition: max-height 0.25s ease, opacity 0.2s ease;
+  padding-left: 4px;
+}
+.dp-section-body.open {
+  max-height: 400px;
+  opacity: 1;
+}
+.dp-sub {
+  margin-top: 6px;
+}
+
+/* Rows */
+.detail-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 2px 0;
+}
+.detail-section { margin-top: 6px; }
+.detail-label {
+  font-size: 9px;
+  color: #7a7e98;
+  text-transform: uppercase;
+  letter-spacing: 0.8px;
+}
 .detail-value {
-  font-size: 12px;
+  font-size: var(--font-sm);
+  color: #c8cce0;
+}
+
+/* ── Nav bar at bottom ── */
+.dp-nav {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  margin-top: auto;
+  padding-top: 10px;
+  border-top: 1px solid rgba(108, 92, 231, 0.1);
+}
+.dp-nav-btn {
+  background: rgba(108, 92, 231, 0.08);
+  border: 1px solid rgba(108, 92, 231, 0.2);
+  border-radius: 2px;
+  cursor: pointer;
+  padding: 4px 8px;
+  display: flex;
+  align-items: center;
+  transition: all 0.15s;
+}
+.dp-nav-btn:hover {
+  background: rgba(108, 92, 231, 0.2);
+  border-color: rgba(162, 155, 254, 0.4);
+}
+.dp-nav-icon {
+  width: 12px;
+  height: 12px;
+  image-rendering: pixelated;
+  filter: brightness(0.8);
+}
+.dp-nav-btn:hover .dp-nav-icon { filter: brightness(1.3); }
+.dp-nav-label {
+  font-size: 9px;
+  color: #5a5e78;
+  letter-spacing: 0.5px;
+}
+
+/* ── Recent comms in detail panel ── */
+.dp-msg-item {
+  padding: 4px 6px;
+  margin-bottom: 4px;
+  background: rgba(108, 92, 231, 0.03);
+  border-left: 2px solid rgba(108, 92, 231, 0.12);
+  border-radius: 1px;
+  font-size: 10px;
+}
+.dp-msg-dir {
+  font-weight: 700;
+  margin-right: 3px;
+}
+.dp-msg-peer {
+  color: #a29bfe;
+  font-weight: 600;
+  font-size: 10px;
+}
+.dp-msg-conv {
+  font-size: 8px;
+  color: #5a5e78;
+  margin-left: 4px;
+  padding: 0 4px;
+  background: rgba(108, 92, 231, 0.08);
+  border-radius: 2px;
+}
+.dp-msg-preview {
+  color: #8890a4;
+  font-size: 9px;
+  line-height: 1.3;
+  margin-top: 2px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.dp-msg-time {
+  font-size: 8px;
+  color: #4a4e60;
+  float: right;
+  margin-top: -12px;
 }
 
 /* Scrollbar styling */
@@ -676,67 +919,92 @@ main.mode-detail #vault-panel { display: none; }
 
 /* Hierarchy links in detail panel */
 .detail-hierarchy-link {
-  color: #6c5ce7;
+  color: #a29bfe;
   cursor: pointer;
   text-decoration: none;
+  font-size: var(--font-sm);
+  transition: all 0.15s;
+  text-shadow: 0 0 6px rgba(162, 155, 254, 0);
 }
 .detail-hierarchy-link:hover {
-  text-decoration: underline;
-  color: #a29bfe;
+  color: #d4cfff;
+  text-shadow: 0 0 8px rgba(162, 155, 254, 0.5);
 }
 
 .detail-reports-list {
   display: flex;
   flex-wrap: wrap;
-  gap: 4px;
+  gap: 5px;
+  margin-top: 4px;
 }
 
 .detail-report-tag {
-  display: inline-block;
-  font-size: 11px;
-  color: #6c5ce7;
-  background: rgba(108, 92, 231, 0.15);
+  display: inline-flex;
+  align-items: center;
+  font-size: 10px;
+  color: #a29bfe;
+  background: rgba(108, 92, 231, 0.1);
+  border: 1px solid rgba(108, 92, 231, 0.2);
   padding: 2px 8px;
-  border-radius: 3px;
+  border-radius: 2px;
   cursor: pointer;
+  transition: all 0.15s;
+  letter-spacing: 0.3px;
 }
 .detail-report-tag:hover {
-  background: rgba(108, 92, 231, 0.3);
+  background: rgba(108, 92, 231, 0.25);
+  border-color: rgba(162, 155, 254, 0.4);
+  box-shadow: 0 0 6px rgba(108, 92, 231, 0.2);
+  color: #d4cfff;
 }
 
 .detail-task-item {
   display: flex;
   gap: 6px;
   font-size: 10px;
-  padding: 3px 0;
-  border-bottom: 1px solid rgba(108, 92, 231, 0.1);
+  padding: 4px 6px;
+  margin-bottom: 3px;
+  background: rgba(108, 92, 231, 0.04);
+  border-left: 2px solid rgba(108, 92, 231, 0.15);
+  border-radius: 1px;
   align-items: center;
+  transition: background 0.15s;
+}
+.detail-task-item:hover {
+  background: rgba(108, 92, 231, 0.08);
 }
 
 /* Team badges in detail panel */
 .detail-team-tag {
-  display: inline-block;
+  display: inline-flex;
+  align-items: center;
   font-size: 10px;
   padding: 2px 8px;
-  border-radius: 3px;
+  border-radius: 2px;
   cursor: default;
   font-weight: 600;
+  letter-spacing: 0.3px;
+  border: 1px solid transparent;
+  transition: all 0.15s;
 }
 
 .detail-team-type-regular {
   color: #74b9ff;
-  background: rgba(116, 185, 255, 0.15);
+  background: rgba(116, 185, 255, 0.1);
+  border-color: rgba(116, 185, 255, 0.15);
 }
 
 .detail-team-type-admin {
   color: #ffd700;
-  background: rgba(255, 215, 0, 0.15);
-  border: 1px solid rgba(255, 215, 0, 0.3);
+  background: rgba(255, 215, 0, 0.1);
+  border: 1px solid rgba(255, 215, 0, 0.25);
+  text-shadow: 0 0 6px rgba(255, 215, 0, 0.3);
 }
 
 .detail-team-type-bot {
   color: #55efc4;
-  background: rgba(85, 239, 196, 0.15);
+  background: rgba(85, 239, 196, 0.1);
+  border-color: rgba(85, 239, 196, 0.15);
 }
 
 /* Header tabs */


### PR DESCRIPTION
## Summary
- Redesign agent detail panel with Civ-style macro > micro pattern: hero zone (name, status, activity), current task highlight, collapsible sections
- Add animated selection ring on canvas around selected mech (rotating dashed segments + chevrons)
- Fade non-selected agents to 25% opacity for visual focus
- Add RECENT COMMS section showing last 5 messages per agent
- Fix arrow key navigation to stay within current project in colony mode

## Test plan
- [ ] Click agent in colony → selection ring appears, others fade
- [ ] Detail panel shows status dot, current task, collapsible sections
- [ ] Arrow keys only cycle through agents of current project
- [ ] Nav arrows at bottom of panel work
- [ ] Section headers toggle open/close
- [ ] RECENT COMMS shows agent messages with direction arrows

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added animated selection ring around selected agents in the colony view
  * Redesigned agent detail panel with collapsible sections for communications, hierarchy, teams, and tasks
  * Added navigation controls to cycle through agents
  * Enhanced agent information display with status indicators, activity label, and current task

* **Style**
  * Refreshed visual design of the agent detail panel with improved layout, spacing, and color scheme

<!-- end of auto-generated comment: release notes by coderabbit.ai -->