### PR TITLE
fix: V0.3.1 Setup UX — resolve 13 issues from user testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,26 @@ This creates `.mcp.json` with the correct config (merges if one already exists):
 
 That's it. Your agents register, talk, remember, and execute. You watch the galaxy.
 
+### Where to put the MCP config
+
+Claude Code resolves MCP servers from multiple levels, merged top-down:
+
+| Level | File | Scope |
+|-------|------|-------|
+| **Project** | `.mcp.json` in repo root | Only this repo. Committed = shared with your team. |
+| **User-global** | `~/.claude/.mcp.json` | Every repo on your machine. |
+| **CLAUDE.md** | Project or global `CLAUDE.md` | Can document the expected config, but doesn't auto-connect. |
+
+**Which one to use:**
+
+- **Single project** — `agent-relay init` in the repo root. The relay is scoped to that project.
+- **All your projects** — `agent-relay init --global`. One connection shared everywhere. Each agent still passes `project` per tool call to scope its data.
+- **Team repo** — Commit `.mcp.json` to the repo so every contributor gets the relay automatically.
+
+If the relay appears at multiple levels, Claude Code deduplicates by server name (`agent-relay`). Project-level takes precedence over global.
+
+> **Tip:** Don't put `?project=` in the URL. Agents pass `project` explicitly on each tool call, which lets a single connection work across multiple projects.
+
 ### Server Deployment
 
 For team use on a shared server, configure security via environment variables. **All settings are opt-in — without any env vars, behavior is identical to local mode.**

--- a/README.md
+++ b/README.md
@@ -44,7 +44,17 @@ irm https://raw.githubusercontent.com/Synergix-lab/WRAI.TH/main/install.ps1 | ie
 
 The installer builds from source (Go + GCC), falls back to prebuilt, sets up auto-start, installs the `/relay` skill, and configures your projects.
 
-Connect any MCP client:
+**Or** generate the MCP config manually:
+
+```bash
+# From your project directory (creates .mcp.json):
+agent-relay init
+
+# Or globally for all projects:
+agent-relay init --global
+```
+
+This creates `.mcp.json` with the correct config (merges if one already exists):
 
 ```json
 {
@@ -456,6 +466,21 @@ Open `localhost:8090`. Projects orbit as pixel art planets. Click one to land. R
 
 ## &#x1F465; Agents & Hierarchy
 
+### Session linking (the salt)
+
+Before registering, agents call `whoami` with a unique **salt** — a random string like `"crimson-wave-orbit"`. The relay searches `~/.claude/` transcripts for that salt to find the calling session's ID. This links the MCP connection to a specific Claude Code session for activity tracking.
+
+```
+# Step 1: Generate a salt and call whoami
+whoami({ salt: "crimson-wave-orbit" })
+→ { session_id: "e7b51532-...", transcript_path: "..." }
+
+# Step 2: Register with the session ID
+register_agent({ name: "backend", session_id: "e7b51532-...", ... })
+```
+
+The salt must be unique (3+ random words) and must appear in your conversation transcript before calling `whoami`. The relay reads the last 64KB of each transcript file, so it finds recent salts instantly.
+
 ### Persistent identity
 
 Agents are not sessions — they're persistent entities in the DB. An agent named `backend` exists across restarts:
@@ -465,6 +490,8 @@ register_agent({ name: "backend", role: "FastAPI developer", reports_to: "tech-l
 ```
 
 First call creates the agent. Second call from a new session? **Respawn** — same identity, same inbox, same memories, same task queue. The response includes `is_respawn: true` and the full `session_context` so the agent picks up mid-conversation without missing a beat.
