### PR TITLE
test: comprehensive MCP handler and REST API test coverage

### DIFF
--- a/internal/db/testing.go
+++ b/internal/db/testing.go
@@ -1,0 +1,21 @@
+package db
+
+import (
+	"database/sql"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+// NewTestDB creates a database at the given path for testing.
+func NewTestDB(path string) (*DB, error) {
+	conn, err := sql.Open("sqlite3", path+"?_journal_mode=WAL&_busy_timeout=5000&_foreign_keys=ON")
+	if err != nil {
+		return nil, err
+	}
+	conn.SetMaxOpenConns(1)
+	if err := migrate(conn); err != nil {
+		conn.Close()
+		return nil, err
+	}
+	return &DB{conn: conn, path: path}, nil
+}

--- a/internal/relay/api_test.go
+++ b/internal/relay/api_test.go
@@ -1,0 +1,592 @@
+package relay
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"agent-relay/internal/config"
+	"agent-relay/internal/db"
+
+	"github.com/mark3labs/mcp-go/server"
+)
+
+// testRelay creates a fully wired Relay with a test DB for API testing.
+func testRelay(t *testing.T) *Relay {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	database, err := db.NewTestDB(dbPath)
+	if err != nil {
+		t.Fatalf("create test db: %v", err)
+	}
+	t.Cleanup(func() { database.Close() })
+
+	mcpSrv := server.NewMCPServer("test", "0.0.0")
+	events := NewEventBus()
+	registry := NewSessionRegistry(mcpSrv)
+
+	return &Relay{
+		MCPServer: mcpSrv,
+		DB:        database,
+		Registry:  registry,
+		Events:    events,
+		Config:    config.Config{},
+	}
+}
+
+func doAPI(r *Relay, method, path string, body string) *httptest.ResponseRecorder {
+	var req *http.Request
+	if body != "" {
+		req = httptest.NewRequest(method, "/api"+path, strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+	} else {
+		req = httptest.NewRequest(method, "/api"+path, nil)
+	}
+	w := httptest.NewRecorder()
+	r.ServeAPI(w, req)
+	return w
+}
+
+func decodeJSON(t *testing.T, w *httptest.ResponseRecorder) map[string]any {
+	t.Helper()
+	var data map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&data); err != nil {
+		t.Fatalf("decode json: %v\nstatus: %d\nbody: %s", err, w.Code, w.Body.String())
+	}
+	return data
+}
+
+func decodeJSONArray(t *testing.T, w *httptest.ResponseRecorder) []any {
+	t.Helper()
+	var data []any
+	if err := json.NewDecoder(w.Body).Decode(&data); err != nil {
+		t.Fatalf("decode json array: %v\nstatus: %d\nbody: %s", err, w.Code, w.Body.String())
+	}
+	return data
+}
+
+// --- Project API Tests ---
+
+func TestAPIGetProjects(t *testing.T) {
+	r := testRelay(t)
+
+	// Create a project by registering an agent
+	r.DB.RegisterAgent("test-proj", "bot-a", "dev", "", nil, nil, false, nil)
+
+	w := doAPI(r, "GET", "/projects", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	projects := decodeJSONArray(t, w)
+	if len(projects) < 1 {
+		t.Errorf("expected at least 1 project, got %d", len(projects))
+	}
+}
+
+func TestAPIGetProject(t *testing.T) {
+	r := testRelay(t)
+	r.DB.RegisterAgent("my-proj", "bot-a", "dev", "", nil, nil, false, nil)
+
+	w := doAPI(r, "GET", "/projects/my-proj", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	proj := decodeJSON(t, w)
+	if proj["name"] != "my-proj" {
+		t.Errorf("expected my-proj, got %v", proj["name"])
+	}
+}
+
+func TestAPIGetProjectNotFound(t *testing.T) {
+	r := testRelay(t)
+	w := doAPI(r, "GET", "/projects/nonexistent", "")
+	if w.Code != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", w.Code)
+	}
+}
+
+func TestAPIPatchProject(t *testing.T) {
+	r := testRelay(t)
+	r.DB.RegisterAgent("my-proj", "bot-a", "dev", "", nil, nil, false, nil)
+
+	w := doAPI(r, "PATCH", "/projects/my-proj", `{"planet_type":"lava/1"}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestAPIPatchProjectMissingPlanetType(t *testing.T) {
+	r := testRelay(t)
+	r.DB.RegisterAgent("my-proj", "bot-a", "dev", "", nil, nil, false, nil)
+
+	w := doAPI(r, "PATCH", "/projects/my-proj", `{}`)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+// --- Settings API Tests ---
+
+func TestAPISettings(t *testing.T) {
+	r := testRelay(t)
+
+	// Get default
+	w := doAPI(r, "GET", "/settings", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	settings := decodeJSON(t, w)
+	if settings["sun_type"] != "1" {
+		t.Errorf("expected default sun_type=1, got %v", settings["sun_type"])
+	}
+
+	// Set
+	w2 := doAPI(r, "PUT", "/settings", `{"sun_type":"3"}`)
+	if w2.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w2.Code)
+	}
+
+	// Verify
+	w3 := doAPI(r, "GET", "/settings", "")
+	settings2 := decodeJSON(t, w3)
+	if settings2["sun_type"] != "3" {
+		t.Errorf("expected sun_type=3, got %v", settings2["sun_type"])
+	}
+}
+
+// --- Agent API Tests ---
+
+func TestAPIGetAgents(t *testing.T) {
+	r := testRelay(t)
+	r.DB.RegisterAgent("p1", "bot-a", "dev", "", nil, nil, false, nil)
+	r.DB.RegisterAgent("p1", "bot-b", "qa", "", nil, nil, false, nil)
+
+	w := doAPI(r, "GET", "/agents?project=p1", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	agents := decodeJSONArray(t, w)
+	if len(agents) != 2 {
+		t.Errorf("expected 2 agents, got %d", len(agents))
+	}
+}
+
+func TestAPIGetAllAgents(t *testing.T) {
+	r := testRelay(t)
+	r.DB.RegisterAgent("p1", "bot-a", "dev", "", nil, nil, false, nil)
+	r.DB.RegisterAgent("p2", "bot-b", "qa", "", nil, nil, false, nil)
+
+	w := doAPI(r, "GET", "/agents/all", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	agents := decodeJSONArray(t, w)
+	if len(agents) != 2 {
+		t.Errorf("expected 2 agents across projects, got %d", len(agents))
+	}
+}
+
+func TestAPIGetOrgTree(t *testing.T) {
+	r := testRelay(t)
+	mgr := "manager"
+	r.DB.RegisterAgent("p1", "manager", "lead", "", nil, nil, false, nil)
+	r.DB.RegisterAgent("p1", "dev-1", "dev", "", &mgr, nil, false, nil)
+
+	w := doAPI(r, "GET", "/org?project=p1", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	tree := decodeJSONArray(t, w)
+	if len(tree) != 1 { // 1 root (manager)
+		t.Errorf("expected 1 root node, got %d", len(tree))
+	}
+	root := tree[0].(map[string]any)
+	reports := root["reports"].([]any)
+	if len(reports) != 1 {
+		t.Errorf("expected 1 report, got %d", len(reports))
+	}
+}
+
+// --- Message API Tests ---
+
+func TestAPIGetAllMessages(t *testing.T) {
+	r := testRelay(t)
+	r.DB.RegisterAgent("p1", "bot-a", "dev", "", nil, nil, false, nil)
+	r.DB.InsertMessage("p1", "bot-a", "bot-b", "notification", "test", "hello", "{}", nil, nil)
+
+	w := doAPI(r, "GET", "/messages/all?project=p1", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	msgs := decodeJSONArray(t, w)
+	if len(msgs) != 1 {
+		t.Errorf("expected 1 message, got %d", len(msgs))
+	}
+}
+
+func TestAPIGetAllMessagesAllProjects(t *testing.T) {
+	r := testRelay(t)
+	r.DB.RegisterAgent("p1", "bot-a", "dev", "", nil, nil, false, nil)
+	r.DB.RegisterAgent("p2", "bot-b", "qa", "", nil, nil, false, nil)
+	r.DB.InsertMessage("p1", "bot-a", "bot-b", "notification", "test", "hello", "{}", nil, nil)
+	r.DB.InsertMessage("p2", "bot-b", "bot-a", "notification", "test", "hey", "{}", nil, nil)
+
+	w := doAPI(r, "GET", "/messages/all-projects", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	msgs := decodeJSONArray(t, w)
+	if len(msgs) != 2 {
+		t.Errorf("expected 2 messages, got %d", len(msgs))
+	}
+}
+
+func TestAPIPostUserResponse(t *testing.T) {
+	r := testRelay(t)
+	r.DB.RegisterAgent("p1", "bot-a", "dev", "", nil, nil, false, nil)
+
+	w := doAPI(r, "POST", "/user-response", `{"project":"p1","to":"bot-a","content":"yes"}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	data := decodeJSON(t, w)
+	if data["ok"] != true {
+		t.Error("expected ok=true")
+	}
+	if data["message_id"] == nil || data["message_id"] == "" {
+		t.Error("expected message_id")
+	}
+}
+
+func TestAPIPostUserResponseMissingFields(t *testing.T) {
+	r := testRelay(t)
+	w := doAPI(r, "POST", "/user-response", `{"project":"p1"}`)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+// --- Conversation API Tests ---
+
+func TestAPIGetConversations(t *testing.T) {
+	r := testRelay(t)
+	r.DB.RegisterAgent("p1", "bot-a", "dev", "", nil, nil, false, nil)
+	r.DB.RegisterAgent("p1", "bot-b", "qa", "", nil, nil, false, nil)
+	r.DB.CreateConversation("p1", "test conv", "bot-a", []string{"bot-a", "bot-b"})
+
+	w := doAPI(r, "GET", "/conversations?project=p1", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	convs := decodeJSONArray(t, w)
+	if len(convs) != 1 {
+		t.Errorf("expected 1 conversation, got %d", len(convs))
+	}
+}
+
+func TestAPIGetConversationMessages(t *testing.T) {
+	r := testRelay(t)
+	r.DB.RegisterAgent("p1", "bot-a", "dev", "", nil, nil, false, nil)
+	r.DB.RegisterAgent("p1", "bot-b", "qa", "", nil, nil, false, nil)
+	conv, _ := r.DB.CreateConversation("p1", "test", "bot-a", []string{"bot-a", "bot-b"})
+	r.DB.InsertMessage("p1", "bot-a", "", "notification", "test", "hello", "{}", nil, &conv.ID)
+
+	w := doAPI(r, "GET", "/conversations/"+conv.ID+"/messages", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	msgs := decodeJSONArray(t, w)
+	if len(msgs) != 1 {
+		t.Errorf("expected 1 message, got %d", len(msgs))
+	}
+}
+
+// --- Memory API Tests ---
+
+func TestAPIMemoryCRUD(t *testing.T) {
+	r := testRelay(t)
+
+	// Create
+	w := doAPI(r, "POST", "/memories", `{"project":"p1","agent_name":"bot-a","key":"test_key","value":"test_value"}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	mem := decodeJSON(t, w)
+	memID := mem["id"].(string)
+	if mem["key"] != "test_key" {
+		t.Errorf("expected test_key, got %v", mem["key"])
+	}
+
+	// List
+	w2 := doAPI(r, "GET", "/memories?project=p1", "")
+	if w2.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w2.Code)
+	}
+	memories := decodeJSONArray(t, w2)
+	if len(memories) != 1 {
+		t.Errorf("expected 1 memory, got %d", len(memories))
+	}
+
+	// Delete
+	w3 := doAPI(r, "DELETE", "/memories/"+memID, "")
+	if w3.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w3.Code, w3.Body.String())
+	}
+
+	// Verify deleted
+	w4 := doAPI(r, "GET", "/memories?project=p1", "")
+	memories2 := decodeJSONArray(t, w4)
+	if len(memories2) != 0 {
+		t.Errorf("expected 0 memories after delete, got %d", len(memories2))
+	}
+}
+
+func TestAPIMemoryCreateMissingFields(t *testing.T) {
+	r := testRelay(t)
+	w := doAPI(r, "POST", "/memories", `{"project":"p1","key":"k"}`)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestAPISearchMemories(t *testing.T) {
+	r := testRelay(t)
+	r.DB.SetMemory("p1", "bot-a", "deploy_config", "production URL is https://prod.example.com", "[]", "project", "stated", "behavior")
+
+	w := doAPI(r, "GET", "/memories/search?q=deploy", "")
+	// FTS5 may not be available in test builds
+	if w.Code == http.StatusInternalServerError {
+		t.Skip("FTS5 not available in this build")
+	}
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	results := decodeJSONArray(t, w)
+	if len(results) < 1 {
+		t.Errorf("expected at least 1 search result, got %d", len(results))
+	}
+}
+
+func TestAPISearchMemoriesMissingQuery(t *testing.T) {
+	r := testRelay(t)
+	w := doAPI(r, "GET", "/memories/search", "")
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+// --- Task API Tests ---
+
+func TestAPITaskCRUD(t *testing.T) {
+	r := testRelay(t)
+	r.DB.RegisterAgent("p1", "bot-a", "dev", "", nil, nil, false, nil)
+
+	// Dispatch
+	w := doAPI(r, "POST", "/tasks", `{"project":"p1","dispatched_by":"bot-a","profile":"dev","title":"Fix bug","description":"fix it"}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	task := decodeJSON(t, w)
+	taskID := task["id"].(string)
+	if task["title"] != "Fix bug" {
+		t.Errorf("expected 'Fix bug', got %v", task["title"])
+	}
+
+	// Get
+	w2 := doAPI(r, "GET", "/tasks/"+taskID+"?project=p1", "")
+	if w2.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w2.Code)
+	}
+	got := decodeJSON(t, w2)
+	if got["title"] != "Fix bug" {
+		t.Errorf("expected 'Fix bug', got %v", got["title"])
+	}
+
+	// List
+	w3 := doAPI(r, "GET", "/tasks?project=p1", "")
+	if w3.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w3.Code)
+	}
+	tasks := decodeJSONArray(t, w3)
+	if len(tasks) != 1 {
+		t.Errorf("expected 1 task, got %d", len(tasks))
+	}
+}
+
+func TestAPITaskTransition(t *testing.T) {
+	r := testRelay(t)
+	r.DB.RegisterAgent("p1", "bot-a", "dev", "", nil, nil, false, nil)
+
+	task, _ := r.DB.DispatchTask("p1", "dev", "bot-a", "task1", "", "P2", nil, nil, nil)
+
+	// Claim (status=accepted)
+	w := doAPI(r, "POST", "/tasks/"+task.ID+"/transition", `{"project":"p1","agent":"bot-a","status":"accepted"}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	claimed := decodeJSON(t, w)
+	if claimed["status"] != "accepted" {
+		t.Errorf("expected accepted, got %v", claimed["status"])
+	}
+
+	// Start (status=in-progress)
+	w2 := doAPI(r, "POST", "/tasks/"+task.ID+"/transition", `{"project":"p1","agent":"bot-a","status":"in-progress"}`)
+	if w2.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w2.Code)
+	}
+	started := decodeJSON(t, w2)
+	if started["status"] != "in-progress" {
+		t.Errorf("expected in-progress, got %v", started["status"])
+	}
+
+	// Complete (status=done)
+	w3 := doAPI(r, "POST", "/tasks/"+task.ID+"/transition", `{"project":"p1","agent":"bot-a","status":"done","result":"done!"}`)
+	if w3.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w3.Code)
+	}
+	completed := decodeJSON(t, w3)
+	if completed["status"] != "done" {
+		t.Errorf("expected done, got %v", completed["status"])
+	}
+}
+
+func TestAPIGetAllTasks(t *testing.T) {
+	r := testRelay(t)
+	r.DB.RegisterAgent("p1", "bot-a", "dev", "", nil, nil, false, nil)
+	r.DB.DispatchTask("p1", "dev", "bot-a", "task1", "", "P2", nil, nil, nil)
+	r.DB.DispatchTask("p1", "dev", "bot-a", "task2", "", "P1", nil, nil, nil)
+
+	w := doAPI(r, "GET", "/tasks/all", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	tasks := decodeJSONArray(t, w)
+	if len(tasks) != 2 {
+		t.Errorf("expected 2 tasks, got %d", len(tasks))
+	}
+}
+
+// --- Profile API Tests ---
+
+func TestAPIGetProfiles(t *testing.T) {
+	r := testRelay(t)
+	r.DB.RegisterProfile("p1", "backend", "Backend Dev", "developer", "", "[]", "[]", "[]")
+
+	w := doAPI(r, "GET", "/profiles?project=p1", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	profiles := decodeJSONArray(t, w)
+	if len(profiles) != 1 {
+		t.Errorf("expected 1 profile, got %d", len(profiles))
+	}
+}
+
+func TestAPIGetProfile(t *testing.T) {
+	r := testRelay(t)
+	r.DB.RegisterProfile("p1", "backend", "Backend Dev", "developer", "", "[]", "[]", "[]")
+
+	w := doAPI(r, "GET", "/profiles/backend?project=p1", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	profile := decodeJSON(t, w)
+	if profile["slug"] != "backend" {
+		t.Errorf("expected backend, got %v", profile["slug"])
+	}
+}
+
+// --- Goal API Tests ---
+
+func TestAPIGoalCRUD(t *testing.T) {
+	r := testRelay(t)
+
+	// Create
+	w := doAPI(r, "POST", "/goals", `{"project":"p1","title":"Ship v2","type":"agent_goal"}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	goal := decodeJSON(t, w)
+	goalID := goal["id"].(string)
+
+	// Get
+	w2 := doAPI(r, "GET", "/goals/"+goalID+"?project=p1", "")
+	if w2.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w2.Code)
+	}
+
+	// Update
+	w3 := doAPI(r, "PUT", "/goals/"+goalID, `{"project":"p1","status":"completed"}`)
+	if w3.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w3.Code, w3.Body.String())
+	}
+
+	// List
+	w4 := doAPI(r, "GET", "/goals?project=p1", "")
+	if w4.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w4.Code)
+	}
+	goals := decodeJSONArray(t, w4)
+	if len(goals) != 1 {
+		t.Errorf("expected 1 goal, got %d", len(goals))
+	}
+}
+
+// --- Board API Tests ---
+
+func TestAPIGetBoards(t *testing.T) {
+	r := testRelay(t)
+	r.DB.CreateBoard("p1", "Sprint 1", "sprint-1", "", "user")
+
+	w := doAPI(r, "GET", "/boards?project=p1", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	boards := decodeJSONArray(t, w)
+	if len(boards) != 1 {
+		t.Errorf("expected 1 board, got %d", len(boards))
+	}
+}
+
+// --- Team API Tests ---
+
+func TestAPIGetTeams(t *testing.T) {
+	r := testRelay(t)
+	r.DB.CreateTeam("Backend", "backend", "p1", "", "regular", nil, nil)
+
+	w := doAPI(r, "GET", "/teams?project=p1", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	teams := decodeJSONArray(t, w)
+	if len(teams) != 1 {
+		t.Errorf("expected 1 team, got %d", len(teams))
+	}
+}
+
+// --- 404 Test ---
+
+func TestAPINotFound(t *testing.T) {
+	r := testRelay(t)
+	w := doAPI(r, "GET", "/nonexistent", "")
+	if w.Code != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", w.Code)
+	}
+}
+
+// --- Activity API Tests ---
+
+func TestAPIGetActivity(t *testing.T) {
+	r := testRelay(t)
+	w := doAPI(r, "GET", "/activity", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	sessions := decodeJSONArray(t, w)
+	if len(sessions) != 0 {
+		t.Errorf("expected 0 sessions with nil ingester, got %d", len(sessions))
+	}
+}

--- a/internal/relay/api_test.go
+++ b/internal/relay/api_test.go
@@ -567,6 +567,201 @@ func TestAPIGetTeams(t *testing.T) {
 	}
 }
 
+// --- More Team/Org API Tests ---
+
+func TestAPIGetOrgs(t *testing.T) {
+	r := testRelay(t)
+	r.DB.CreateOrg("Acme", "acme", "")
+
+	w := doAPI(r, "GET", "/orgs", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	orgs := decodeJSONArray(t, w)
+	if len(orgs) != 1 {
+		t.Errorf("expected 1 org, got %d", len(orgs))
+	}
+}
+
+func TestAPIGetAllTeams(t *testing.T) {
+	r := testRelay(t)
+	r.DB.CreateTeam("Backend", "backend", "p1", "", "regular", nil, nil)
+	r.DB.CreateTeam("Frontend", "frontend", "p2", "", "regular", nil, nil)
+
+	w := doAPI(r, "GET", "/teams/all", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	teams := decodeJSONArray(t, w)
+	if len(teams) != 2 {
+		t.Errorf("expected 2 teams across projects, got %d", len(teams))
+	}
+}
+
+func TestAPIGetTeamMembers(t *testing.T) {
+	r := testRelay(t)
+	team, _ := r.DB.CreateTeam("Backend", "backend", "p1", "", "regular", nil, nil)
+	r.DB.RegisterAgent("p1", "bot-a", "dev", "", nil, nil, false, nil)
+	r.DB.AddTeamMember(team.ID, "bot-a", "p1", "lead")
+
+	w := doAPI(r, "GET", "/teams/backend/members?project=p1", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// --- More Conversation API Tests ---
+
+func TestAPIGetAllConversations(t *testing.T) {
+	r := testRelay(t)
+	r.DB.RegisterAgent("p1", "bot-a", "dev", "", nil, nil, false, nil)
+	r.DB.RegisterAgent("p2", "bot-b", "qa", "", nil, nil, false, nil)
+	r.DB.CreateConversation("p1", "conv1", "bot-a", []string{"bot-a"})
+	r.DB.CreateConversation("p2", "conv2", "bot-b", []string{"bot-b"})
+
+	w := doAPI(r, "GET", "/conversations/all", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	convs := decodeJSONArray(t, w)
+	if len(convs) != 2 {
+		t.Errorf("expected 2 conversations across projects, got %d", len(convs))
+	}
+}
+
+// --- More Message API Tests ---
+
+func TestAPIGetLatestMessages(t *testing.T) {
+	r := testRelay(t)
+	r.DB.RegisterAgent("p1", "bot-a", "dev", "", nil, nil, false, nil)
+	r.DB.InsertMessage("p1", "bot-a", "bot-b", "notification", "test", "recent msg", "{}", nil, nil)
+
+	w := doAPI(r, "GET", "/messages/latest?project=p1", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	msgs := decodeJSONArray(t, w)
+	if len(msgs) != 1 {
+		t.Errorf("expected 1 recent message, got %d", len(msgs))
+	}
+}
+
+func TestAPIGetLatestMessagesAllProjects(t *testing.T) {
+	r := testRelay(t)
+	r.DB.RegisterAgent("p1", "bot-a", "dev", "", nil, nil, false, nil)
+	r.DB.InsertMessage("p1", "bot-a", "bot-b", "notification", "test", "msg1", "{}", nil, nil)
+
+	w := doAPI(r, "GET", "/messages/latest-all", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+}
+
+// --- More Task API Tests ---
+
+func TestAPIGetLatestTasks(t *testing.T) {
+	r := testRelay(t)
+	r.DB.RegisterAgent("p1", "bot-a", "dev", "", nil, nil, false, nil)
+	r.DB.DispatchTask("p1", "dev", "bot-a", "recent task", "", "P2", nil, nil, nil)
+
+	w := doAPI(r, "GET", "/tasks/latest?project=p1", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+}
+
+func TestAPIUpdateTask(t *testing.T) {
+	r := testRelay(t)
+	r.DB.RegisterAgent("p1", "bot-a", "dev", "", nil, nil, false, nil)
+	task, _ := r.DB.DispatchTask("p1", "dev", "bot-a", "old title", "", "P2", nil, nil, nil)
+
+	w := doAPI(r, "PUT", "/tasks/"+task.ID, `{"project":"p1","title":"new title"}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	updated := decodeJSON(t, w)
+	if updated["title"] != "new title" {
+		t.Errorf("expected 'new title', got %v", updated["title"])
+	}
+}
+
+func TestAPIDeleteTask(t *testing.T) {
+	r := testRelay(t)
+	r.DB.RegisterAgent("p1", "bot-a", "dev", "", nil, nil, false, nil)
+	task, _ := r.DB.DispatchTask("p1", "dev", "bot-a", "to delete", "", "P2", nil, nil, nil)
+
+	w := doAPI(r, "DELETE", "/tasks/"+task.ID+"?project=p1", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	data := decodeJSON(t, w)
+	if data["deleted"] != true {
+		t.Error("expected deleted=true")
+	}
+}
+
+// --- More Goal API Tests ---
+
+func TestAPIGetAllGoals(t *testing.T) {
+	r := testRelay(t)
+	r.DB.CreateGoal("p1", "agent_goal", "Goal 1", "", "user", nil, nil)
+	r.DB.CreateGoal("p2", "agent_goal", "Goal 2", "", "user", nil, nil)
+
+	w := doAPI(r, "GET", "/goals/all", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	goals := decodeJSONArray(t, w)
+	if len(goals) != 2 {
+		t.Errorf("expected 2 goals, got %d", len(goals))
+	}
+}
+
+func TestAPIGetGoalCascade(t *testing.T) {
+	r := testRelay(t)
+	parent, _ := r.DB.CreateGoal("p1", "mission", "Mission", "", "user", nil, nil)
+	r.DB.CreateGoal("p1", "project_goal", "Sub-goal", "", "user", nil, &parent.ID)
+
+	w := doAPI(r, "GET", "/goals/cascade?project=p1", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+}
+
+// --- More Board API Tests ---
+
+func TestAPIGetAllBoards(t *testing.T) {
+	r := testRelay(t)
+	r.DB.CreateBoard("p1", "Sprint 1", "sprint-1", "", "user")
+	r.DB.CreateBoard("p2", "Sprint 2", "sprint-2", "", "user")
+
+	w := doAPI(r, "GET", "/boards/all", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	boards := decodeJSONArray(t, w)
+	if len(boards) != 2 {
+		t.Errorf("expected 2 boards, got %d", len(boards))
+	}
+}
+
+// --- Memory API resolve conflict ---
+
+func TestAPIResolveMemoryConflict(t *testing.T) {
+	r := testRelay(t)
+	r.DB.SetMemory("p1", "bot-a", "key1", "value-a", "[]", "project", "stated", "behavior")
+	r.DB.SetMemory("p1", "bot-b", "key1", "value-b", "[]", "project", "stated", "behavior")
+
+	w := doAPI(r, "POST", "/memories/key1/resolve", `{"project":"p1","chosen_value":"value-b"}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	data := decodeJSON(t, w)
+	if data["resolved"] != true {
+		t.Error("expected resolved=true")
+	}
+}
+
 // --- 404 Test ---
 
 func TestAPINotFound(t *testing.T) {

--- a/internal/relay/handlers_test.go
+++ b/internal/relay/handlers_test.go
@@ -900,6 +900,246 @@ func TestOrgAndTeamLifecycle(t *testing.T) {
 	}
 }
 
+// --- Memory Conflict Tests ---
+
+func TestMemoryConflictAndResolve(t *testing.T) {
+	h := testHandlers(t)
+
+	// Agent A sets a memory
+	h.HandleSetMemory(ctx, call(map[string]any{
+		"project": "p1", "as": "bot-a", "key": "db_host", "value": "localhost",
+	}))
+
+	// Agent B sets the same key with different value → conflict
+	setRes, _ := h.HandleSetMemory(ctx, call(map[string]any{
+		"project": "p1", "as": "bot-b", "key": "db_host", "value": "prod-db.internal",
+	}))
+	setData := parseJSON(t, setRes)
+	if setData["conflict"] != true {
+		t.Error("expected conflict=true")
+	}
+
+	// Get should show multiple values
+	getRes, _ := h.HandleGetMemory(ctx, call(map[string]any{
+		"project": "p1", "as": "bot-a", "key": "db_host",
+	}))
+	getData := parseJSON(t, getRes)
+	if getData["count"].(float64) < 2 {
+		t.Errorf("expected at least 2 conflicting memories, got %v", getData["count"])
+	}
+
+	// Resolve conflict
+	resolveRes, _ := h.HandleResolveConflict(ctx, call(map[string]any{
+		"project": "p1", "as": "bot-a", "key": "db_host", "chosen_value": "prod-db.internal",
+	}))
+	resolveData := parseJSON(t, resolveRes)
+	if resolveData["resolved"] != true {
+		t.Error("expected resolved=true")
+	}
+
+	// After resolve, should be 1 value
+	getRes2, _ := h.HandleGetMemory(ctx, call(map[string]any{
+		"project": "p1", "as": "bot-a", "key": "db_host",
+	}))
+	getData2 := parseJSON(t, getRes2)
+	if getData2["count"].(float64) != 1 {
+		t.Errorf("expected 1 memory after resolve, got %v", getData2["count"])
+	}
+}
+
+func TestResolveConflictMissingFields(t *testing.T) {
+	h := testHandlers(t)
+	res, _ := h.HandleResolveConflict(ctx, call(map[string]any{
+		"project": "p1", "as": "bot-a", "chosen_value": "x",
+	}))
+	expectError(t, res)
+
+	res2, _ := h.HandleResolveConflict(ctx, call(map[string]any{
+		"project": "p1", "as": "bot-a", "key": "k",
+	}))
+	expectError(t, res2)
+}
+
+// --- Goal Cascade Tests ---
+
+func TestGoalCascade(t *testing.T) {
+	h := testHandlers(t)
+
+	// Create parent goal
+	parentRes, _ := h.HandleCreateGoal(ctx, call(map[string]any{
+		"project": "p1", "as": "bot-a", "title": "Mission", "type": "mission",
+	}))
+	parent := parseJSON(t, parentRes)
+	parentID := parent["id"].(string)
+
+	// Create child goal
+	h.HandleCreateGoal(ctx, call(map[string]any{
+		"project": "p1", "as": "bot-a", "title": "Sub-goal", "type": "project_goal",
+		"parent_goal_id": parentID,
+	}))
+
+	// Get cascade
+	cascadeRes, _ := h.HandleGetGoalCascade(ctx, call(map[string]any{
+		"project": "p1",
+	}))
+	if cascadeRes.IsError {
+		t.Fatalf("cascade error: %v", cascadeRes.Content)
+	}
+	// cascade returns a structure — just verify it doesn't error
+}
+
+// --- Team Inbox Tests ---
+
+func TestTeamInbox(t *testing.T) {
+	h := testHandlers(t)
+	h.HandleRegisterAgent(ctx, call(map[string]any{"project": "p1", "name": "bot-a", "role": "dev"}))
+
+	h.HandleCreateTeam(ctx, call(map[string]any{
+		"project": "p1", "name": "Dev Team", "slug": "dev",
+	}))
+	h.HandleAddTeamMember(ctx, call(map[string]any{
+		"project": "p1", "team": "dev", "agent_name": "bot-a",
+	}))
+
+	// Send message to team
+	h.HandleSendMessage(ctx, call(map[string]any{
+		"project": "p1", "as": "bot-a", "to": "team:dev", "content": "team message",
+	}))
+
+	// Get team inbox
+	inboxRes, _ := h.HandleGetTeamInbox(ctx, call(map[string]any{
+		"project": "p1", "team": "dev",
+	}))
+	data := parseJSON(t, inboxRes)
+	if data["count"].(float64) != 1 {
+		t.Errorf("expected 1 team message, got %v", data["count"])
+	}
+}
+
+func TestTeamInboxMissingTeam(t *testing.T) {
+	h := testHandlers(t)
+	res, _ := h.HandleGetTeamInbox(ctx, call(map[string]any{"project": "p1"}))
+	expectError(t, res)
+}
+
+func TestTeamInboxNotFound(t *testing.T) {
+	h := testHandlers(t)
+	res, _ := h.HandleGetTeamInbox(ctx, call(map[string]any{
+		"project": "p1", "team": "nonexistent",
+	}))
+	expectError(t, res)
+}
+
+// --- Notify Channel Tests ---
+
+func TestAddNotifyChannel(t *testing.T) {
+	h := testHandlers(t)
+
+	res, _ := h.HandleAddNotifyChannel(ctx, call(map[string]any{
+		"project": "p1", "as": "bot-a", "target": "bot-b",
+	}))
+	data := parseJSON(t, res)
+	if data["added"] != true {
+		t.Error("expected added=true")
+	}
+}
+
+func TestAddNotifyChannelMissingTarget(t *testing.T) {
+	h := testHandlers(t)
+	res, _ := h.HandleAddNotifyChannel(ctx, call(map[string]any{
+		"project": "p1", "as": "bot-a",
+	}))
+	expectError(t, res)
+}
+
+// --- Message Broadcast Tests ---
+
+func TestSendBroadcastMessage(t *testing.T) {
+	h := testHandlers(t)
+	h.HandleRegisterAgent(ctx, call(map[string]any{"project": "p1", "name": "bot-a", "role": "dev"}))
+	h.HandleRegisterAgent(ctx, call(map[string]any{"project": "p1", "name": "bot-b", "role": "qa"}))
+
+	res, _ := h.HandleSendMessage(ctx, call(map[string]any{
+		"project": "p1", "as": "bot-a", "to": "*", "content": "broadcast!",
+	}))
+	msg := parseJSON(t, res)
+	if msg["to"] != "*" {
+		t.Errorf("expected to=*, got %v", msg["to"])
+	}
+
+	// bot-b should see it in inbox
+	inboxRes, _ := h.HandleGetInbox(ctx, call(map[string]any{
+		"project": "p1", "as": "bot-b", "unread_only": true,
+	}))
+	inbox := parseJSON(t, inboxRes)
+	if inbox["count"].(float64) != 1 {
+		t.Errorf("expected 1 broadcast message, got %v", inbox["count"])
+	}
+}
+
+func TestSendConversationShorthand(t *testing.T) {
+	h := testHandlers(t)
+	h.HandleRegisterAgent(ctx, call(map[string]any{"project": "p1", "name": "bot-a", "role": "dev"}))
+	h.HandleRegisterAgent(ctx, call(map[string]any{"project": "p1", "name": "bot-b", "role": "qa"}))
+
+	// Create conversation
+	createRes, _ := h.HandleCreateConversation(ctx, call(map[string]any{
+		"project": "p1", "as": "bot-a", "title": "test", "members": []any{"bot-a", "bot-b"},
+	}))
+	conv := parseJSON(t, createRes)["conversation"].(map[string]any)
+	convID := conv["id"].(string)
+
+	// Send using "to": "conversation:<id>" shorthand
+	sendRes, _ := h.HandleSendMessage(ctx, call(map[string]any{
+		"project": "p1", "as": "bot-a", "to": "conversation:" + convID, "content": "shorthand!",
+	}))
+	if sendRes.IsError {
+		t.Fatalf("send via shorthand failed: %v", sendRes.Content)
+	}
+}
+
+// --- Task with subtasks ---
+
+func TestTaskSubtaskCompletion(t *testing.T) {
+	h := testHandlers(t)
+	h.HandleRegisterAgent(ctx, call(map[string]any{"project": "p1", "name": "bot-a", "role": "dev"}))
+
+	// Dispatch parent
+	parentRes, _ := h.HandleDispatchTask(ctx, call(map[string]any{
+		"project": "p1", "as": "bot-a", "profile": "dev", "title": "Parent task",
+	}))
+	parent := parseJSON(t, parentRes)
+	parentID := parent["id"].(string)
+
+	// Dispatch subtask
+	subRes, _ := h.HandleDispatchTask(ctx, call(map[string]any{
+		"project": "p1", "as": "bot-a", "profile": "dev", "title": "Subtask 1",
+		"parent_task_id": parentID,
+	}))
+	sub := parseJSON(t, subRes)
+	subID := sub["id"].(string)
+
+	// Complete subtask flow
+	h.HandleClaimTask(ctx, call(map[string]any{"project": "p1", "as": "bot-a", "task_id": subID}))
+	h.HandleStartTask(ctx, call(map[string]any{"project": "p1", "as": "bot-a", "task_id": subID}))
+	completeRes, _ := h.HandleCompleteTask(ctx, call(map[string]any{
+		"project": "p1", "as": "bot-a", "task_id": subID, "result": "done",
+	}))
+	completed := parseJSON(t, completeRes)
+	if completed["status"] != "done" {
+		t.Errorf("expected done, got %v", completed["status"])
+	}
+
+	// Get parent with subtasks
+	getRes, _ := h.HandleGetTask(ctx, call(map[string]any{
+		"project": "p1", "task_id": parentID, "include_subtasks": true,
+	}))
+	parentData := parseJSON(t, getRes)
+	if parentData["title"] != "Parent task" {
+		t.Errorf("expected 'Parent task', got %v", parentData["title"])
+	}
+}
+
 // --- Validation Tests (cross-cutting) ---
 
 func TestResolveProjectDefault(t *testing.T) {

--- a/internal/relay/handlers_test.go
+++ b/internal/relay/handlers_test.go
@@ -1,0 +1,926 @@
+package relay
+
+import (
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"testing"
+
+	"agent-relay/internal/db"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+// --- Test helpers ---
+
+func testHandlers(t *testing.T) *Handlers {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	database, err := db.NewTestDB(dbPath)
+	if err != nil {
+		t.Fatalf("create test db: %v", err)
+	}
+	t.Cleanup(func() { database.Close() })
+
+	mcpSrv := server.NewMCPServer("test", "0.0.0")
+	registry := NewSessionRegistry(mcpSrv)
+	events := NewEventBus()
+	return NewHandlers(database, registry, nil, nil, events)
+}
+
+func call(args map[string]any) mcp.CallToolRequest {
+	return mcp.CallToolRequest{
+		Params: mcp.CallToolParams{Arguments: args},
+	}
+}
+
+func parseJSON(t *testing.T, result *mcp.CallToolResult) map[string]any {
+	t.Helper()
+	if result.IsError {
+		tc := result.Content[0].(mcp.TextContent)
+		t.Fatalf("unexpected error result: %s", tc.Text)
+	}
+	tc := result.Content[0].(mcp.TextContent)
+	var data map[string]any
+	if err := json.Unmarshal([]byte(tc.Text), &data); err != nil {
+		t.Fatalf("parse result json: %v\nraw: %s", err, tc.Text)
+	}
+	return data
+}
+
+func expectError(t *testing.T, result *mcp.CallToolResult) string {
+	t.Helper()
+	if !result.IsError {
+		t.Fatal("expected error result, got success")
+	}
+	return result.Content[0].(mcp.TextContent).Text
+}
+
+var ctx = context.Background()
+
+// --- Agent Tests ---
+
+func TestRegisterAgent(t *testing.T) {
+	h := testHandlers(t)
+
+	res, err := h.HandleRegisterAgent(ctx, call(map[string]any{
+		"project": "test-proj",
+		"name":    "bot-a",
+		"role":    "developer",
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	data := parseJSON(t, res)
+	agent := data["agent"].(map[string]any)
+	if agent["name"] != "bot-a" {
+		t.Errorf("expected bot-a, got %v", agent["name"])
+	}
+	if agent["role"] != "developer" {
+		t.Errorf("expected developer, got %v", agent["role"])
+	}
+	sessionCtx := data["session_context"].(map[string]any)
+	if sessionCtx["is_respawn"] != false {
+		t.Error("expected is_respawn=false for new agent")
+	}
+}
+
+func TestRegisterAgentRespawn(t *testing.T) {
+	h := testHandlers(t)
+
+	h.HandleRegisterAgent(ctx, call(map[string]any{
+		"project": "test-proj",
+		"name":    "bot-a",
+		"role":    "developer",
+	}))
+
+	res, _ := h.HandleRegisterAgent(ctx, call(map[string]any{
+		"project": "test-proj",
+		"name":    "bot-a",
+		"role":    "updated-role",
+	}))
+	data := parseJSON(t, res)
+	sessionCtx := data["session_context"].(map[string]any)
+	if sessionCtx["is_respawn"] != true {
+		t.Error("expected is_respawn=true for respawn")
+	}
+}
+
+func TestRegisterAgentMissingName(t *testing.T) {
+	h := testHandlers(t)
+	res, _ := h.HandleRegisterAgent(ctx, call(map[string]any{
+		"project": "test-proj",
+	}))
+	expectError(t, res)
+}
+
+func TestListAgents(t *testing.T) {
+	h := testHandlers(t)
+
+	h.HandleRegisterAgent(ctx, call(map[string]any{"project": "p1", "name": "bot-a", "role": "dev"}))
+	h.HandleRegisterAgent(ctx, call(map[string]any{"project": "p1", "name": "bot-b", "role": "qa"}))
+
+	res, _ := h.HandleListAgents(ctx, call(map[string]any{"project": "p1"}))
+	data := parseJSON(t, res)
+	if data["count"].(float64) != 2 {
+		t.Errorf("expected 2 agents, got %v", data["count"])
+	}
+}
+
+func TestDeactivateAgent(t *testing.T) {
+	h := testHandlers(t)
+	h.HandleRegisterAgent(ctx, call(map[string]any{"project": "p1", "name": "bot-a", "role": "dev"}))
+
+	res, _ := h.HandleDeactivateAgent(ctx, call(map[string]any{"project": "p1", "name": "bot-a"}))
+	data := parseJSON(t, res)
+	if data["deactivated"] != true {
+		t.Error("expected deactivated=true")
+	}
+
+	// Agent should not appear in list (inactive excluded from default list)
+	listRes, _ := h.HandleListAgents(ctx, call(map[string]any{"project": "p1"}))
+	listData := parseJSON(t, listRes)
+	// inactive agents ARE shown in list (status IN active, sleeping, inactive)
+	agents := listData["agents"].([]any)
+	if len(agents) != 1 {
+		t.Errorf("expected 1 agent (inactive shown), got %d", len(agents))
+	}
+}
+
+func TestDeleteAgent(t *testing.T) {
+	h := testHandlers(t)
+	h.HandleRegisterAgent(ctx, call(map[string]any{"project": "p1", "name": "bot-a", "role": "dev"}))
+
+	res, _ := h.HandleDeleteAgent(ctx, call(map[string]any{"project": "p1", "name": "bot-a"}))
+	data := parseJSON(t, res)
+	if data["deleted"] != true {
+		t.Error("expected deleted=true")
+	}
+
+	// Deleted agents should NOT appear in list
+	listRes, _ := h.HandleListAgents(ctx, call(map[string]any{"project": "p1"}))
+	listData := parseJSON(t, listRes)
+	if listData["count"].(float64) != 0 {
+		t.Errorf("expected 0 agents after delete, got %v", listData["count"])
+	}
+}
+
+func TestSleepAgent(t *testing.T) {
+	h := testHandlers(t)
+	h.HandleRegisterAgent(ctx, call(map[string]any{"project": "p1", "name": "bot-a", "role": "dev"}))
+
+	res, _ := h.HandleSleepAgent(ctx, call(map[string]any{"project": "p1", "as": "bot-a"}))
+	data := parseJSON(t, res)
+	if data["status"] != "sleeping" {
+		t.Errorf("expected status=sleeping, got %v", data["status"])
+	}
+}
+
+// --- Message Tests ---
+
+func TestSendAndGetInbox(t *testing.T) {
+	h := testHandlers(t)
+	h.HandleRegisterAgent(ctx, call(map[string]any{"project": "p1", "name": "bot-a", "role": "dev"}))
+	h.HandleRegisterAgent(ctx, call(map[string]any{"project": "p1", "name": "bot-b", "role": "qa"}))
+
+	// Send message
+	sendRes, _ := h.HandleSendMessage(ctx, call(map[string]any{
+		"project": "p1",
+		"as":      "bot-a",
+		"to":      "bot-b",
+		"type":    "notification",
+		"subject": "test",
+		"content": "hello bot-b",
+	}))
+	msg := parseJSON(t, sendRes)
+	if msg["from"] != "bot-a" {
+		t.Errorf("expected from=bot-a, got %v", msg["from"])
+	}
+
+	// Check inbox
+	inboxRes, _ := h.HandleGetInbox(ctx, call(map[string]any{
+		"project":    "p1",
+		"as":         "bot-b",
+		"unread_only": true,
+	}))
+	inbox := parseJSON(t, inboxRes)
+	if inbox["count"].(float64) != 1 {
+		t.Errorf("expected 1 message in inbox, got %v", inbox["count"])
+	}
+}
+
+func TestSendMessageMissingContent(t *testing.T) {
+	h := testHandlers(t)
+	res, _ := h.HandleSendMessage(ctx, call(map[string]any{
+		"project": "p1",
+		"as":      "bot-a",
+		"to":      "bot-b",
+	}))
+	expectError(t, res)
+}
+
+func TestSendMessageMissingTo(t *testing.T) {
+	h := testHandlers(t)
+	res, _ := h.HandleSendMessage(ctx, call(map[string]any{
+		"project": "p1",
+		"as":      "bot-a",
+		"content": "hello",
+	}))
+	expectError(t, res)
+}
+
+func TestMarkRead(t *testing.T) {
+	h := testHandlers(t)
+	h.HandleRegisterAgent(ctx, call(map[string]any{"project": "p1", "name": "bot-a", "role": "dev"}))
+	h.HandleRegisterAgent(ctx, call(map[string]any{"project": "p1", "name": "bot-b", "role": "qa"}))
+
+	sendRes, _ := h.HandleSendMessage(ctx, call(map[string]any{
+		"project": "p1", "as": "bot-a", "to": "bot-b", "content": "hello",
+	}))
+	msg := parseJSON(t, sendRes)
+	msgID := msg["id"].(string)
+
+	// Mark read
+	readRes, _ := h.HandleMarkRead(ctx, call(map[string]any{
+		"project":     "p1",
+		"as":          "bot-b",
+		"message_ids": []any{msgID},
+	}))
+	readData := parseJSON(t, readRes)
+	if readData["marked_read"].(float64) != 1 {
+		t.Errorf("expected 1 marked read, got %v", readData["marked_read"])
+	}
+
+	// Inbox should be empty (unread_only)
+	inboxRes, _ := h.HandleGetInbox(ctx, call(map[string]any{
+		"project": "p1", "as": "bot-b", "unread_only": true,
+	}))
+	inbox := parseJSON(t, inboxRes)
+	if inbox["count"].(float64) != 0 {
+		t.Errorf("expected 0 unread after mark read, got %v", inbox["count"])
+	}
+}
+
+func TestMarkReadMissingIDs(t *testing.T) {
+	h := testHandlers(t)
+	res, _ := h.HandleMarkRead(ctx, call(map[string]any{
+		"project": "p1", "as": "bot-b",
+	}))
+	expectError(t, res)
+}
+
+func TestGetThread(t *testing.T) {
+	h := testHandlers(t)
+	h.HandleRegisterAgent(ctx, call(map[string]any{"project": "p1", "name": "bot-a", "role": "dev"}))
+	h.HandleRegisterAgent(ctx, call(map[string]any{"project": "p1", "name": "bot-b", "role": "qa"}))
+
+	// Send original
+	res1, _ := h.HandleSendMessage(ctx, call(map[string]any{
+		"project": "p1", "as": "bot-a", "to": "bot-b", "content": "original",
+	}))
+	msg1 := parseJSON(t, res1)
+	msg1ID := msg1["id"].(string)
+
+	// Reply
+	h.HandleSendMessage(ctx, call(map[string]any{
+		"project": "p1", "as": "bot-b", "to": "bot-a", "content": "reply", "reply_to": msg1ID,
+	}))
+
+	// Get thread
+	threadRes, _ := h.HandleGetThread(ctx, call(map[string]any{"message_id": msg1ID}))
+	thread := parseJSON(t, threadRes)
+	if thread["count"].(float64) != 2 {
+		t.Errorf("expected 2 messages in thread, got %v", thread["count"])
+	}
+}
+
+// --- Conversation Tests ---
+
+func TestConversationLifecycle(t *testing.T) {
+	h := testHandlers(t)
+	h.HandleRegisterAgent(ctx, call(map[string]any{"project": "p1", "name": "bot-a", "role": "dev"}))
+	h.HandleRegisterAgent(ctx, call(map[string]any{"project": "p1", "name": "bot-b", "role": "qa"}))
+	h.HandleRegisterAgent(ctx, call(map[string]any{"project": "p1", "name": "bot-c", "role": "pm"}))
+
+	// Create conversation
+	createRes, _ := h.HandleCreateConversation(ctx, call(map[string]any{
+		"project": "p1", "as": "bot-a", "title": "Test conv", "members": []any{"bot-a", "bot-b"},
+	}))
+	createData := parseJSON(t, createRes)
+	conv := createData["conversation"].(map[string]any)
+	convID := conv["id"].(string)
+
+	// List conversations
+	listRes, _ := h.HandleListConversations(ctx, call(map[string]any{
+		"project": "p1", "as": "bot-a",
+	}))
+	listData := parseJSON(t, listRes)
+	if listData["count"].(float64) != 1 {
+		t.Errorf("expected 1 conversation, got %v", listData["count"])
+	}
+
+	// Send message to conversation
+	h.HandleSendMessage(ctx, call(map[string]any{
+		"project": "p1", "as": "bot-a", "to": "", "content": "hello conv",
+		"conversation_id": convID,
+	}))
+
+	// Get conversation messages
+	msgsRes, _ := h.HandleGetConversationMessages(ctx, call(map[string]any{
+		"as": "bot-a", "conversation_id": convID,
+	}))
+	msgsData := parseJSON(t, msgsRes)
+	if msgsData["count"].(float64) != 1 {
+		t.Errorf("expected 1 message, got %v", msgsData["count"])
+	}
+
+	// Invite bot-c
+	inviteRes, _ := h.HandleInviteToConversation(ctx, call(map[string]any{
+		"project": "p1", "as": "bot-a", "conversation_id": convID, "agent_name": "bot-c",
+	}))
+	inviteData := parseJSON(t, inviteRes)
+	if inviteData["invited"] != "bot-c" {
+		t.Errorf("expected invited=bot-c, got %v", inviteData["invited"])
+	}
+
+	// bot-b leaves
+	leaveRes, _ := h.HandleLeaveConversation(ctx, call(map[string]any{
+		"project": "p1", "as": "bot-b", "conversation_id": convID,
+	}))
+	leaveData := parseJSON(t, leaveRes)
+	if leaveData["left"] != "bot-b" {
+		t.Errorf("expected left=bot-b, got %v", leaveData["left"])
+	}
+
+	// Archive
+	archiveRes, _ := h.HandleArchiveConversation(ctx, call(map[string]any{
+		"project": "p1", "as": "bot-a", "conversation_id": convID,
+	}))
+	archiveData := parseJSON(t, archiveRes)
+	if archiveData["archived"] != true {
+		t.Error("expected archived=true")
+	}
+}
+
+func TestCreateConversationMissingTitle(t *testing.T) {
+	h := testHandlers(t)
+	res, _ := h.HandleCreateConversation(ctx, call(map[string]any{
+		"project": "p1", "as": "bot-a", "members": []any{"bot-b"},
+	}))
+	expectError(t, res)
+}
+
+func TestCreateConversationMissingMembers(t *testing.T) {
+	h := testHandlers(t)
+	res, _ := h.HandleCreateConversation(ctx, call(map[string]any{
+		"project": "p1", "as": "bot-a", "title": "test",
+	}))
+	expectError(t, res)
+}
+
+func TestConversationNonMemberCantRead(t *testing.T) {
+	h := testHandlers(t)
+	h.HandleRegisterAgent(ctx, call(map[string]any{"project": "p1", "name": "bot-a", "role": "dev"}))
+	h.HandleRegisterAgent(ctx, call(map[string]any{"project": "p1", "name": "bot-b", "role": "qa"}))
+
+	createRes, _ := h.HandleCreateConversation(ctx, call(map[string]any{
+		"project": "p1", "as": "bot-a", "title": "private", "members": []any{"bot-a", "bot-b"},
+	}))
+	conv := parseJSON(t, createRes)["conversation"].(map[string]any)
+	convID := conv["id"].(string)
+
+	// bot-c (not a member) tries to read
+	res, _ := h.HandleGetConversationMessages(ctx, call(map[string]any{
+		"as": "bot-c", "conversation_id": convID,
+	}))
+	expectError(t, res)
+}
+
+// --- Task Tests ---
+
+func TestTaskLifecycle(t *testing.T) {
+	h := testHandlers(t)
+	h.HandleRegisterAgent(ctx, call(map[string]any{"project": "p1", "name": "bot-a", "role": "dev"}))
+
+	// Dispatch
+	dispatchRes, _ := h.HandleDispatchTask(ctx, call(map[string]any{
+		"project": "p1", "as": "bot-a", "profile": "dev", "title": "Fix bug", "description": "fix the thing",
+	}))
+	task := parseJSON(t, dispatchRes)
+	taskID := task["id"].(string)
+	if task["status"] != "pending" {
+		t.Errorf("expected pending, got %v", task["status"])
+	}
+
+	// Claim
+	claimRes, _ := h.HandleClaimTask(ctx, call(map[string]any{
+		"project": "p1", "as": "bot-a", "task_id": taskID,
+	}))
+	claimed := parseJSON(t, claimRes)
+	if claimed["status"] != "accepted" {
+		t.Errorf("expected accepted, got %v", claimed["status"])
+	}
+
+	// Start
+	startRes, _ := h.HandleStartTask(ctx, call(map[string]any{
+		"project": "p1", "as": "bot-a", "task_id": taskID,
+	}))
+	started := parseJSON(t, startRes)
+	if started["status"] != "in-progress" {
+		t.Errorf("expected in-progress, got %v", started["status"])
+	}
+
+	// Complete
+	completeRes, _ := h.HandleCompleteTask(ctx, call(map[string]any{
+		"project": "p1", "as": "bot-a", "task_id": taskID, "result": "done!",
+	}))
+	completed := parseJSON(t, completeRes)
+	if completed["status"] != "done" {
+		t.Errorf("expected done, got %v", completed["status"])
+	}
+}
+
+func TestTaskBlock(t *testing.T) {
+	h := testHandlers(t)
+	h.HandleRegisterAgent(ctx, call(map[string]any{"project": "p1", "name": "bot-a", "role": "dev"}))
+
+	dispatchRes, _ := h.HandleDispatchTask(ctx, call(map[string]any{
+		"project": "p1", "as": "bot-a", "profile": "dev", "title": "task1",
+	}))
+	task := parseJSON(t, dispatchRes)
+	taskID := task["id"].(string)
+
+	h.HandleClaimTask(ctx, call(map[string]any{"project": "p1", "as": "bot-a", "task_id": taskID}))
+	h.HandleStartTask(ctx, call(map[string]any{"project": "p1", "as": "bot-a", "task_id": taskID}))
+
+	blockRes, _ := h.HandleBlockTask(ctx, call(map[string]any{
+		"project": "p1", "as": "bot-a", "task_id": taskID, "reason": "waiting for API",
+	}))
+	blocked := parseJSON(t, blockRes)
+	if blocked["status"] != "blocked" {
+		t.Errorf("expected blocked, got %v", blocked["status"])
+	}
+}
+
+func TestTaskCancel(t *testing.T) {
+	h := testHandlers(t)
+	h.HandleRegisterAgent(ctx, call(map[string]any{"project": "p1", "name": "bot-a", "role": "dev"}))
+
+	dispatchRes, _ := h.HandleDispatchTask(ctx, call(map[string]any{
+		"project": "p1", "as": "bot-a", "profile": "dev", "title": "to cancel",
+	}))
+	task := parseJSON(t, dispatchRes)
+	taskID := task["id"].(string)
+
+	cancelRes, _ := h.HandleCancelTask(ctx, call(map[string]any{
+		"project": "p1", "as": "bot-a", "task_id": taskID, "reason": "not needed",
+	}))
+	cancelled := parseJSON(t, cancelRes)
+	if cancelled["status"] != "cancelled" {
+		t.Errorf("expected cancelled, got %v", cancelled["status"])
+	}
+}
+
+func TestGetTask(t *testing.T) {
+	h := testHandlers(t)
+	h.HandleRegisterAgent(ctx, call(map[string]any{"project": "p1", "name": "bot-a", "role": "dev"}))
+
+	dispatchRes, _ := h.HandleDispatchTask(ctx, call(map[string]any{
+		"project": "p1", "as": "bot-a", "profile": "dev", "title": "get me",
+	}))
+	task := parseJSON(t, dispatchRes)
+	taskID := task["id"].(string)
+
+	getRes, _ := h.HandleGetTask(ctx, call(map[string]any{
+		"project": "p1", "task_id": taskID,
+	}))
+	got := parseJSON(t, getRes)
+	if got["title"] != "get me" {
+		t.Errorf("expected 'get me', got %v", got["title"])
+	}
+}
+
+func TestGetTaskNotFound(t *testing.T) {
+	h := testHandlers(t)
+	res, _ := h.HandleGetTask(ctx, call(map[string]any{
+		"project": "p1", "task_id": "nonexistent",
+	}))
+	expectError(t, res)
+}
+
+func TestListTasks(t *testing.T) {
+	h := testHandlers(t)
+	h.HandleRegisterAgent(ctx, call(map[string]any{"project": "p1", "name": "bot-a", "role": "dev"}))
+
+	h.HandleDispatchTask(ctx, call(map[string]any{"project": "p1", "as": "bot-a", "profile": "dev", "title": "task1"}))
+	h.HandleDispatchTask(ctx, call(map[string]any{"project": "p1", "as": "bot-a", "profile": "dev", "title": "task2"}))
+	h.HandleDispatchTask(ctx, call(map[string]any{"project": "p1", "as": "bot-a", "profile": "qa", "title": "task3"}))
+
+	// List all
+	res, _ := h.HandleListTasks(ctx, call(map[string]any{"project": "p1"}))
+	data := parseJSON(t, res)
+	if data["count"].(float64) != 3 {
+		t.Errorf("expected 3 tasks, got %v", data["count"])
+	}
+
+	// Filter by profile
+	res2, _ := h.HandleListTasks(ctx, call(map[string]any{"project": "p1", "profile": "dev"}))
+	data2 := parseJSON(t, res2)
+	if data2["count"].(float64) != 2 {
+		t.Errorf("expected 2 dev tasks, got %v", data2["count"])
+	}
+}
+
+func TestArchiveTasks(t *testing.T) {
+	h := testHandlers(t)
+	h.HandleRegisterAgent(ctx, call(map[string]any{"project": "p1", "name": "bot-a", "role": "dev"}))
+
+	dispatchRes, _ := h.HandleDispatchTask(ctx, call(map[string]any{
+		"project": "p1", "as": "bot-a", "profile": "dev", "title": "to archive",
+	}))
+	task := parseJSON(t, dispatchRes)
+	taskID := task["id"].(string)
+
+	// Complete it first
+	h.HandleClaimTask(ctx, call(map[string]any{"project": "p1", "as": "bot-a", "task_id": taskID}))
+	h.HandleStartTask(ctx, call(map[string]any{"project": "p1", "as": "bot-a", "task_id": taskID}))
+	h.HandleCompleteTask(ctx, call(map[string]any{"project": "p1", "as": "bot-a", "task_id": taskID}))
+
+	// Archive done tasks
+	archiveRes, _ := h.HandleArchiveTasks(ctx, call(map[string]any{
+		"project": "p1", "status": "done",
+	}))
+	// ArchiveTasks returns plain text, not JSON
+	tc := archiveRes.Content[0].(mcp.TextContent)
+	if tc.Text == "" {
+		t.Error("expected archive result text")
+	}
+}
+
+func TestDispatchTaskMissingFields(t *testing.T) {
+	h := testHandlers(t)
+	// Missing profile
+	res, _ := h.HandleDispatchTask(ctx, call(map[string]any{
+		"project": "p1", "as": "bot-a", "title": "test",
+	}))
+	expectError(t, res)
+
+	// Missing title
+	res2, _ := h.HandleDispatchTask(ctx, call(map[string]any{
+		"project": "p1", "as": "bot-a", "profile": "dev",
+	}))
+	expectError(t, res2)
+}
+
+// --- Memory Tests ---
+
+func TestMemorySetAndGet(t *testing.T) {
+	h := testHandlers(t)
+
+	// Set
+	setRes, _ := h.HandleSetMemory(ctx, call(map[string]any{
+		"project": "p1", "as": "bot-a", "key": "api_url", "value": "https://example.com",
+	}))
+	setData := parseJSON(t, setRes)
+	mem := setData["memory"].(map[string]any)
+	if mem["key"] != "api_url" {
+		t.Errorf("expected key=api_url, got %v", mem["key"])
+	}
+
+	// Get
+	getRes, _ := h.HandleGetMemory(ctx, call(map[string]any{
+		"project": "p1", "as": "bot-a", "key": "api_url",
+	}))
+	getData := parseJSON(t, getRes)
+	if getData["count"].(float64) != 1 {
+		t.Errorf("expected 1 memory, got %v", getData["count"])
+	}
+}
+
+func TestMemorySetMissingFields(t *testing.T) {
+	h := testHandlers(t)
+	// Missing key
+	res, _ := h.HandleSetMemory(ctx, call(map[string]any{
+		"project": "p1", "as": "bot-a", "value": "test",
+	}))
+	expectError(t, res)
+
+	// Missing value
+	res2, _ := h.HandleSetMemory(ctx, call(map[string]any{
+		"project": "p1", "as": "bot-a", "key": "test",
+	}))
+	expectError(t, res2)
+}
+
+func TestMemorySearch(t *testing.T) {
+	h := testHandlers(t)
+	h.HandleSetMemory(ctx, call(map[string]any{
+		"project": "p1", "as": "bot-a", "key": "deploy_url", "value": "the production deploy URL is https://prod.example.com",
+	}))
+	h.HandleSetMemory(ctx, call(map[string]any{
+		"project": "p1", "as": "bot-a", "key": "db_host", "value": "database host is db.internal",
+	}))
+
+	res, _ := h.HandleSearchMemory(ctx, call(map[string]any{
+		"project": "p1", "as": "bot-a", "query": "deploy",
+	}))
+	// FTS5 may not be available in test builds — if error, that's expected
+	if res.IsError {
+		t.Skip("FTS5 not available in this build")
+	}
+	data := parseJSON(t, res)
+	if data["count"].(float64) < 1 {
+		t.Errorf("expected at least 1 search result, got %v", data["count"])
+	}
+}
+
+func TestMemoryList(t *testing.T) {
+	h := testHandlers(t)
+	h.HandleSetMemory(ctx, call(map[string]any{
+		"project": "p1", "as": "bot-a", "key": "k1", "value": "v1",
+	}))
+	h.HandleSetMemory(ctx, call(map[string]any{
+		"project": "p1", "as": "bot-b", "key": "k2", "value": "v2",
+	}))
+
+	res, _ := h.HandleListMemories(ctx, call(map[string]any{
+		"project": "p1",
+	}))
+	data := parseJSON(t, res)
+	if data["count"].(float64) != 2 {
+		t.Errorf("expected 2 memories, got %v", data["count"])
+	}
+}
+
+func TestMemoryDelete(t *testing.T) {
+	h := testHandlers(t)
+	h.HandleSetMemory(ctx, call(map[string]any{
+		"project": "p1", "as": "bot-a", "key": "temp", "value": "to delete",
+	}))
+
+	res, _ := h.HandleDeleteMemory(ctx, call(map[string]any{
+		"project": "p1", "as": "bot-a", "key": "temp",
+	}))
+	data := parseJSON(t, res)
+	if data["deleted"] != true {
+		t.Error("expected deleted=true")
+	}
+
+	// Should be gone
+	getRes, _ := h.HandleGetMemory(ctx, call(map[string]any{
+		"project": "p1", "as": "bot-a", "key": "temp",
+	}))
+	getData := parseJSON(t, getRes)
+	if getData["count"].(float64) != 0 {
+		t.Errorf("expected 0 memories after delete, got %v", getData["count"])
+	}
+}
+
+// --- Profile Tests ---
+
+func TestProfileLifecycle(t *testing.T) {
+	h := testHandlers(t)
+
+	// Register
+	regRes, _ := h.HandleRegisterProfile(ctx, call(map[string]any{
+		"project": "p1", "slug": "backend", "name": "Backend Dev", "role": "developer",
+	}))
+	profile := parseJSON(t, regRes)
+	if profile["slug"] != "backend" {
+		t.Errorf("expected slug=backend, got %v", profile["slug"])
+	}
+
+	// Get
+	getRes, _ := h.HandleGetProfile(ctx, call(map[string]any{
+		"project": "p1", "slug": "backend",
+	}))
+	got := parseJSON(t, getRes)
+	if got["name"] != "Backend Dev" {
+		t.Errorf("expected name=Backend Dev, got %v", got["name"])
+	}
+
+	// List
+	listRes, _ := h.HandleListProfiles(ctx, call(map[string]any{
+		"project": "p1",
+	}))
+	listData := parseJSON(t, listRes)
+	if listData["count"].(float64) != 1 {
+		t.Errorf("expected 1 profile, got %v", listData["count"])
+	}
+}
+
+func TestProfileNotFound(t *testing.T) {
+	h := testHandlers(t)
+	res, _ := h.HandleGetProfile(ctx, call(map[string]any{
+		"project": "p1", "slug": "nonexistent",
+	}))
+	expectError(t, res)
+}
+
+func TestRegisterProfileMissingFields(t *testing.T) {
+	h := testHandlers(t)
+	res, _ := h.HandleRegisterProfile(ctx, call(map[string]any{
+		"project": "p1", "name": "test",
+	}))
+	expectError(t, res)
+
+	res2, _ := h.HandleRegisterProfile(ctx, call(map[string]any{
+		"project": "p1", "slug": "test",
+	}))
+	expectError(t, res2)
+}
+
+func TestFindProfiles(t *testing.T) {
+	h := testHandlers(t)
+	h.HandleRegisterProfile(ctx, call(map[string]any{
+		"project": "p1", "slug": "backend", "name": "Backend Dev", "role": "dev",
+		"skills": `[{"tag": "golang"}]`,
+	}))
+	h.HandleRegisterProfile(ctx, call(map[string]any{
+		"project": "p1", "slug": "frontend", "name": "Frontend Dev", "role": "dev",
+		"skills": `[{"tag": "react"}]`,
+	}))
+
+	res, _ := h.HandleFindProfiles(ctx, call(map[string]any{
+		"project": "p1", "skill_tag": "golang",
+	}))
+	data := parseJSON(t, res)
+	if data["count"].(float64) != 1 {
+		t.Errorf("expected 1 profile with golang tag, got %v", data["count"])
+	}
+}
+
+// --- Board Tests ---
+
+func TestBoardLifecycle(t *testing.T) {
+	h := testHandlers(t)
+
+	// Create
+	createRes, _ := h.HandleCreateBoard(ctx, call(map[string]any{
+		"project": "p1", "as": "bot-a", "name": "Sprint 1", "slug": "sprint-1",
+	}))
+	board := parseJSON(t, createRes)
+	boardID := board["id"].(string)
+	if board["name"] != "Sprint 1" {
+		t.Errorf("expected Sprint 1, got %v", board["name"])
+	}
+
+	// List (returns array, not map)
+	listRes, _ := h.HandleListBoards(ctx, call(map[string]any{"project": "p1"}))
+	tc := listRes.Content[0].(mcp.TextContent)
+	var boardList []any
+	if err := json.Unmarshal([]byte(tc.Text), &boardList); err != nil {
+		t.Fatalf("parse board list: %v", err)
+	}
+	if len(boardList) != 1 {
+		t.Errorf("expected 1 board, got %d", len(boardList))
+	}
+
+	// Archive (returns plain text)
+	archiveRes, _ := h.HandleArchiveBoard(ctx, call(map[string]any{
+		"project": "p1", "board_id": boardID,
+	}))
+	if archiveRes.IsError {
+		t.Errorf("archive board failed: %v", archiveRes.Content)
+	}
+
+	// Delete (returns plain text)
+	deleteRes, _ := h.HandleDeleteBoard(ctx, call(map[string]any{
+		"project": "p1", "board_id": boardID,
+	}))
+	if deleteRes.IsError {
+		t.Errorf("delete board failed: %v", deleteRes.Content)
+	}
+}
+
+func TestCreateBoardMissingFields(t *testing.T) {
+	h := testHandlers(t)
+	res, _ := h.HandleCreateBoard(ctx, call(map[string]any{
+		"project": "p1", "as": "bot-a", "name": "test",
+	}))
+	expectError(t, res)
+}
+
+// --- Goal Tests ---
+
+func TestGoalLifecycle(t *testing.T) {
+	h := testHandlers(t)
+
+	// Create
+	createRes, _ := h.HandleCreateGoal(ctx, call(map[string]any{
+		"project": "p1", "as": "bot-a", "title": "Ship v2", "type": "agent_goal",
+	}))
+	goal := parseJSON(t, createRes)
+	goalID := goal["id"].(string)
+	if goal["title"] != "Ship v2" {
+		t.Errorf("expected 'Ship v2', got %v", goal["title"])
+	}
+
+	// Get
+	getRes, _ := h.HandleGetGoal(ctx, call(map[string]any{
+		"project": "p1", "goal_id": goalID,
+	}))
+	got := parseJSON(t, getRes)
+	if got["title"] != "Ship v2" {
+		t.Errorf("expected 'Ship v2', got %v", got["title"])
+	}
+
+	// Update
+	updateRes, _ := h.HandleUpdateGoal(ctx, call(map[string]any{
+		"project": "p1", "goal_id": goalID, "status": "completed",
+	}))
+	updated := parseJSON(t, updateRes)
+	if updated["status"] != "completed" {
+		t.Errorf("expected completed, got %v", updated["status"])
+	}
+
+	// List
+	listRes, _ := h.HandleListGoals(ctx, call(map[string]any{
+		"project": "p1",
+	}))
+	listData := parseJSON(t, listRes)
+	if listData["count"].(float64) != 1 {
+		t.Errorf("expected 1 goal, got %v", listData["count"])
+	}
+}
+
+// --- Org / Team Tests ---
+
+func TestOrgAndTeamLifecycle(t *testing.T) {
+	h := testHandlers(t)
+	h.HandleRegisterAgent(ctx, call(map[string]any{"project": "p1", "name": "bot-a", "role": "dev"}))
+
+	// Create org
+	orgRes, _ := h.HandleCreateOrg(ctx, call(map[string]any{
+		"name": "Acme Corp", "slug": "acme",
+	}))
+	org := parseJSON(t, orgRes)
+	orgID := org["id"].(string)
+
+	// List orgs
+	listOrgRes, _ := h.HandleListOrgs(ctx, call(map[string]any{}))
+	orgs := parseJSON(t, listOrgRes)
+	if orgs["count"].(float64) != 1 {
+		t.Errorf("expected 1 org, got %v", orgs["count"])
+	}
+
+	// Create team
+	teamRes, _ := h.HandleCreateTeam(ctx, call(map[string]any{
+		"project": "p1", "name": "Backend Team", "slug": "backend", "org_id": orgID,
+	}))
+	team := parseJSON(t, teamRes)
+	if team["name"] != "Backend Team" {
+		t.Errorf("expected Backend Team, got %v", team["name"])
+	}
+
+	// List teams
+	listTeamRes, _ := h.HandleListTeams(ctx, call(map[string]any{"project": "p1"}))
+	teams := parseJSON(t, listTeamRes)
+	if teams["count"].(float64) != 1 {
+		t.Errorf("expected 1 team, got %v", teams["count"])
+	}
+
+	// Add member (uses team slug, not ID)
+	addRes, _ := h.HandleAddTeamMember(ctx, call(map[string]any{
+		"project": "p1", "team": "backend", "agent_name": "bot-a", "role": "lead",
+	}))
+	addData := parseJSON(t, addRes)
+	if addData["added"] != true {
+		t.Error("expected added=true")
+	}
+
+	// Remove member (uses team slug)
+	removeRes, _ := h.HandleRemoveTeamMember(ctx, call(map[string]any{
+		"project": "p1", "team": "backend", "agent_name": "bot-a",
+	}))
+	removeData := parseJSON(t, removeRes)
+	if removeData["removed"] != true {
+		t.Error("expected removed=true")
+	}
+}
+
+// --- Validation Tests (cross-cutting) ---
+
+func TestResolveProjectDefault(t *testing.T) {
+	req := call(map[string]any{})
+	if p := resolveProject(req); p != "default" {
+		t.Errorf("expected 'default', got %s", p)
+	}
+}
+
+func TestResolveAgentDefault(t *testing.T) {
+	req := call(map[string]any{})
+	if a := resolveAgent(req); a != "anonymous" {
+		t.Errorf("expected 'anonymous', got %s", a)
+	}
+}
+
+func TestOptionalString(t *testing.T) {
+	if optionalString("") != nil {
+		t.Error("expected nil for empty string")
+	}
+	if *optionalString("hello") != "hello" {
+		t.Error("expected 'hello'")
+	}
+}


### PR DESCRIPTION
## Summary
- 68 tests covering all MCP handlers and REST API endpoints
- Handlers: agents, messages, conversations, tasks, memories, profiles, goals, boards, teams/orgs
- API: projects, agents, messages, tasks, settings, conversations, memories, goals, boards, teams
- Validation: missing required fields, 404s, error cases, membership checks
- Added `db.NewTestDB()` helper for creating test databases

## Test plan
- [x] All 68 tests pass locally
- [x] Race detector clean (`go test -race ./...`)
- [x] FTS5-dependent tests gracefully skip when module unavailable
- [x] CI workflow from PR #5 will run these automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded test infrastructure with comprehensive end-to-end suites covering API endpoints and handler workflows across projects, settings, agents, messages, conversations, memories, tasks, profiles, goals, boards, and teams.
  * Added a lightweight SQLite-backed test database helper for isolated per-test databases, including migration and reliability tweaks to improve test stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->