### PR TITLE
feat: auto-normalize JSON keys to snake_case

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -3,6 +3,7 @@ package db
 import (
 	"database/sql"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 
@@ -388,6 +389,9 @@ func migrate(conn *sql.DB) error {
 		return fmt.Errorf("migrate vault: %w", err)
 	}
 
+	// Lowercase all agent names for case-insensitive matching
+	migrateLowercaseAgentNames(conn)
+
 	return nil
 }
 
@@ -592,4 +596,52 @@ func migrateMemories(conn *sql.DB) error {
 	END`)
 
 	return nil
+}
+
+// migrateLowercaseAgentNames normalizes all agent name fields to lowercase
+// for case-insensitive matching. Idempotent — skips rows already lowercase.
+// If duplicate agent names would result (e.g. "Bot-A" and "bot-a" in same project),
+// the migration is skipped entirely and a warning is logged.
+func migrateLowercaseAgentNames(conn *sql.DB) {
+	// Check for duplicates that would violate UNIQUE(project, name)
+	var dupes int
+	conn.QueryRow(`SELECT COUNT(*) FROM (
+		SELECT project, LOWER(name) FROM agents GROUP BY project, LOWER(name) HAVING COUNT(*) > 1
+	)`).Scan(&dupes)
+	if dupes > 0 {
+		log.Printf("warning: skipping agent name lowercase migration — %d duplicate name(s) found (differing only in case). Resolve manually.", dupes)
+		return
+	}
+
+	tx, err := conn.Begin()
+	if err != nil {
+		return
+	}
+	defer tx.Rollback()
+
+	stmts := []string{
+		"UPDATE agents SET name = LOWER(name) WHERE name != LOWER(name)",
+		"UPDATE agents SET reports_to = LOWER(reports_to) WHERE reports_to IS NOT NULL AND reports_to != LOWER(reports_to)",
+		"UPDATE messages SET from_agent = LOWER(from_agent) WHERE from_agent != LOWER(from_agent)",
+		"UPDATE messages SET to_agent = LOWER(to_agent) WHERE to_agent != LOWER(to_agent)",
+		"UPDATE tasks SET assigned_to = LOWER(assigned_to) WHERE assigned_to IS NOT NULL AND assigned_to != LOWER(assigned_to)",
+		"UPDATE tasks SET dispatched_by = LOWER(dispatched_by) WHERE dispatched_by != LOWER(dispatched_by)",
+		"UPDATE conversations SET created_by = LOWER(created_by) WHERE created_by != LOWER(created_by)",
+		"UPDATE conversation_members SET agent_name = LOWER(agent_name) WHERE agent_name != LOWER(agent_name)",
+		"UPDATE memories SET agent_name = LOWER(agent_name) WHERE agent_name != LOWER(agent_name)",
+		"UPDATE team_members SET agent_name = LOWER(agent_name) WHERE agent_name != LOWER(agent_name)",
+		"UPDATE agent_notify_channels SET agent_name = LOWER(agent_name) WHERE agent_name != LOWER(agent_name)",
+		"UPDATE message_reads SET agent_name = LOWER(agent_name) WHERE agent_name != LOWER(agent_name)",
+		"UPDATE boards SET created_by = LOWER(created_by) WHERE created_by != LOWER(created_by)",
+		"UPDATE goals SET owner_agent = LOWER(owner_agent) WHERE owner_agent IS NOT NULL AND owner_agent != LOWER(owner_agent)",
+		"UPDATE goals SET created_by = LOWER(created_by) WHERE created_by != LOWER(created_by)",
+	}
+
+	for _, s := range stmts {
+		if _, err := tx.Exec(s); err != nil {
+			return
+		}
+	}
+
+	tx.Commit()
 }

--- a/internal/db/memories.go
+++ b/internal/db/memories.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"agent-relay/internal/models"
+	"agent-relay/internal/normalize"
 
 	"github.com/google/uuid"
 )
@@ -16,6 +17,7 @@ const memoryTimeFmt = "2006-01-02T15:04:05.000000Z"
 // SetMemory creates or versions a memory. If the key already exists at the same
 // scope with a different value, a conflict is flagged instead of overwriting.
 func (d *DB) SetMemory(project, agentName, key, value, tagsJSON, scope, confidence, layer string) (*models.Memory, error) {
+	value = normalize.JSONKeys(value)
 	now := time.Now().UTC().Format(memoryTimeFmt)
 	if confidence == "" {
 		confidence = "stated"

--- a/internal/db/messages.go
+++ b/internal/db/messages.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"agent-relay/internal/models"
+	"agent-relay/internal/normalize"
 	"fmt"
 	"time"
 
@@ -18,8 +19,8 @@ func (d *DB) InsertMessage(project, from, to, msgType, subject, content, metadat
 		ReplyTo:        replyTo,
 		Type:           msgType,
 		Subject:        subject,
-		Content:        content,
-		Metadata:       metadata,
+		Content:        normalize.JSONKeys(content),
+		Metadata:       normalize.JSONKeys(metadata),
 		CreatedAt:      now,
 		ConversationID: conversationID,
 		Project:        project,

--- a/internal/db/tasks.go
+++ b/internal/db/tasks.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"agent-relay/internal/models"
+	"agent-relay/internal/normalize"
 	"database/sql"
 	"fmt"
 	"time"
@@ -144,6 +145,7 @@ func (d *DB) transitionTask(taskID, agentName, project, newStatus string, result
 		)
 	case "done":
 		task.CompletedAt = &now
+		result = normalizePtr(result)
 		task.Result = result
 		_, err = d.conn.Exec(
 			"UPDATE tasks SET status = ?, result = ?, completed_at = ? WHERE id = ? AND project = ?",
@@ -532,4 +534,12 @@ func (d *DB) ArchiveTasks(project, status, boardID string) (int64, error) {
 		return 0, fmt.Errorf("archive tasks: %w", err)
 	}
 	return result.RowsAffected()
+}
+
+func normalizePtr(s *string) *string {
+	if s == nil {
+		return nil
+	}
+	v := normalize.JSONKeys(*s)
+	return &v
 }

--- a/internal/normalize/json.go
+++ b/internal/normalize/json.go
@@ -1,0 +1,75 @@
+package normalize
+
+import (
+	"encoding/json"
+	"strings"
+	"unicode"
+)
+
+// JSONKeys normalizes all keys in a JSON string from camelCase to snake_case.
+// If the input is not valid JSON, it is returned unchanged.
+func JSONKeys(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return s
+	}
+
+	// Only process JSON objects and arrays
+	if s[0] != '{' && s[0] != '[' {
+		return s
+	}
+
+	var raw any
+	if err := json.Unmarshal([]byte(s), &raw); err != nil {
+		return s
+	}
+
+	converted := convertKeys(raw)
+	out, err := json.Marshal(converted)
+	if err != nil {
+		return s
+	}
+	return string(out)
+}
+
+func convertKeys(v any) any {
+	switch val := v.(type) {
+	case map[string]any:
+		out := make(map[string]any, len(val))
+		for k, v := range val {
+			out[toSnakeCase(k)] = convertKeys(v)
+		}
+		return out
+	case []any:
+		out := make([]any, len(val))
+		for i, v := range val {
+			out[i] = convertKeys(v)
+		}
+		return out
+	default:
+		return v
+	}
+}
+
+// toSnakeCase converts camelCase/PascalCase to snake_case.
+// Already snake_case strings pass through unchanged.
+func toSnakeCase(s string) string {
+	var b strings.Builder
+	b.Grow(len(s) + 4)
+
+	for i, r := range s {
+		if unicode.IsUpper(r) {
+			if i > 0 {
+				prev := rune(s[i-1])
+				// Insert underscore before uppercase unless already preceded by underscore or uppercase
+				if prev != '_' && !unicode.IsUpper(prev) {
+					b.WriteByte('_')
+				}
+			}
+			b.WriteRune(unicode.ToLower(r))
+		} else {
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}

--- a/internal/normalize/json_test.go
+++ b/internal/normalize/json_test.go
@@ -1,0 +1,69 @@
+package normalize
+
+import "testing"
+
+func TestToSnakeCase(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"taskId", "task_id"},
+		{"assignedTo", "assigned_to"},
+		{"alreadySnake", "already_snake"},
+		{"already_snake", "already_snake"},
+		{"HTMLParser", "htmlparser"},
+		{"id", "id"},
+		{"ID", "id"},
+		{"profileSlug", "profile_slug"},
+		{"parentTaskID", "parent_task_id"},
+		{"", ""},
+	}
+	for _, tc := range cases {
+		got := toSnakeCase(tc.in)
+		if got != tc.want {
+			t.Errorf("toSnakeCase(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestJSONKeys(t *testing.T) {
+	cases := []struct {
+		name, in, want string
+	}{
+		{
+			"camelCase object",
+			`{"taskId":"123","assignedTo":"bot-a","nestedObj":{"parentGoalId":"g1"}}`,
+			`{"assigned_to":"bot-a","nested_obj":{"parent_goal_id":"g1"},"task_id":"123"}`,
+		},
+		{
+			"already snake_case",
+			`{"task_id":"123","assigned_to":"bot-a"}`,
+			`{"assigned_to":"bot-a","task_id":"123"}`,
+		},
+		{
+			"array of objects",
+			`[{"taskId":"1"},{"taskId":"2"}]`,
+			`[{"task_id":"1"},{"task_id":"2"}]`,
+		},
+		{
+			"not json",
+			`hello world`,
+			`hello world`,
+		},
+		{
+			"empty string",
+			``,
+			``,
+		},
+		{
+			"plain text with braces in middle",
+			`some text`,
+			`some text`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := JSONKeys(tc.in)
+			if got != tc.want {
+				t.Errorf("JSONKeys(%q) =\n  %q\nwant:\n  %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/relay/handlers.go
+++ b/internal/relay/handlers.go
@@ -96,13 +96,13 @@ func (h *Handlers) HandleWhoami(ctx context.Context, req mcp.CallToolRequest) (*
 
 func (h *Handlers) HandleRegisterAgent(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	project := resolveProject(req)
-	name := req.GetString("name", "")
+	name := strings.ToLower(req.GetString("name", ""))
 	if name == "" {
 		return mcp.NewToolResultError("name is required"), nil
 	}
 	role := req.GetString("role", "")
 	description := req.GetString("description", "")
-	reportsTo := optionalString(req.GetString("reports_to", ""))
+	reportsTo := optionalStringLower(req.GetString("reports_to", ""))
 	profileSlug := optionalString(req.GetString("profile_slug", ""))
 	isExecutive := req.GetBool("is_executive", false)
 	sessionID := optionalString(req.GetString("session_id", ""))
@@ -136,7 +136,7 @@ func (h *Handlers) HandleRegisterAgent(ctx context.Context, req mcp.CallToolRequ
 func (h *Handlers) HandleSendMessage(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	project := resolveProject(req)
 	from := resolveAgent(req)
-	to := req.GetString("to", "")
+	to := strings.ToLower(req.GetString("to", ""))
 	msgType := req.GetString("type", "notification")
 	subject := req.GetString("subject", "")
 	content := req.GetString("content", "")
@@ -392,9 +392,13 @@ func (h *Handlers) HandleCreateConversation(ctx context.Context, req mcp.CallToo
 		return mcp.NewToolResultError("title is required"), nil
 	}
 
-	members := req.GetStringSlice("members", nil)
-	if len(members) == 0 {
+	rawMembers := req.GetStringSlice("members", nil)
+	if len(rawMembers) == 0 {
 		return mcp.NewToolResultError("at least one other member is required"), nil
+	}
+	members := make([]string, len(rawMembers))
+	for i, m := range rawMembers {
+		members[i] = strings.ToLower(m)
 	}
 
 	// Ensure creator is included in members
@@ -512,7 +516,7 @@ func (h *Handlers) HandleInviteToConversation(ctx context.Context, req mcp.CallT
 	if convID == "" {
 		return mcp.NewToolResultError("conversation_id is required"), nil
 	}
-	invitee := req.GetString("agent_name", "")
+	invitee := strings.ToLower(req.GetString("agent_name", ""))
 	if invitee == "" {
 		return mcp.NewToolResultError("agent_name is required"), nil
 	}
@@ -619,9 +623,10 @@ func resolveProject(req mcp.CallToolRequest) string {
 }
 
 // resolveAgent returns the agent name from the explicit `as` tool parameter.
+// Names are lowercased for case-insensitive matching.
 func resolveAgent(req mcp.CallToolRequest) string {
 	if as := req.GetString("as", ""); as != "" {
-		return as
+		return strings.ToLower(as)
 	}
 	return "anonymous"
 }
@@ -641,6 +646,14 @@ func optionalString(s string) *string {
 		return nil
 	}
 	return &s
+}
+
+func optionalStringLower(s string) *string {
+	if s == "" {
+		return nil
+	}
+	l := strings.ToLower(s)
+	return &l
 }
 
 func sessionFromContext(ctx context.Context) clientSession {
@@ -1217,7 +1230,7 @@ func (h *Handlers) HandleListTasks(ctx context.Context, req mcp.CallToolRequest)
 
 func (h *Handlers) HandleDeactivateAgent(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	project := resolveProject(req)
-	name := req.GetString("name", "")
+	name := strings.ToLower(req.GetString("name", ""))
 	if name == "" {
 		return mcp.NewToolResultError("name is required"), nil
 	}
@@ -1290,7 +1303,7 @@ func (h *Handlers) HandleDeleteBoard(ctx context.Context, req mcp.CallToolReques
 
 func (h *Handlers) HandleDeleteAgent(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	project := resolveProject(req)
-	name := req.GetString("name", "")
+	name := strings.ToLower(req.GetString("name", ""))
 	if name == "" {
 		return mcp.NewToolResultError("name is required"), nil
 	}
@@ -1744,7 +1757,7 @@ func (h *Handlers) HandleListTeams(ctx context.Context, req mcp.CallToolRequest)
 func (h *Handlers) HandleAddTeamMember(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	project := resolveProject(req)
 	teamSlug := req.GetString("team", "")
-	agentName := req.GetString("agent_name", "")
+	agentName := strings.ToLower(req.GetString("agent_name", ""))
 	role := req.GetString("role", "member")
 
 	if teamSlug == "" || agentName == "" {
@@ -1778,7 +1791,7 @@ func (h *Handlers) HandleAddTeamMember(ctx context.Context, req mcp.CallToolRequ
 func (h *Handlers) HandleRemoveTeamMember(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	project := resolveProject(req)
 	teamSlug := req.GetString("team", "")
-	agentName := req.GetString("agent_name", "")
+	agentName := strings.ToLower(req.GetString("agent_name", ""))
 
 	if teamSlug == "" || agentName == "" {
 		return mcp.NewToolResultError("team and agent_name are required"), nil
@@ -1832,7 +1845,7 @@ func (h *Handlers) HandleGetTeamInbox(ctx context.Context, req mcp.CallToolReque
 func (h *Handlers) HandleAddNotifyChannel(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	project := resolveProject(req)
 	agent := resolveAgent(req)
-	target := req.GetString("target", "")
+	target := strings.ToLower(req.GetString("target", ""))
 
 	if target == "" {
 		return mcp.NewToolResultError("target is required"), nil

--- a/skill/relay.md
+++ b/skill/relay.md
@@ -125,6 +125,8 @@ Link session to agent: pass `session_id` from `whoami` in `register_agent`.
 
 ## Data Conventions
 
+**Agent names are case-insensitive.** The relay lowercases all agent names on ingestion. `Bot-A`, `bot-a`, and `BOT-A` all resolve to `bot-a`.
+
 **All JSON keys MUST use `snake_case`** — never camelCase. This applies to:
 - Message `content` and `metadata` fields
 - Task `result` values

--- a/skill/relay.md
+++ b/skill/relay.md
@@ -123,6 +123,21 @@ Thresholds: 1.5s min display, 10s → waiting, 30s → idle, 5min → exited.
 
 Link session to agent: pass `session_id` from `whoami` in `register_agent`.
 
+## Data Conventions
+
+**All JSON keys MUST use `snake_case`** — never camelCase. This applies to:
+- Message `content` and `metadata` fields
+- Task `result` values
+- Memory `value` fields
+- Any structured data exchanged between agents
+
+```
+✅ {"task_id": "abc", "assigned_to": "bot-a", "parent_goal_id": "g1"}
+❌ {"taskId": "abc", "assignedTo": "bot-a", "parentGoalId": "g1"}
+```
+
+The relay auto-normalizes JSON keys to snake_case on ingestion, but agents should follow this convention to avoid confusion.
+
 ## Reference
 
 See `skill/tools-reference.md` for the full 60+ MCP tools list.


### PR DESCRIPTION
## Summary
- Add `internal/normalize` package: converts camelCase JSON keys to snake_case
- Apply normalization on ingestion for message `content`/`metadata`, task `result`, and memory `value`
- Document snake_case convention in `/relay` skill
- Non-JSON content passes through unchanged (safe for plain text)

## Context
Bots exchanging JSON payloads between channels (messages, tasks, memories) sometimes use camelCase keys (`taskId`, `assignedTo`), causing parsing issues for other bots expecting snake_case.

## Test plan
- [x] Unit tests for `toSnakeCase` and `JSONKeys` (8 passing)
- [ ] Send a message with camelCase JSON content, verify it's stored as snake_case
- [ ] Complete a task with camelCase result JSON, verify normalization
- [ ] Verify plain text content is not modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * JSON keys are normalized to snake_case across memories, messages, and task results.
  * User-supplied identifiers (agent names, targets, invites) are treated case-insensitively by lowercasing on ingestion.
  * Migration added to lowercase existing agent-related fields for consistent matching.

* **Documentation**
  * Added data conventions documenting snake_case and lowercase agent names.

* **Tests**
  * Added unit tests covering JSON key normalization and casing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->