### PR TITLE
feat: delete project endpoint and MCP tool

### DIFF
--- a/internal/db/projects.go
+++ b/internal/db/projects.go
@@ -3,6 +3,7 @@ package db
 import (
 	"agent-relay/internal/models"
 	"database/sql"
+	"fmt"
 	"math/rand"
 	"time"
 )
@@ -62,6 +63,40 @@ func (d *DB) GetSetting(key string) string {
 // SetSetting upserts a setting.
 func (d *DB) SetSetting(key, value string) {
 	d.conn.Exec("INSERT INTO settings (key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value = ?", key, value, value)
+}
+
+// DeleteProject removes a project and all its associated data (cascade delete).
+func (d *DB) DeleteProject(name string) error {
+	tx, err := d.conn.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	// Delete all related data
+	tables := []string{
+		"notify_channels", "team_members", "teams", "orgs",
+		"goals", "boards", "vault_docs", "vaults",
+		"message_reads", "memories", "profiles",
+		"tasks", "conversations", "messages", "agents",
+	}
+	for _, t := range tables {
+		if _, err := tx.Exec("DELETE FROM "+t+" WHERE project = ?", name); err != nil {
+			return fmt.Errorf("delete from %s: %w", t, err)
+		}
+	}
+
+	// Delete the project itself
+	res, err := tx.Exec("DELETE FROM projects WHERE name = ?", name)
+	if err != nil {
+		return fmt.Errorf("delete project: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return fmt.Errorf("project %q not found", name)
+	}
+
+	return tx.Commit()
 }
 
 // ListProjectsWithInfo returns all projects with their planet_type and stats.

--- a/internal/relay/api.go
+++ b/internal/relay/api.go
@@ -31,6 +31,8 @@ func (r *Relay) ServeAPI(w http.ResponseWriter, req *http.Request) {
 	switch {
 	case path == "/projects" && req.Method == http.MethodGet:
 		r.apiGetProjects(w)
+	case strings.HasPrefix(path, "/projects/") && req.Method == http.MethodDelete:
+		r.apiDeleteProject(w, strings.TrimPrefix(path, "/projects/"))
 	case strings.HasPrefix(path, "/projects/") && req.Method == http.MethodPatch:
 		r.apiPatchProject(w, req, strings.TrimPrefix(path, "/projects/"))
 	case strings.HasPrefix(path, "/projects/") && req.Method == http.MethodGet:
@@ -196,6 +198,18 @@ func (r *Relay) apiPatchProject(w http.ResponseWriter, req *http.Request, name s
 		return
 	}
 	writeJSON(w, map[string]string{"ok": "true"})
+}
+
+func (r *Relay) apiDeleteProject(w http.ResponseWriter, name string) {
+	if name == "" {
+		http.Error(w, `{"error":"missing project name"}`, http.StatusBadRequest)
+		return
+	}
+	if err := r.DB.DeleteProject(name); err != nil {
+		apiError(w, http.StatusInternalServerError, "failed to delete project", err)
+		return
+	}
+	writeJSON(w, map[string]any{"deleted": true, "project": name})
 }
 
 func (r *Relay) apiGetSettings(w http.ResponseWriter) {

--- a/internal/relay/handlers.go
+++ b/internal/relay/handlers.go
@@ -1305,6 +1305,22 @@ func (h *Handlers) HandleDeleteAgent(ctx context.Context, req mcp.CallToolReques
 	})
 }
 
+func (h *Handlers) HandleDeleteProject(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	project := req.GetString("project", "")
+	if project == "" {
+		return mcp.NewToolResultError("project is required"), nil
+	}
+
+	if err := h.db.DeleteProject(project); err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("failed to delete project: %v", err)), nil
+	}
+
+	return resultJSON(map[string]any{
+		"deleted": true,
+		"project": project,
+	})
+}
+
 func (h *Handlers) HandleSleepAgent(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	project := resolveProject(req)
 	agent := resolveAgent(req)

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -99,6 +99,8 @@ func New(database *db.DB, ingester *ingest.Ingester, vaultWatcher *vault.Watcher
 		server.ServerTool{Tool: deactivateAgentTool(), Handler: handlers.HandleDeactivateAgent},
 		server.ServerTool{Tool: deleteAgentTool(), Handler: handlers.HandleDeleteAgent},
 		server.ServerTool{Tool: sleepAgentTool(), Handler: handlers.HandleSleepAgent},
+		// Project lifecycle
+		server.ServerTool{Tool: deleteProjectTool(), Handler: handlers.HandleDeleteProject},
 		// Soul RAG
 		server.ServerTool{Tool: queryContextTool(), Handler: handlers.HandleQueryContext},
 		// Session context

--- a/internal/relay/tools.go
+++ b/internal/relay/tools.go
@@ -606,6 +606,16 @@ func sleepAgentTool() mcp.Tool {
 	)
 }
 
+// --- Project lifecycle ---
+
+func deleteProjectTool() mcp.Tool {
+	return mcp.NewTool(
+		"delete_project",
+		mcp.WithDescription("Permanently delete a project and ALL its data (agents, tasks, messages, memories, boards, goals, etc). This is irreversible. Use to clean up empty or obsolete projects."),
+		mcp.WithString("project", mcp.Description("Project name to delete"), mcp.Required()),
+	)
+}
+
 // --- Soul RAG ---
 
 func queryContextTool() mcp.Tool {


### PR DESCRIPTION
## Summary
- Add `DELETE /api/projects/:name` REST endpoint
- Add `delete_project` MCP tool for agent-driven cleanup
- Cascade-deletes all related data (agents, tasks, messages, memories, boards, goals, profiles, teams, orgs, vault docs, conversations) in a single transaction

## Test plan
- [ ] `curl -X DELETE localhost:4100/api/projects/test-project` on a project with data
- [ ] Verify all related tables are cleaned up
- [ ] Verify 404-style error on non-existent project
- [ ] Test via MCP tool `delete_project`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now delete projects. Project deletion is permanent and cascades to remove all associated data including team members, goals, tasks, messages, vaults, and other project-related information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->