+
+Executive agents (`is_executive: true`) are automatically added to a `leadership` admin team with broadcast permissions — no manual team setup needed.
 
 ### One session, many agents
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -20,6 +20,8 @@ func Run(args []string) {
 	switch cmd {
 	case "help":
 		printUsage()
+	case "init":
+		runInit(rest)
 	case "status":
 		runStatus()
 	case "agents":
@@ -89,6 +91,10 @@ func printUsage() {
 	fmt.Print(`usage: agent-relay <command> [-p <project>]
 
 commands:
+  init [project] [flags]       create .mcp.json for Claude Code
+    --global                   write to ~/.claude/.mcp.json instead
+    --port <port>              relay port (default: 8090)
+    --host <host>              relay host (default: localhost)
   serve                        start the relay server
   status                       relay status & summary
   agents [-p project]          list registered agents

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -1,0 +1,128 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+type mcpConfig struct {
+	MCPServers map[string]mcpServerEntry `json:"mcpServers"`
+}
+
+type mcpServerEntry struct {
+	Type string `json:"type"`
+	URL  string `json:"url"`
+}
+
+func runInit(args []string) {
+	// Parse flags
+	port := "8090"
+	host := "localhost"
+	project := ""
+	dir := "."
+	global := false
+
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--port":
+			if i+1 < len(args) {
+				port = args[i+1]
+				i++
+			}
+		case "--host":
+			if i+1 < len(args) {
+				host = args[i+1]
+				i++
+			}
+		case "-p", "--project":
+			if i+1 < len(args) {
+				project = args[i+1]
+				i++
+			}
+		case "--global":
+			global = true
+		default:
+			// First positional arg is the project name
+			if project == "" && args[i][0] != '-' {
+				project = args[i]
+			}
+		}
+	}
+
+	if global {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error: cannot determine home directory: %v\n", err)
+			os.Exit(1)
+		}
+		dir = filepath.Join(home, ".claude")
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			fmt.Fprintf(os.Stderr, "error: cannot create %s: %v\n", dir, err)
+			os.Exit(1)
+		}
+	}
+
+	mcpPath := filepath.Join(dir, ".mcp.json")
+
+	// Build the URL
+	url := fmt.Sprintf("http://%s:%s/mcp", host, port)
+	if project != "" {
+		url += "?project=" + project
+	}
+
+	// Check if file already exists
+	if _, err := os.Stat(mcpPath); err == nil {
+		// File exists — try to merge
+		existing, err := os.ReadFile(mcpPath)
+		if err == nil {
+			var cfg mcpConfig
+			if json.Unmarshal(existing, &cfg) == nil {
+				if _, exists := cfg.MCPServers["agent-relay"]; exists {
+					fmt.Printf("agent-relay already configured in %s\n", mcpPath)
+					fmt.Printf("  url: %s\n", cfg.MCPServers["agent-relay"].URL)
+					return
+				}
+				// Add agent-relay to existing config
+				cfg.MCPServers["agent-relay"] = mcpServerEntry{Type: "http", URL: url}
+				writeConfig(mcpPath, cfg)
+				fmt.Printf("added agent-relay to existing %s\n", mcpPath)
+				fmt.Printf("  url: %s\n", url)
+				return
+			}
+		}
+	}
+
+	// Create new config
+	cfg := mcpConfig{
+		MCPServers: map[string]mcpServerEntry{
+			"agent-relay": {Type: "http", URL: url},
+		},
+	}
+	writeConfig(mcpPath, cfg)
+
+	absPath, _ := filepath.Abs(mcpPath)
+	fmt.Printf("created %s\n", absPath)
+	fmt.Printf("  url: %s\n", url)
+	if project != "" {
+		fmt.Printf("  project: %s (set as default via URL param)\n", project)
+	}
+	fmt.Println("\nnext steps:")
+	fmt.Println("  1. Run /mcp in Claude Code to reload MCP connections")
+	fmt.Println("  2. Call whoami() with a unique salt to identify your session")
+	fmt.Println("  3. Call register_agent() to announce your presence")
+}
+
+func writeConfig(path string, cfg mcpConfig) {
+	data, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+	data = append(data, '\n')
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		fmt.Fprintf(os.Stderr, "error writing %s: %v\n", path, err)
+		os.Exit(1)
+	}
+}

--- a/internal/relay/api.go
+++ b/internal/relay/api.go
@@ -86,6 +86,8 @@ func (r *Relay) ServeAPI(w http.ResponseWriter, req *http.Request) {
 	case path == "/file-locks" && req.Method == http.MethodGet:
 		r.apiGetFileLocks(w, req)
 	// Task endpoints
+	case path == "/tasks/human" && req.Method == http.MethodGet:
+		r.apiGetHumanTasks(w, req)
 	case path == "/tasks/all" && req.Method == http.MethodGet:
 		r.apiGetAllTasks(w)
 	case path == "/tasks" && req.Method == http.MethodGet:
@@ -909,6 +911,23 @@ func (r *Relay) apiGetTasks(w http.ResponseWriter, req *http.Request) {
 	tasks, err := r.DB.ListTasks(project, status, profile, priority, "", boardID, 100)
 	if err != nil {
 		http.Error(w, `{"error":"failed to list tasks"}`, http.StatusInternalServerError)
+		return
+	}
+	if tasks == nil {
+		tasks = []models.Task{}
+	}
+	writeJSON(w, tasks)
+}
+
+func (r *Relay) apiGetHumanTasks(w http.ResponseWriter, req *http.Request) {
+	project := projectFromRequest(req)
+	status := req.URL.Query().Get("status")
+	if status == "" {
+		status = "" // all statuses
+	}
+	tasks, err := r.DB.ListTasks(project, status, "human", "", "", "", 100)
+	if err != nil {
+		http.Error(w, `{"error":"failed to list human tasks"}`, http.StatusInternalServerError)
 		return
 	}
 	if tasks == nil {

--- a/internal/relay/handlers.go
+++ b/internal/relay/handlers.go
@@ -95,7 +95,7 @@ func (h *Handlers) HandleWhoami(ctx context.Context, req mcp.CallToolRequest) (*
 }
 
 func (h *Handlers) HandleRegisterAgent(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	project := resolveProject(req)
+	project := resolveProject(ctx, req)
 	name := strings.ToLower(req.GetString("name", ""))
 	if name == "" {
 		return mcp.NewToolResultError("name is required"), nil
@@ -114,6 +114,19 @@ func (h *Handlers) HandleRegisterAgent(ctx context.Context, req mcp.CallToolRequ
 		return mcp.NewToolResultError(fmt.Sprintf("failed to register agent: %v", err)), nil
 	}
 
+	// Auto-create admin team + add executive agent (fixes broadcast permission UX)
+	var autoAdminTeam *string
+	if isExecutive {
+		adminTeam, _ := h.db.GetTeam(project, "leadership")
+		if adminTeam == nil {
+			adminTeam, _ = h.db.CreateTeam("Leadership", "leadership", project, "Auto-created admin team for executive agents", "admin", nil, nil)
+		}
+		if adminTeam != nil {
+			_ = h.db.AddTeamMember(adminTeam.ID, name, project, "admin")
+			autoAdminTeam = &adminTeam.Slug
+		}
+	}
+
 	// Register the session for push notifications
 	if sess := sessionFromContext(ctx); sess != nil {
 		h.registry.Register(project, name, sess.SessionID())
@@ -129,15 +142,20 @@ func (h *Handlers) HandleRegisterAgent(ctx context.Context, req mcp.CallToolRequ
 	}
 	h.events.Emit(MCPEvent{Type: "register", Action: action, Agent: name, Project: project, Label: role})
 
-	return resultJSON(map[string]any{
+	resp := map[string]any{
 		"agent":           agent,
 		"session_context": sessionCtx,
-	})
+	}
+	if autoAdminTeam != nil {
+		resp["auto_admin_team"] = *autoAdminTeam
+		resp["hint"] = "You were auto-added to the 'leadership' admin team (broadcast enabled). Use send_message(to='*') to broadcast."
+	}
+	return resultJSON(resp)
 }
 
 func (h *Handlers) HandleSendMessage(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	project := resolveProject(req)
-	from := resolveAgent(req)
+	project := resolveProject(ctx, req)
+	from := resolveAgent(ctx, req)
 	to := strings.ToLower(req.GetString("to", ""))
 	msgType := req.GetString("type", "notification")
 	subject := req.GetString("subject", "")
@@ -225,7 +243,7 @@ func (h *Handlers) HandleSendMessage(ctx context.Context, req mcp.CallToolReques
 		if hasTeams {
 			allowed, _ := h.db.CanMessage(project, from, "*")
 			if !allowed {
-				return mcp.NewToolResultError("broadcast requires membership in an 'admin' type team"), nil
+				return mcp.NewToolResultError("broadcast requires membership in an 'admin' type team. Fix: register with is_executive=true (auto-creates admin team), or manually: create_team(type='admin') then add_team_member()"), nil
 			}
 		}
 	}
@@ -252,8 +270,8 @@ func (h *Handlers) HandleSendMessage(ctx context.Context, req mcp.CallToolReques
 }
 
 func (h *Handlers) HandleGetInbox(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	project := resolveProject(req)
-	agent := resolveAgent(req)
+	project := resolveProject(ctx, req)
+	agent := resolveAgent(ctx, req)
 	unreadOnly := req.GetBool("unread_only", true)
 	limit := req.GetInt("limit", 10)
 	fullContent := req.GetBool("full_content", false)
@@ -352,7 +370,7 @@ func (h *Handlers) HandleGetThread(ctx context.Context, req mcp.CallToolRequest)
 }
 
 func (h *Handlers) HandleListAgents(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	project := resolveProject(req)
+	project := resolveProject(ctx, req)
 
 	agents, err := h.db.ListAgents(project)
 	if err != nil {
@@ -397,8 +415,8 @@ func (h *Handlers) HandleListAgents(ctx context.Context, req mcp.CallToolRequest
 }
 
 func (h *Handlers) HandleMarkRead(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	project := resolveProject(req)
-	agent := resolveAgent(req)
+	project := resolveProject(ctx, req)
+	agent := resolveAgent(ctx, req)
 
 	// Support marking a whole conversation as read
 	convID := req.GetString("conversation_id", "")
@@ -428,8 +446,8 @@ func (h *Handlers) HandleMarkRead(ctx context.Context, req mcp.CallToolRequest) 
 }
 
 func (h *Handlers) HandleCreateConversation(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	project := resolveProject(req)
-	agent := resolveAgent(req)
+	project := resolveProject(ctx, req)
+	agent := resolveAgent(ctx, req)
 	title := req.GetString("title", "")
 	if title == "" {
 		return mcp.NewToolResultError("title is required"), nil
@@ -468,8 +486,8 @@ func (h *Handlers) HandleCreateConversation(ctx context.Context, req mcp.CallToo
 }
 
 func (h *Handlers) HandleListConversations(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	project := resolveProject(req)
-	agent := resolveAgent(req)
+	project := resolveProject(ctx, req)
+	agent := resolveAgent(ctx, req)
 
 	convs, err := h.db.ListConversations(project, agent)
 	if err != nil {
@@ -487,7 +505,7 @@ func (h *Handlers) HandleListConversations(ctx context.Context, req mcp.CallTool
 }
 
 func (h *Handlers) HandleGetConversationMessages(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	agent := resolveAgent(req)
+	agent := resolveAgent(ctx, req)
 	convID := req.GetString("conversation_id", "")
 	if convID == "" {
 		return mcp.NewToolResultError("conversation_id is required"), nil
@@ -553,8 +571,8 @@ func (h *Handlers) HandleGetConversationMessages(ctx context.Context, req mcp.Ca
 }
 
 func (h *Handlers) HandleInviteToConversation(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	project := resolveProject(req)
-	agent := resolveAgent(req)
+	project := resolveProject(ctx, req)
+	agent := resolveAgent(ctx, req)
 	convID := req.GetString("conversation_id", "")
 	if convID == "" {
 		return mcp.NewToolResultError("conversation_id is required"), nil
@@ -587,8 +605,8 @@ func (h *Handlers) HandleInviteToConversation(ctx context.Context, req mcp.CallT
 }
 
 func (h *Handlers) HandleLeaveConversation(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	project := resolveProject(req)
-	agent := resolveAgent(req)
+	project := resolveProject(ctx, req)
+	agent := resolveAgent(ctx, req)
 	convID := req.GetString("conversation_id", "")
 	if convID == "" {
 		return mcp.NewToolResultError("conversation_id is required"), nil
@@ -621,7 +639,7 @@ func (h *Handlers) HandleLeaveConversation(ctx context.Context, req mcp.CallTool
 }
 
 func (h *Handlers) HandleArchiveConversation(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	project := resolveProject(req)
+	project := resolveProject(ctx, req)
 	convID := req.GetString("conversation_id", "")
 	if convID == "" {
 		return mcp.NewToolResultError("conversation_id is required"), nil
@@ -634,7 +652,7 @@ func (h *Handlers) HandleArchiveConversation(ctx context.Context, req mcp.CallTo
 	h.events.Emit(MCPEvent{
 		Type:    "conversation",
 		Action:  "archived",
-		Agent:   resolveAgent(req),
+		Agent:   resolveAgent(ctx, req),
 		Project: project,
 		Label:   convID,
 	})
@@ -657,21 +675,23 @@ func (h *Handlers) notifyConversation(project, conversationID, senderName, subje
 	}
 }
 
-// resolveProject returns the project from the explicit `project` tool parameter.
-func resolveProject(req mcp.CallToolRequest) string {
+// resolveProject returns the project from the explicit `project` tool parameter,
+// falling back to the HTTP context default (from ?project= URL param).
+func resolveProject(ctx context.Context, req mcp.CallToolRequest) string {
 	if p := req.GetString("project", ""); p != "" {
 		return p
 	}
-	return "default"
+	return ProjectFromContext(ctx)
 }
 
-// resolveAgent returns the agent name from the explicit `as` tool parameter.
+// resolveAgent returns the agent name from the explicit `as` tool parameter,
+// falling back to the HTTP context default (from ?agent= URL param).
 // Names are lowercased for case-insensitive matching.
-func resolveAgent(req mcp.CallToolRequest) string {
+func resolveAgent(ctx context.Context, req mcp.CallToolRequest) string {
 	if as := req.GetString("as", ""); as != "" {
 		return strings.ToLower(as)
 	}
-	return "anonymous"
+	return AgentFromContext(ctx)
 }
 
 // helpers
@@ -697,6 +717,33 @@ func optionalStringLower(s string) *string {
 	}
 	l := strings.ToLower(s)
 	return &l
+}
+
+// normalizeJSONArrayParam handles profile parameters that can be either a JSON string
+// (e.g. "[\"a\",\"b\"]") or a native JSON array from the MCP client. Returns a JSON string.
+func normalizeJSONArrayParam(req mcp.CallToolRequest, key string) string {
+	// First try as string (the documented format)
+	if s := req.GetString(key, ""); s != "" {
+		// Validate it's valid JSON
+		var check json.RawMessage
+		if json.Unmarshal([]byte(s), &check) == nil {
+			return s
+		}
+		// Not valid JSON — wrap as a single-element array
+		b, _ := json.Marshal([]string{s})
+		return string(b)
+	}
+	// Try to extract the raw argument value — it might be a native array
+	if args := req.GetArguments(); args != nil {
+		if raw, exists := args[key]; exists {
+			// Re-marshal whatever the MCP client sent (array, object, etc.)
+			b, err := json.Marshal(raw)
+			if err == nil {
+				return string(b)
+			}
+		}
+	}
+	return "[]"
 }
 
 // mapPriority normalizes MACP aliases to P0-P3.
@@ -731,8 +778,8 @@ const sessionKey contextKey = "mcp_session"
 // --- Memory handlers ---
 
 func (h *Handlers) HandleSetMemory(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	project := resolveProject(req)
-	agent := resolveAgent(req)
+	project := resolveProject(ctx, req)
+	agent := resolveAgent(ctx, req)
 	key := req.GetString("key", "")
 	if key == "" {
 		return mcp.NewToolResultError("key is required"), nil
@@ -767,8 +814,8 @@ func (h *Handlers) HandleSetMemory(ctx context.Context, req mcp.CallToolRequest)
 }
 
 func (h *Handlers) HandleGetMemory(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	project := resolveProject(req)
-	agent := resolveAgent(req)
+	project := resolveProject(ctx, req)
+	agent := resolveAgent(ctx, req)
 	key := req.GetString("key", "")
 	if key == "" {
 		return mcp.NewToolResultError("key is required"), nil
@@ -797,8 +844,8 @@ func (h *Handlers) HandleGetMemory(ctx context.Context, req mcp.CallToolRequest)
 }
 
 func (h *Handlers) HandleSearchMemory(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	project := resolveProject(req)
-	agent := resolveAgent(req)
+	project := resolveProject(ctx, req)
+	agent := resolveAgent(ctx, req)
 	query := req.GetString("query", "")
 	if query == "" {
 		return mcp.NewToolResultError("query is required"), nil
@@ -844,7 +891,7 @@ func (h *Handlers) HandleSearchMemory(ctx context.Context, req mcp.CallToolReque
 }
 
 func (h *Handlers) HandleListMemories(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	project := resolveProject(req)
+	project := resolveProject(ctx, req)
 	scope := req.GetString("scope", "")
 	agentFilter := req.GetString("agent", "")
 	tags := req.GetStringSlice("tags", nil)
@@ -853,7 +900,7 @@ func (h *Handlers) HandleListMemories(ctx context.Context, req mcp.CallToolReque
 	// Bug fix: scope=agent must be filtered by the calling agent to prevent leaking
 	// other agents' private memories. If no explicit agent filter, use the caller's identity.
 	if scope == "agent" && agentFilter == "" {
-		agentFilter = resolveAgent(req)
+		agentFilter = resolveAgent(ctx, req)
 	}
 
 	memories, err := h.db.ListMemories(project, scope, agentFilter, tags, limit)
@@ -893,8 +940,8 @@ func (h *Handlers) HandleListMemories(ctx context.Context, req mcp.CallToolReque
 }
 
 func (h *Handlers) HandleDeleteMemory(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	project := resolveProject(req)
-	agent := resolveAgent(req)
+	project := resolveProject(ctx, req)
+	agent := resolveAgent(ctx, req)
 	key := req.GetString("key", "")
 	if key == "" {
 		return mcp.NewToolResultError("key is required"), nil
@@ -913,8 +960,8 @@ func (h *Handlers) HandleDeleteMemory(ctx context.Context, req mcp.CallToolReque
 }
 
 func (h *Handlers) HandleResolveConflict(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	project := resolveProject(req)
-	agent := resolveAgent(req)
+	project := resolveProject(ctx, req)
+	agent := resolveAgent(ctx, req)
 	key := req.GetString("key", "")
 	if key == "" {
 		return mcp.NewToolResultError("key is required"), nil
@@ -940,7 +987,7 @@ func (h *Handlers) HandleResolveConflict(ctx context.Context, req mcp.CallToolRe
 // --- Profile handlers ---
 
 func (h *Handlers) HandleRegisterProfile(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	project := resolveProject(req)
+	project := resolveProject(ctx, req)
 	slug := req.GetString("slug", "")
 	if slug == "" {
 		return mcp.NewToolResultError("slug is required"), nil
@@ -951,9 +998,9 @@ func (h *Handlers) HandleRegisterProfile(ctx context.Context, req mcp.CallToolRe
 	}
 	role := req.GetString("role", "")
 	contextPack := req.GetString("context_pack", "")
-	soulKeys := req.GetString("soul_keys", "[]")
-	skills := req.GetString("skills", "[]")
-	vaultPaths := req.GetString("vault_paths", "[]")
+	soulKeys := normalizeJSONArrayParam(req, "soul_keys")
+	skills := normalizeJSONArrayParam(req, "skills")
+	vaultPaths := normalizeJSONArrayParam(req, "vault_paths")
 
 	profile, err := h.db.RegisterProfile(project, slug, name, role, contextPack, soulKeys, skills, vaultPaths)
 	if err != nil {
@@ -963,7 +1010,7 @@ func (h *Handlers) HandleRegisterProfile(ctx context.Context, req mcp.CallToolRe
 }
 
 func (h *Handlers) HandleGetProfile(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	project := resolveProject(req)
+	project := resolveProject(ctx, req)
 	slug := req.GetString("slug", "")
 	if slug == "" {
 		return mcp.NewToolResultError("slug is required"), nil
@@ -980,7 +1027,7 @@ func (h *Handlers) HandleGetProfile(ctx context.Context, req mcp.CallToolRequest
 }
 
 func (h *Handlers) HandleListProfiles(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	project := resolveProject(req)
+	project := resolveProject(ctx, req)
 
 	profiles, err := h.db.ListProfiles(project)
 	if err != nil {
@@ -999,8 +1046,8 @@ func (h *Handlers) HandleListProfiles(ctx context.Context, req mcp.CallToolReque
 // --- Task handlers ---
 
 func (h *Handlers) HandleDispatchTask(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	project := resolveProject(req)
-	agent := resolveAgent(req)
+	project := resolveProject(ctx, req)
+	agent := resolveAgent(ctx, req)
 	profile := req.GetString("profile", "")
 	if profile == "" {
 		return mcp.NewToolResultError("profile is required"), nil
@@ -1015,6 +1062,32 @@ func (h *Handlers) HandleDispatchTask(ctx context.Context, req mcp.CallToolReque
 	boardID := optionalString(req.GetString("board_id", ""))
 	goalID := optionalString(req.GetString("goal_id", ""))
 
+	// Auto-create "human" profile if dispatching to it for the first time
+	if profile == "human" {
+		existing, _ := h.db.GetProfile(project, "human")
+		if existing == nil {
+			_, _ = h.db.RegisterProfile(project, "human", "Human Operator",
+				"Tasks that require human action (API keys, approvals, purchases, manual config)",
+				"You are the human operator. Complete these tasks outside the relay.",
+				"[]", "[]", "[]")
+		}
+	}
+
+	// Auto-create a default "backlog" board if none specified and none exist
+	var autoBoard *models.Board
+	if boardID == nil {
+		boards, _ := h.db.ListBoards(project)
+		if len(boards) == 0 {
+			autoBoard, _ = h.db.CreateBoard(project, "Backlog", "backlog", "Auto-created default board", agent)
+			if autoBoard != nil {
+				boardID = &autoBoard.ID
+			}
+		} else {
+			// Use the first existing board as default
+			boardID = &boards[0].ID
+		}
+	}
+
 	task, err := h.db.DispatchTask(project, profile, agent, title, description, priority, parentTaskID, boardID, goalID)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("failed to dispatch task: %v", err)), nil
@@ -1027,6 +1100,12 @@ func (h *Handlers) HandleDispatchTask(ctx context.Context, req mcp.CallToolReque
 
 	h.events.Emit(MCPEvent{Type: "task", Action: "dispatch", Agent: agent, Project: project, Target: profile, Label: title})
 
+	resp := map[string]any{"task": task}
+	if autoBoard != nil {
+		resp["auto_board"] = autoBoard
+		resp["hint"] = fmt.Sprintf("Auto-created 'backlog' board (id: %s) since no boards existed.", autoBoard.ID)
+	}
+
 	// Dedup warning: check for similar active tasks on same profile
 	similar, _ := h.db.FindSimilarTasks(project, profile, title)
 	if len(similar) > 0 {
@@ -1038,22 +1117,17 @@ func (h *Handlers) HandleDispatchTask(ctx context.Context, req mcp.CallToolReque
 			}
 		}
 		if len(dupes) > 0 {
-			resp := map[string]any{
-				"task":    task,
-				"warning": fmt.Sprintf("Found %d similar active task(s) on profile '%s'", len(dupes), profile),
-				"similar": dupes,
-			}
-			data, _ := json.Marshal(resp)
-			return mcp.NewToolResultText(string(data)), nil
+			resp["warning"] = fmt.Sprintf("Found %d similar active task(s) on profile '%s'", len(dupes), profile)
+			resp["similar"] = dupes
 		}
 	}
 
-	return resultJSON(task)
+	return resultJSON(resp)
 }
 
 func (h *Handlers) HandleClaimTask(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	project := resolveProject(req)
-	agent := resolveAgent(req)
+	project := resolveProject(ctx, req)
+	agent := resolveAgent(ctx, req)
 	taskID := req.GetString("task_id", "")
 	if taskID == "" {
 		return mcp.NewToolResultError("task_id is required"), nil
@@ -1068,8 +1142,8 @@ func (h *Handlers) HandleClaimTask(ctx context.Context, req mcp.CallToolRequest)
 }
 
 func (h *Handlers) HandleStartTask(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	project := resolveProject(req)
-	agent := resolveAgent(req)
+	project := resolveProject(ctx, req)
+	agent := resolveAgent(ctx, req)
 	taskID := req.GetString("task_id", "")
 	if taskID == "" {
 		return mcp.NewToolResultError("task_id is required"), nil
@@ -1084,8 +1158,8 @@ func (h *Handlers) HandleStartTask(ctx context.Context, req mcp.CallToolRequest)
 }
 
 func (h *Handlers) HandleCompleteTask(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	project := resolveProject(req)
-	agent := resolveAgent(req)
+	project := resolveProject(ctx, req)
+	agent := resolveAgent(ctx, req)
 	taskID := req.GetString("task_id", "")
 	if taskID == "" {
 		return mcp.NewToolResultError("task_id is required"), nil
@@ -1130,8 +1204,8 @@ func (h *Handlers) HandleCompleteTask(ctx context.Context, req mcp.CallToolReque
 }
 
 func (h *Handlers) HandleBlockTask(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	project := resolveProject(req)
-	agent := resolveAgent(req)
+	project := resolveProject(ctx, req)
+	agent := resolveAgent(ctx, req)
 	taskID := req.GetString("task_id", "")
 	if taskID == "" {
 		return mcp.NewToolResultError("task_id is required"), nil
@@ -1165,8 +1239,8 @@ func (h *Handlers) HandleBlockTask(ctx context.Context, req mcp.CallToolRequest)
 }
 
 func (h *Handlers) HandleCancelTask(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	project := resolveProject(req)
-	agent := resolveAgent(req)
+	project := resolveProject(ctx, req)
+	agent := resolveAgent(ctx, req)
 	taskID := req.GetString("task_id", "")
 	if taskID == "" {
 		return mcp.NewToolResultError("task_id is required"), nil
@@ -1207,7 +1281,7 @@ func (h *Handlers) HandleCancelTask(ctx context.Context, req mcp.CallToolRequest
 }
 
 func (h *Handlers) HandleArchiveTasks(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	project := resolveProject(req)
+	project := resolveProject(ctx, req)
 	status := req.GetString("status", "")
 	boardID := req.GetString("board_id", "")
 
@@ -1227,7 +1301,7 @@ func (h *Handlers) HandleArchiveTasks(ctx context.Context, req mcp.CallToolReque
 }
 
 func (h *Handlers) HandleGetTask(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	project := resolveProject(req)
+	project := resolveProject(ctx, req)
 	taskID := req.GetString("task_id", "")
 	if taskID == "" {
 		return mcp.NewToolResultError("task_id is required"), nil
@@ -1269,7 +1343,7 @@ func (h *Handlers) HandleGetTask(ctx context.Context, req mcp.CallToolRequest) (
 }
 
 func (h *Handlers) HandleListTasks(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	project := resolveProject(req)
+	project := resolveProject(ctx, req)
 	status := req.GetString("status", "")
 	profile := req.GetString("profile", "")
 	priority := req.GetString("priority", "")
@@ -1294,8 +1368,8 @@ func (h *Handlers) HandleListTasks(ctx context.Context, req mcp.CallToolRequest)
 // --- File locks ---
 
 func (h *Handlers) HandleClaimFiles(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	project := resolveProject(req)
-	agent := resolveAgent(req)
+	project := resolveProject(ctx, req)
+	agent := resolveAgent(ctx, req)
 	filePaths := req.GetString("file_paths", "[]")
 	ttlSeconds := req.GetInt("ttl_seconds", 1800)
 
@@ -1313,8 +1387,8 @@ func (h *Handlers) HandleClaimFiles(ctx context.Context, req mcp.CallToolRequest
 }
 
 func (h *Handlers) HandleReleaseFiles(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	project := resolveProject(req)
-	agent := resolveAgent(req)
+	project := resolveProject(ctx, req)
+	agent := resolveAgent(ctx, req)
 	filePaths := req.GetString("file_paths", "[]")
 
 	if err := h.db.ReleaseFiles(project, agent, filePaths); err != nil {
@@ -1330,7 +1404,7 @@ func (h *Handlers) HandleReleaseFiles(ctx context.Context, req mcp.CallToolReque
 }
 
 func (h *Handlers) HandleListLocks(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	project := resolveProject(req)
+	project := resolveProject(ctx, req)
 
 	locks, err := h.db.ListFileLocks(project)
 	if err != nil {
@@ -1349,7 +1423,7 @@ func (h *Handlers) HandleListLocks(ctx context.Context, req mcp.CallToolRequest)
 // --- Agent lifecycle ---
 
 func (h *Handlers) HandleDeactivateAgent(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	project := resolveProject(req)
+	project := resolveProject(ctx, req)
 	name := strings.ToLower(req.GetString("name", ""))
 	if name == "" {
 		return mcp.NewToolResultError("name is required"), nil
@@ -1367,8 +1441,8 @@ func (h *Handlers) HandleDeactivateAgent(ctx context.Context, req mcp.CallToolRe
 }
 
 func (h *Handlers) HandleCreateBoard(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	project := resolveProject(req)
-	agent := resolveAgent(req)
+	project := resolveProject(ctx, req)
+	agent := resolveAgent(ctx, req)
 	name := req.GetString("name", "")
 	slug := req.GetString("slug", "")
 	if name == "" || slug == "" {
@@ -1384,7 +1458,7 @@ func (h *Handlers) HandleCreateBoard(ctx context.Context, req mcp.CallToolReques
 }
 
 func (h *Handlers) HandleListBoards(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	project := resolveProject(req)
+	project := resolveProject(ctx, req)
 	boards, err := h.db.ListBoards(project)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("failed to list boards: %v", err)), nil
@@ -1396,7 +1470,7 @@ func (h *Handlers) HandleListBoards(ctx context.Context, req mcp.CallToolRequest
 }
 
 func (h *Handlers) HandleArchiveBoard(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	project := resolveProject(req)
+	project := resolveProject(ctx, req)
 	boardID := req.GetString("board_id", "")
 	if boardID == "" {
 		return mcp.NewToolResultError("board_id is required"), nil
@@ -1409,7 +1483,7 @@ func (h *Handlers) HandleArchiveBoard(ctx context.Context, req mcp.CallToolReque
 }
 
 func (h *Handlers) HandleDeleteBoard(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	project := resolveProject(req)
+	project := resolveProject(ctx, req)
 	boardID := req.GetString("board_id", "")
 	if boardID == "" {
 		return mcp.NewToolResultError("board_id is required"), nil
@@ -1422,7 +1496,7 @@ func (h *Handlers) HandleDeleteBoard(ctx context.Context, req mcp.CallToolReques
 }
 
 func (h *Handlers) HandleDeleteAgent(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	project := resolveProject(req)
+	project := resolveProject(ctx, req)
 	name := strings.ToLower(req.GetString("name", ""))
 	if name == "" {
 		return mcp.NewToolResultError("name is required"), nil
@@ -1455,8 +1529,8 @@ func (h *Handlers) HandleDeleteProject(ctx context.Context, req mcp.CallToolRequ
 }
 
 func (h *Handlers) HandleSleepAgent(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	project := resolveProject(req)
-	agent := resolveAgent(req)
+	project := resolveProject(ctx, req)
+	agent := resolveAgent(ctx, req)
 
 	if err := h.db.SleepAgent(project, agent); err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("failed to sleep agent: %v", err)), nil
@@ -1472,7 +1546,7 @@ func (h *Handlers) HandleSleepAgent(ctx context.Context, req mcp.CallToolRequest
 // --- Find profiles by skill ---
 
 func (h *Handlers) HandleFindProfiles(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	project := resolveProject(req)
+	project := resolveProject(ctx, req)
 	tag := req.GetString("skill_tag", "")
 	if tag == "" {
 		return mcp.NewToolResultError("skill_tag is required"), nil
@@ -1496,8 +1570,8 @@ func (h *Handlers) HandleFindProfiles(ctx context.Context, req mcp.CallToolReque
 // --- Goals ---
 
 func (h *Handlers) HandleCreateGoal(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	project := resolveProject(req)
-	agent := resolveAgent(req)
+	project := resolveProject(ctx, req)
+	agent := resolveAgent(ctx, req)
 	goalType := req.GetString("type", "agent_goal")
 	title := req.GetString("title", "")
 	if title == "" {
@@ -1512,11 +1586,14 @@ func (h *Handlers) HandleCreateGoal(ctx context.Context, req mcp.CallToolRequest
 		return mcp.NewToolResultError(fmt.Sprintf("failed to create goal: %v", err)), nil
 	}
 	h.events.Emit(MCPEvent{Type: "goal", Action: "create", Agent: agent, Project: project, Label: title})
-	return resultJSON(goal)
+	return resultJSON(map[string]any{
+		"goal": goal,
+		"hint": "Goals are objectives, NOT tasks. To create actionable work items, use dispatch_task() and link them via goal_id. Goals track progress by counting linked tasks.",
+	})
 }
 
 func (h *Handlers) HandleListGoals(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	project := resolveProject(req)
+	project := resolveProject(ctx, req)
 	goalType := req.GetString("type", "")
 	status := req.GetString("status", "")
 	ownerAgent := optionalString(req.GetString("owner_agent", ""))
@@ -1554,7 +1631,7 @@ func (h *Handlers) HandleListGoals(ctx context.Context, req mcp.CallToolRequest)
 }
 
 func (h *Handlers) HandleGetGoal(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	project := resolveProject(req)
+	project := resolveProject(ctx, req)
 	goalID := req.GetString("goal_id", "")
 	if goalID == "" {
 		return mcp.NewToolResultError("goal_id is required"), nil
@@ -1571,7 +1648,7 @@ func (h *Handlers) HandleGetGoal(ctx context.Context, req mcp.CallToolRequest) (
 }
 
 func (h *Handlers) HandleUpdateGoal(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	project := resolveProject(req)
+	project := resolveProject(ctx, req)
 	goalID := req.GetString("goal_id", "")
 	if goalID == "" {
 		return mcp.NewToolResultError("goal_id is required"), nil
@@ -1588,7 +1665,7 @@ func (h *Handlers) HandleUpdateGoal(ctx context.Context, req mcp.CallToolRequest
 }
 
 func (h *Handlers) HandleGetGoalCascade(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	project := resolveProject(req)
+	project := resolveProject(ctx, req)
 
 	cascade, err := h.db.GetGoalCascade(project)
 	if err != nil {
@@ -1699,8 +1776,8 @@ func (h *Handlers) buildSessionContext(project, agentName string, profileSlug *s
 }
 
 func (h *Handlers) HandleGetSessionContext(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	project := resolveProject(req)
-	agent := resolveAgent(req)
+	project := resolveProject(ctx, req)
+	agent := resolveAgent(ctx, req)
 	profileSlugParam := optionalString(req.GetString("profile_slug", ""))
 
 	_ = h.db.TouchAgent(project, agent)
@@ -1723,8 +1800,8 @@ func (h *Handlers) HandleGetSessionContext(ctx context.Context, req mcp.CallTool
 // --- Soul RAG ---
 
 func (h *Handlers) HandleQueryContext(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	project := resolveProject(req)
-	agent := resolveAgent(req)
+	project := resolveProject(ctx, req)
+	agent := resolveAgent(ctx, req)
 	query := req.GetString("query", "")
 	if query == "" {
 		return mcp.NewToolResultError("query is required"), nil
@@ -1837,7 +1914,7 @@ func (h *Handlers) HandleListOrgs(ctx context.Context, req mcp.CallToolRequest) 
 }
 
 func (h *Handlers) HandleCreateTeam(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	project := resolveProject(req)
+	project := resolveProject(ctx, req)
 	name := req.GetString("name", "")
 	slug := req.GetString("slug", "")
 	description := req.GetString("description", "")
@@ -1864,7 +1941,7 @@ func (h *Handlers) HandleCreateTeam(ctx context.Context, req mcp.CallToolRequest
 }
 
 func (h *Handlers) HandleListTeams(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	project := resolveProject(req)
+	project := resolveProject(ctx, req)
 
 	teams, err := h.db.ListTeams(project)
 	if err != nil {
@@ -1891,7 +1968,7 @@ func (h *Handlers) HandleListTeams(ctx context.Context, req mcp.CallToolRequest)
 }
 
 func (h *Handlers) HandleAddTeamMember(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	project := resolveProject(req)
+	project := resolveProject(ctx, req)
 	teamSlug := req.GetString("team", "")
 	agentName := strings.ToLower(req.GetString("agent_name", ""))
 	role := req.GetString("role", "member")
@@ -1925,7 +2002,7 @@ func (h *Handlers) HandleAddTeamMember(ctx context.Context, req mcp.CallToolRequ
 }
 
 func (h *Handlers) HandleRemoveTeamMember(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	project := resolveProject(req)
+	project := resolveProject(ctx, req)
 	teamSlug := req.GetString("team", "")
 	agentName := strings.ToLower(req.GetString("agent_name", ""))
 
@@ -1950,7 +2027,7 @@ func (h *Handlers) HandleRemoveTeamMember(ctx context.Context, req mcp.CallToolR
 }
 
 func (h *Handlers) HandleGetTeamInbox(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	project := resolveProject(req)
+	project := resolveProject(ctx, req)
 	teamSlug := req.GetString("team", "")
 	limit := req.GetInt("limit", 50)
 
@@ -1979,8 +2056,8 @@ func (h *Handlers) HandleGetTeamInbox(ctx context.Context, req mcp.CallToolReque
 }
 
 func (h *Handlers) HandleAddNotifyChannel(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	project := resolveProject(req)
-	agent := resolveAgent(req)
+	project := resolveProject(ctx, req)
+	agent := resolveAgent(ctx, req)
 	target := strings.ToLower(req.GetString("target", ""))
 
 	if target == "" {
@@ -2001,7 +2078,7 @@ func (h *Handlers) HandleAddNotifyChannel(ctx context.Context, req mcp.CallToolR
 // --- Vault ---
 
 func (h *Handlers) HandleRegisterVault(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	project := resolveProject(req)
+	project := resolveProject(ctx, req)
 	path := req.GetString("path", "")
 	if path == "" {
 		return mcp.NewToolResultError("path is required"), nil
@@ -2030,17 +2107,30 @@ func (h *Handlers) HandleRegisterVault(ctx context.Context, req mcp.CallToolRequ
 	// Get stats
 	count, totalSize, _ := h.db.GetVaultStats(project)
 
-	return resultJSON(map[string]any{
-		"registered": true,
-		"project":    project,
-		"path":       path,
+	// Check if any profiles exist with empty vault_paths
+	profiles, _ := h.db.ListProfiles(project)
+	var emptyVaultProfiles []string
+	for _, p := range profiles {
+		if p.VaultPaths == "" || p.VaultPaths == "[]" {
+			emptyVaultProfiles = append(emptyVaultProfiles, p.Slug)
+		}
+	}
+
+	resp := map[string]any{
+		"registered":   true,
+		"project":      project,
+		"path":         path,
 		"docs_indexed": count,
 		"total_bytes":  totalSize,
-	})
+	}
+	if len(emptyVaultProfiles) > 0 {
+		resp["hint"] = fmt.Sprintf("Profiles with empty vault_paths: %v. Consider updating them with register_profile to auto-inject vault docs at boot.", emptyVaultProfiles)
+	}
+	return resultJSON(resp)
 }
 
 func (h *Handlers) HandleSearchVault(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	project := resolveProject(req)
+	project := resolveProject(ctx, req)
 	query := req.GetString("query", "")
 	if query == "" {
 		return mcp.NewToolResultError("query is required"), nil
@@ -2068,7 +2158,7 @@ func (h *Handlers) HandleSearchVault(ctx context.Context, req mcp.CallToolReques
 }
 
 func (h *Handlers) HandleGetVaultDoc(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	project := resolveProject(req)
+	project := resolveProject(ctx, req)
 	path := req.GetString("path", "")
 	if path == "" {
 		return mcp.NewToolResultError("path is required"), nil
@@ -2086,7 +2176,7 @@ func (h *Handlers) HandleGetVaultDoc(ctx context.Context, req mcp.CallToolReques
 }
 
 func (h *Handlers) HandleListVaultDocs(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	project := resolveProject(req)
+	project := resolveProject(ctx, req)
 	limit := req.GetInt("limit", 100)
 
 	var tags []string

--- a/internal/relay/handlers_test.go
+++ b/internal/relay/handlers_test.go
@@ -407,7 +407,8 @@ func TestTaskLifecycle(t *testing.T) {
 	dispatchRes, _ := h.HandleDispatchTask(ctx, call(map[string]any{
 		"project": "p1", "as": "bot-a", "profile": "dev", "title": "Fix bug", "description": "fix the thing",
 	}))
-	task := parseJSON(t, dispatchRes)
+	dispatchBody := parseJSON(t, dispatchRes)
+	task := dispatchBody["task"].(map[string]any)
 	taskID := task["id"].(string)
 	if task["status"] != "pending" {
 		t.Errorf("expected pending, got %v", task["status"])
@@ -448,7 +449,7 @@ func TestTaskBlock(t *testing.T) {
 	dispatchRes, _ := h.HandleDispatchTask(ctx, call(map[string]any{
 		"project": "p1", "as": "bot-a", "profile": "dev", "title": "task1",
 	}))
-	task := parseJSON(t, dispatchRes)
+	task := parseJSON(t, dispatchRes)["task"].(map[string]any)
 	taskID := task["id"].(string)
 
 	h.HandleClaimTask(ctx, call(map[string]any{"project": "p1", "as": "bot-a", "task_id": taskID}))
@@ -470,7 +471,7 @@ func TestTaskCancel(t *testing.T) {
 	dispatchRes, _ := h.HandleDispatchTask(ctx, call(map[string]any{
 		"project": "p1", "as": "bot-a", "profile": "dev", "title": "to cancel",
 	}))
-	task := parseJSON(t, dispatchRes)
+	task := parseJSON(t, dispatchRes)["task"].(map[string]any)
 	taskID := task["id"].(string)
 
 	cancelRes, _ := h.HandleCancelTask(ctx, call(map[string]any{
@@ -489,7 +490,7 @@ func TestGetTask(t *testing.T) {
 	dispatchRes, _ := h.HandleDispatchTask(ctx, call(map[string]any{
 		"project": "p1", "as": "bot-a", "profile": "dev", "title": "get me",
 	}))
-	task := parseJSON(t, dispatchRes)
+	task := parseJSON(t, dispatchRes)["task"].(map[string]any)
 	taskID := task["id"].(string)
 
 	getRes, _ := h.HandleGetTask(ctx, call(map[string]any{
@@ -539,7 +540,7 @@ func TestArchiveTasks(t *testing.T) {
 	dispatchRes, _ := h.HandleDispatchTask(ctx, call(map[string]any{
 		"project": "p1", "as": "bot-a", "profile": "dev", "title": "to archive",
 	}))
-	task := parseJSON(t, dispatchRes)
+	task := parseJSON(t, dispatchRes)["task"].(map[string]any)
 	taskID := task["id"].(string)
 
 	// Complete it first
@@ -811,7 +812,8 @@ func TestGoalLifecycle(t *testing.T) {
 	createRes, _ := h.HandleCreateGoal(ctx, call(map[string]any{
 		"project": "p1", "as": "bot-a", "title": "Ship v2", "type": "agent_goal",
 	}))
-	goal := parseJSON(t, createRes)
+	createBody := parseJSON(t, createRes)
+	goal := createBody["goal"].(map[string]any)
 	goalID := goal["id"].(string)
 	if goal["title"] != "Ship v2" {
 		t.Errorf("expected 'Ship v2', got %v", goal["title"])
@@ -969,7 +971,7 @@ func TestGoalCascade(t *testing.T) {
 	parentRes, _ := h.HandleCreateGoal(ctx, call(map[string]any{
 		"project": "p1", "as": "bot-a", "title": "Mission", "type": "mission",
 	}))
-	parent := parseJSON(t, parentRes)
+	parent := parseJSON(t, parentRes)["goal"].(map[string]any)
 	parentID := parent["id"].(string)
 
 	// Create child goal
@@ -1108,7 +1110,7 @@ func TestTaskSubtaskCompletion(t *testing.T) {
 	parentRes, _ := h.HandleDispatchTask(ctx, call(map[string]any{
 		"project": "p1", "as": "bot-a", "profile": "dev", "title": "Parent task",
 	}))
-	parent := parseJSON(t, parentRes)
+	parent := parseJSON(t, parentRes)["task"].(map[string]any)
 	parentID := parent["id"].(string)
 
 	// Dispatch subtask
@@ -1116,7 +1118,7 @@ func TestTaskSubtaskCompletion(t *testing.T) {
 		"project": "p1", "as": "bot-a", "profile": "dev", "title": "Subtask 1",
 		"parent_task_id": parentID,
 	}))
-	sub := parseJSON(t, subRes)
+	sub := parseJSON(t, subRes)["task"].(map[string]any)
 	subID := sub["id"].(string)
 
 	// Complete subtask flow
@@ -1143,15 +1145,17 @@ func TestTaskSubtaskCompletion(t *testing.T) {
 // --- Validation Tests (cross-cutting) ---
 
 func TestResolveProjectDefault(t *testing.T) {
+	ctx := context.Background()
 	req := call(map[string]any{})
-	if p := resolveProject(req); p != "default" {
+	if p := resolveProject(ctx, req); p != "default" {
 		t.Errorf("expected 'default', got %s", p)
 	}
 }
 
 func TestResolveAgentDefault(t *testing.T) {
+	ctx := context.Background()
 	req := call(map[string]any{})
-	if a := resolveAgent(req); a != "anonymous" {
+	if a := resolveAgent(ctx, req); a != "anonymous" {
 		t.Errorf("expected 'anonymous', got %s", a)
 	}
 }

--- a/internal/relay/tools.go
+++ b/internal/relay/tools.go
@@ -13,17 +13,17 @@ var projectParam = mcp.WithString("project", mcp.Description("Project namespace 
 func whoamiTool() mcp.Tool {
 	return mcp.NewTool(
 		"whoami",
-		mcp.WithDescription("Identify your Claude Code session. Generate a unique salt (e.g. 3 random words), pass it here. The relay greps ~/.claude/ transcripts for that salt to find your session ID. Use the returned session_id when calling register_agent."),
-		mcp.WithString("salt", mcp.Description("A unique string you just generated (e.g. 'purple-falcon-nebula'). It must appear in your conversation transcript."), mcp.Required()),
+		mcp.WithDescription("Identify your Claude Code session.\n\nHow it works: you generate a unique salt (3+ random words like 'purple-falcon-nebula'), include it in your message, then call this tool with that salt. The relay searches ~/.claude/ transcripts for the salt to find your session ID.\n\nNext step: use the returned session_id when calling register_agent."),
+		mcp.WithString("salt", mcp.Description("A unique string you just generated (e.g. 'purple-falcon-nebula'). Must be 3+ random words that appear in your conversation transcript. The relay uses this to match your session."), mcp.Required()),
 	)
 }
 
 func registerAgentTool() mcp.Tool {
 	return mcp.NewTool(
 		"register_agent",
-		mcp.WithDescription("Register an agent with the relay. Call this once per agent at startup to announce their presence. Returns session_context with profile, tasks, unread messages, and conversations."),
+		mcp.WithDescription("Register an agent with the relay. Call this once per agent at startup to announce their presence. Returns session_context with profile, tasks, unread messages, and conversations.\n\nIf is_executive=true, an 'admin' team ('leadership') is auto-created and the agent is added to it, enabling broadcast messages (send_message to='*')."),
 		projectParam,
-		mcp.WithString("name", mcp.Description("Unique agent name (e.g. 'backend', 'frontend')"), mcp.Required()),
+		mcp.WithString("name", mcp.Description("Unique agent name (e.g. 'lead', 'backend', 'frontend'). Re-registering the same name updates the agent. To rename, register the new name and call deactivate_agent on the old one."), mcp.Required()),
 		mcp.WithString("role", mcp.Description("Agent role description (e.g. 'FastAPI backend developer')")),
 		mcp.WithString("description", mcp.Description("What this agent is currently working on")),
 		mcp.WithString("reports_to", mcp.Description("Name of the agent this one reports to (for org hierarchy)")),
@@ -38,7 +38,7 @@ func registerAgentTool() mcp.Tool {
 func sendMessageTool() mcp.Tool {
 	return mcp.NewTool(
 		"send_message",
-		mcp.WithDescription("Send a message to another agent. Use '*' as recipient for broadcast. Set conversation_id to send to a conversation (all members will see it)."),
+		mcp.WithDescription("Send a message to another agent. Use '*' as recipient for broadcast (requires admin team membership — executives get this automatically). Use 'team:<slug>' to message a team. Set conversation_id to send to a conversation."),
 		asParam,
 		projectParam,
 		mcp.WithString("to", mcp.Description("Recipient agent name, or '*' for broadcast. Ignored when conversation_id is set."), mcp.Required()),
@@ -291,9 +291,9 @@ func registerProfileTool() mcp.Tool {
 		mcp.WithString("name", mcp.Description("Display name for the profile"), mcp.Required()),
 		mcp.WithString("role", mcp.Description("Role description")),
 		mcp.WithString("context_pack", mcp.Description("Markdown blob: soul, skills, working style")),
-		mcp.WithString("soul_keys", mcp.Description("JSON array of memory keys to load at boot")),
-		mcp.WithString("skills", mcp.Description("JSON array of skill objects, e.g. [{\"id\":\"supabase-admin\",\"name\":\"Supabase Administration\",\"tags\":[\"database\",\"auth\"]}]")),
-		mcp.WithString("vault_paths", mcp.Description("JSON array of vault doc path patterns to auto-inject at boot via get_session_context. Supports globs (e.g. [\"team/souls/{slug}.md\",\"guides/supabase-*.md\"]). {slug} is resolved to the profile slug.")),
+		mcp.WithString("soul_keys", mcp.Description("Memory keys to load at boot. Accepts JSON string '[\"key1\",\"key2\"]' or native array.")),
+		mcp.WithString("skills", mcp.Description("Skill objects. Accepts JSON string or native array. Format: [{\"id\":\"...\",\"name\":\"...\",\"tags\":[...]}]")),
+		mcp.WithString("vault_paths", mcp.Description("Vault doc path patterns to auto-inject at boot. Accepts JSON string or native array. Supports globs: [\"guides/*.md\"]. {slug} is resolved to the profile slug.")),
 	)
 }
 
@@ -328,7 +328,7 @@ func findProfilesTool() mcp.Tool {
 func dispatchTaskTool() mcp.Tool {
 	return mcp.NewTool(
 		"dispatch_task",
-		mcp.WithDescription("Dispatch a task to a profile archetype. Creates a task in 'pending' state for agents running that profile to claim."),
+		mcp.WithDescription("Dispatch a task to a profile archetype. Creates a task in 'pending' state for agents running that profile to claim.\n\nUse profile='human' for tasks that require human action (API keys, approvals, purchases). A 'human' profile is auto-created on first use.\n\nIf no board_id is provided, the task is auto-assigned to the first existing board (or a 'backlog' board is auto-created)."),
 		asParam,
 		projectParam,
 		mcp.WithString("profile", mcp.Description("Profile slug to dispatch to"), mcp.Required()),
@@ -486,7 +486,7 @@ func archiveTasksTool() mcp.Tool {
 func createGoalTool() mcp.Tool {
 	return mcp.NewTool(
 		"create_goal",
-		mcp.WithDescription("Create a goal in the cascade hierarchy. Goals flow: mission > project_goal > agent_goal > tasks. Link tasks to goals via goal_id in dispatch_task."),
+		mcp.WithDescription("Create a goal (objective) in the cascade hierarchy. Goals are NOT tasks — they don't appear in task boards. Goals flow: mission > project_goal > agent_goal. To create actionable work items, use dispatch_task() and link them to goals via goal_id. Goal progress is tracked by counting linked tasks."),
 		asParam,
 		projectParam,
 		mcp.WithString("type",
@@ -557,7 +557,7 @@ func getGoalCascadeTool() mcp.Tool {
 func registerVaultTool() mcp.Tool {
 	return mcp.NewTool(
 		"register_vault",
-		mcp.WithDescription("Register a vault (markdown docs folder) for a project. The relay indexes all .md files and watches for changes via fsnotify. One vault per project. Re-registering replaces the previous vault path."),
+		mcp.WithDescription("Register a vault (markdown docs folder) for a project. The relay indexes all .md files and watches for changes via fsnotify. One vault per project. Re-registering replaces the previous vault path.\n\nSuggested vault location: ~/.agent-relay/projects/<project-name>/vault/\n\nAfter registering, update your profiles' vault_paths to reference the new docs so they auto-inject at agent boot."),
 		projectParam,
 		mcp.WithString("path", mcp.Description("Absolute path to the vault directory (e.g. '/Users/me/my-org-docs')"), mcp.Required()),
 	)

--- a/main.go
+++ b/main.go
@@ -31,7 +31,7 @@ func main() {
 		case "serve":
 			startServer()
 			return
-		case "status", "agents", "inbox", "send", "thread", "stats", "conversations", "memories":
+		case "init", "status", "agents", "inbox", "send", "thread", "stats", "conversations", "memories":
 			cli.Run(os.Args[1:])
 			return
 		default:


### PR DESCRIPTION
## Summary

Fixes all 13 setup UX issues identified from a real user's first-time project setup session ([full report](https://github.com/Synergix-lab/WRAI.TH/issues/new)).

### Critical (#1–5)
- **`agent-relay init`** CLI command — generates/merges `.mcp.json` with correct config, supports `--global`, `--port`, `--host`
- **Auto admin team** — executive agents (`is_executive=true`) are auto-added to a `leadership` admin team, enabling broadcast without manual team setup
- **Goals ≠ Tasks clarity** — `create_goal` response now includes an explicit hint explaining that goals are objectives, not tasks
- **Human task assignment** — `dispatch_task(profile="human")` auto-creates a Human Operator profile + `GET /api/tasks/human` endpoint
- Improved tool descriptions for ToolSearch discoverability

### Moderate (#6–10)
- **Auto default board** — `dispatch_task` without `board_id` auto-creates a "backlog" board (or uses the first existing one)
- **`as`/`project` defaults from URL** — `resolveProject`/`resolveAgent` now fall back to HTTP context (`?project=X&agent=Y`)
- **Flexible JSON params** — `skills`, `soul_keys`, `vault_paths` in `register_profile` now accept both JSON strings and native arrays
- Agent rename guidance in `register_agent` description
- Vault location suggestion (`~/.agent-relay/projects/<name>/vault/`) in `register_vault` description

### Minor (#11–13)
- Salt mechanism explained in `whoami` tool description + README
- `register_vault` response hints to update profile `vault_paths`
- `send_message` description documents broadcast/admin requirement

### README
- Documents `agent-relay init` command
- Explains the salt/session linking mechanism in the Agents section

## Test plan
- [x] All 116 existing tests pass
- [x] `agent-relay init my-project` creates correct `.mcp.json`
- [x] `agent-relay init` merges with existing `.mcp.json` without clobbering
- [ ] Manual: register executive agent → verify auto admin team + broadcast works
- [ ] Manual: `dispatch_task(profile="human")` → verify profile auto-created
- [ ] Manual: `dispatch_task` without board → verify backlog board auto-created

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an init command to create or merge MCP configs (project or global) and guide next steps.
  * Session linking via a unique "salt" to associate MCP connections with sessions.
  * Executive agents auto-added to a leadership admin team with broadcast permissions.
  * Auto-create default backlog boards and a human profile when needed.
  * New endpoint to list human tasks with optional filtering.

* **Documentation**
  * Expanded setup and examples for MCP config placement, session linking, and executive/team behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->