### PR TITLE
feat: create_project onboarding tool

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,5 +4,5 @@ contact_links:
     url: https://discord.gg/QPq7qfbEk8
     about: Ask questions and discuss ideas with the community
   - name: Documentation
-    url: https://github.com/Synergix-lab/claude-agentic-relay#readme
+    url: https://github.com/Synergix-lab/WRAI.TH#readme
     about: Check the README for setup and usage guides

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,8 +6,8 @@ Thanks for your interest in contributing! Here's how to get started.
 
 ```bash
 # Clone
-git clone https://github.com/Synergix-lab/claude-agentic-relay.git
-cd claude-agentic-relay
+git clone https://github.com/Synergix-lab/WRAI.TH.git
+cd WRAI.TH
 
 # Build (requires Go 1.23+ and a C compiler for CGO/SQLite)
 CGO_ENABLED=1 go build -tags fts5 -o agent-relay .
@@ -37,7 +37,7 @@ install.ps1   Windows installer
 
 ### 1. Start with an issue
 
-Before writing code, open a [Feature Request](https://github.com/Synergix-lab/claude-agentic-relay/issues/new?template=feature.yml). Describe:
+Before writing code, open a [Feature Request](https://github.com/Synergix-lab/WRAI.TH/issues/new?template=feature.yml). Describe:
 - The problem or friction you're hitting
 - Your proposed solution
 - Which component is affected (MCP tools, UI, memory, tasks, etc.)
@@ -52,8 +52,8 @@ Wait for a maintainer to respond. Small fixes and docs can skip this step — ju
 
 ```bash
 # Fork on GitHub, then:
-git clone https://github.com/YOUR-USERNAME/claude-agentic-relay.git
-cd claude-agentic-relay
+git clone https://github.com/YOUR-USERNAME/WRAI.TH.git
+cd WRAI.TH
 git checkout -b feat/your-feature-name
 ```
 
@@ -97,7 +97,7 @@ A maintainer will review. We aim for fast turnaround. Once approved, the PR is s
 
 ## What to work on
 
-- Check [open issues](https://github.com/Synergix-lab/claude-agentic-relay/issues) — look for `good first issue` labels
+- Check [open issues](https://github.com/Synergix-lab/WRAI.TH/issues) — look for `good first issue` labels
 - Join the [Discord](https://discord.gg/QPq7qfbEk8) to discuss ideas
 - The MCP tools were designed by agents themselves — if you use the relay and hit friction, that's a valid feature request
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,12 @@ curl -fsSL https://raw.githubusercontent.com/Synergix-lab/WRAI.TH/main/install.s
 irm https://raw.githubusercontent.com/Synergix-lab/WRAI.TH/main/install.ps1 | iex
 ```
 
-The installer builds from source (Go + GCC), falls back to prebuilt, sets up auto-start, installs the `/relay` skill, and configures your projects.
+The installer checks dependencies, builds from source (Go + GCC) or falls back to prebuilt, sets up auto-start, installs the `/relay` skill, and configures your projects. Existing `.mcp.json` files are merged (never overwritten) with a `.bak` backup.
+
+**Update** to the latest version:
+```bash
+agent-relay update
+```
 
 **Or** generate the MCP config manually:
 
@@ -1124,13 +1129,13 @@ Each activity state shows as a live glow on the robot sprite. No network calls â
 
 Opinionated tooling built for a specific workflow. Moves fast.
 
-Something breaks? [Open an issue](https://github.com/Synergix-lab/claude-agentic-relay/issues). Want to contribute? [Open a PR](https://github.com/Synergix-lab/claude-agentic-relay/pulls).
+Something breaks? [Open an issue](https://github.com/Synergix-lab/WRAI.TH/issues). Want to contribute? [Open a PR](https://github.com/Synergix-lab/WRAI.TH/pulls).
 
 **Stack:** Go 1.22+, SQLite FTS5 (`mattn/go-sqlite3`), `mcp-go`, Vanilla JS, Canvas 2D
 
 ```bash
-git clone https://github.com/Synergix-lab/claude-agentic-relay.git
-cd claude-agentic-relay
+git clone https://github.com/Synergix-lab/WRAI.TH.git
+cd WRAI.TH
 CGO_ENABLED=1 go build -tags fts5 -o agent-relay .
 ./agent-relay serve
 ```

--- a/README.md
+++ b/README.md
@@ -335,107 +335,29 @@ export NODE_EXTRA_CA_CERTS=/path/to/your-ca.crt
 
 ### First project setup
 
-Once the relay is running, paste this prompt into Claude Code. Your agent will analyze the codebase, configure the relay, and set up the entire project autonomously:
-
-<details>
-<summary><b>Copy this bootstrap prompt</b></summary>
+One tool does everything. In Claude Code, call:
 
 ```
-You are setting up this project on the Agent Relay (wrai.th). The relay is running on localhost:8090 and the MCP tools are available.
-
-Do the following steps in order.
-
-## 0. Learn the relay
-
-The relay embeds its own documentation in the vault (project: _relay).
-Before configuring, search it to understand the available tools:
-
-search_vault({ query: "boot sequence" })
-search_vault({ query: "profiles vault_paths soul_keys" })
-search_vault({ query: "memory scopes layers" })
-search_vault({ query: "teams permissions" })
-search_vault({ query: "task dispatch boards" })
-
-Read the results carefully. This is how everything connects.
-
-## 1. Analyze the project
-
-Read the codebase to understand:
-- What this project does (purpose, domain)
-- Tech stack (languages, frameworks, databases, infra)
-- Project structure (monorepo? services? packages?)
-- Key conventions (naming, patterns, testing approach)
-
-## 2. Register the Obsidian vault (if one exists)
-
-Look for a docs/ or vault directory with .md files (Obsidian-style). Common locations:
-~/Documents/*-org/, ~/obsidian-vault/, ./docs/, ./wiki/
-
-If found, call register_vault({ path: "<absolute-path>" }) so the relay indexes it
-with FTS5 for all agents to search.
-
-## 3. Store project knowledge as memories
-
-Use set_memory to persist what you learned. Use scope "project" so all agents share it.
-
-Required memories (adapt keys to your project):
-- "stack" — languages, frameworks, versions
-- "architecture" — high-level structure
-- "conventions" — coding standards, commit style, linting
-- "infra" — hosting, CI, databases
-- "domain" — what the product does in one paragraph
-
-Optional but valuable:
-- "auth-pattern" — how auth works
-- "api-pattern" — REST/GraphQL/tRPC conventions
-- "db-schema-overview" — key tables and relationships
-- "deploy-process" — how to ship to prod
-- "env-vars" — required env vars (names only, never values)
-
-Use tags for discoverability: ["stack", "backend"], ["auth", "api"], etc.
-Use layer "constraints" for hard rules, "behavior" for defaults.
-
-## 4. Create the team structure
-
-Based on the project needs, call create_team for each functional group
-(e.g. backend, frontend, infra, marketing).
-
-Then call register_profile for each role the project needs. A profile is a
-reusable archetype — not a specific agent. Include:
-- slug: short identifier ("backend", "frontend", "devops")
-- name: display name ("Backend Developer")
-- role: what this role does
-- vault_paths: JSON array of doc patterns to auto-inject at boot
-  (e.g. ["team/souls/{slug}.md", "guides/*.md"])
-- soul_keys: JSON array of memory keys to preload at boot
-  (e.g. ["stack", "conventions", "api-pattern"])
-
-## 5. Set the mission
-
-Call create_goal with type "mission" — this is the top-level objective.
-Then break it into "project_goal" children if the project has clear workstreams.
-
-## 6. Register yourself
-
-Call register_agent with:
-- name: your role (e.g. "cto", "lead", "architect")
-- role: description of what you do
-- is_executive: true if you are the decision maker
-- project: this project name
-
-## 7. Report back
-
-Summarize what you configured:
-- Memories stored (list keys)
-- Teams created
-- Profiles registered
-- Goals set
-- Vault indexed (doc count if applicable)
+create_project({ name: "my-app", cwd: "/path/to/repo" })
 ```
 
-</details>
+This returns a full onboarding plan that Claude executes autonomously — like a management game tutorial. It will:
 
-The agent reads the relay's own embedded docs first, then maps your codebase, stores knowledge, creates teams, profiles, goals — everything needed for multi-agent work.
+1. Read the relay's embedded docs to learn the system
+2. Analyze your codebase (stack, architecture, conventions)
+3. Create an Obsidian vault with project documentation
+4. Store knowledge as shared memories
+5. Set up the org (teams, profiles, CTO agent)
+6. Define mission and project goals
+7. Output ready-to-paste `claude -w` commands to spawn worker agents
+
+Each spawned worker auto-onboards: loads context, researches the tech stack, updates memories, then pings the CTO that they're ready.
+
+**Interactive mode:** Add `interactive: true` to review and approve each phase before it executes — Claude will present its findings and proposed memories/teams/profiles for your approval before creating them:
+
+```
+create_project({ name: "my-app", cwd: "/path/to/repo", interactive: true })
+```
 
 <br>
 

--- a/docs/onboarding-prompt.md
+++ b/docs/onboarding-prompt.md
@@ -1,0 +1,291 @@
+# Colony Setup
+
+You are the **setup agent** for this project on the Agent Relay (wrai.th). The relay is running on localhost:8090 and MCP tools are available.
+
+Your job is to configure the entire relay infrastructure so multi-agent work can begin. Think of this like founding a colony in a management game — you place the buildings, assign roles, and set objectives before the workers arrive.
+
+Execute every phase below **in order**. Do NOT skip phases. Adapt everything to what you discover about the codebase.
+
+---
+
+## Phase 1 — Learn the relay
+
+The relay embeds its own documentation. Read it first.
+
+```
+search_vault({ query: "boot sequence", project: "_relay" })
+search_vault({ query: "profiles vault_paths soul_keys", project: "_relay" })
+search_vault({ query: "memory scopes layers", project: "_relay" })
+search_vault({ query: "teams permissions", project: "_relay" })
+search_vault({ query: "task dispatch boards", project: "_relay" })
+```
+
+Read the results. This is how the system works.
+
+---
+
+## Phase 2 — Analyze the codebase
+
+Thoroughly explore the project to understand:
+
+- **Domain**: What does this project do? Who is it for?
+- **Tech stack**: Languages, frameworks, databases, package manager, runtime
+- **Architecture**: Monorepo? Microservices? Key modules and data flow
+- **Conventions**: Naming, code style, commit format, testing approach
+- **Infrastructure**: Hosting, CI/CD, env vars, deployment
+- **Auth**: How authentication works (if applicable)
+- **API**: REST/GraphQL/tRPC patterns (if applicable)
+
+Read at minimum: main entry point, package manifest (package.json / go.mod / Cargo.toml / etc.), config files, README, and 3-5 core source files.
+
+Decide on a **project name** (lowercase, no spaces — e.g. `my-app`). Use the repo directory name if nothing better fits.
+
+Write down your findings — you store them as memories in Phase 4.
+
+---
+
+## Phase 3 — Create the vault
+
+Create an Obsidian-compatible vault **next to** the repo (not inside it):
+
+```bash
+mkdir -p ../obsidian/<project-name>
+```
+
+Write markdown docs based on your analysis:
+
+| File | Content |
+|------|---------|
+| `architecture.md` | System overview, module map, data flow |
+| `stack.md` | Full tech stack with versions |
+| `conventions.md` | Code style, naming, commit format, testing |
+| `api.md` | Endpoints, protocols, session lifecycle (if applicable) |
+| `env.md` | Required env vars (names only, never values) |
+
+Then register it with the relay:
+
+```
+register_vault({ path: "<absolute-path-to-vault>", project: "<project-name>" })
+```
+
+---
+
+## Phase 4 — Store project knowledge
+
+Use `set_memory` to persist what you learned. All memories use `scope: "project"`.
+
+**Required memories:**
+
+| Key | Layer | Tags | Content |
+|-----|-------|------|---------|
+| `stack` | constraints | `["stack", "tech"]` | Languages, frameworks, versions |
+| `architecture` | constraints | `["architecture", "system"]` | High-level structure, modules, data flow |
+| `conventions` | behavior | `["conventions", "style"]` | Naming, style, commits, testing |
+| `domain` | constraints | `["domain", "product"]` | What the product does, target users |
+| `infra` | behavior | `["infra", "hosting"]` | Hosting, CI, databases, deployment |
+
+**Optional** (add if relevant): `auth-pattern`, `api-pattern`, `db-schema-overview`, `env-vars`
+
+Use `confidence: "observed"` since you read the codebase directly.
+
+---
+
+## Phase 5 — Create the org
+
+### 5a. Teams
+
+Create teams based on what you discovered in Phase 2. The leadership team is always required:
+
+```
+create_team({ name: "Leadership", slug: "leadership", type: "admin", description: "Executive team — broadcast and cross-team coordination", project: "<project-name>" })
+```
+
+Then create **only the teams that match the actual codebase**. Examples:
+- Go API → `backend` team only
+- Next.js fullstack → `backend` + `frontend`
+- Monorepo with infra → `backend` + `frontend` + `infra`
+- Python ML project → `backend` + `data`
+- CLI tool → `core` team only
+
+Do NOT create teams for parts of the stack that don't exist.
+
+### 5b. Profiles
+
+Register role archetypes based on the teams you created. **Derive profiles from your Phase 2 analysis, not from a template.**
+
+The **CTO** profile is always required:
+```
+register_profile({
+  slug: "cto",
+  name: "CTO",
+  role: "Technical leader. Owns the backlog, sets priorities, coordinates all teams, reviews architecture.",
+  context_pack: "You are the CTO of <project-name>. You make architecture decisions, manage the task board, and coordinate between tech leads. You have broadcast permissions.",
+  skills: "[{\"id\":\"architecture\",\"name\":\"System Architecture\",\"tags\":[\"architecture\",\"design\"]},{\"id\":\"management\",\"name\":\"Technical Management\",\"tags\":[\"management\",\"coordination\"]}]",
+  soul_keys: "[\"stack\",\"architecture\",\"domain\",\"conventions\",\"infra\"]",
+  vault_paths: "[\"architecture.md\",\"stack.md\"]",
+  project: "<project-name>"
+})
+```
+
+For each additional team, create **one tech lead profile**. Use the actual stack in skills/context_pack:
+```
+register_profile({
+  slug: "<team-slug>-lead",
+  name: "<Team> Tech Lead",
+  role: "<what this role does, based on the actual codebase>",
+  context_pack: "You are the <role> for <project-name>. <specific responsibilities based on what you found>",
+  skills: "<JSON array — use ACTUAL languages/frameworks/tools from Phase 2>",
+  soul_keys: "<JSON array — pick relevant memory keys>",
+  vault_paths: "<JSON array — pick relevant vault docs>",
+  project: "<project-name>"
+})
+```
+
+**Rules:**
+- Only create profiles for teams that exist
+- Skills must reference the real tech stack (e.g. "Go 1.22", "SQLite", "React 19"), never generic placeholders
+- A Go-only project gets 0 frontend profiles. A fullstack project gets both. Use judgment.
+
+### 5c. Register yourself as CTO
+
+```
+whoami({ salt: "<generate-3-random-words>" })
+```
+
+Then:
+
+```
+register_agent({
+  name: "cto",
+  project: "<project-name>",
+  role: "Technical leader and architect. Owns the backlog, coordinates teams.",
+  is_executive: true,
+  profile_slug: "cto",
+  session_id: "<session_id from whoami>"
+})
+```
+
+### 5d. Team memberships
+
+Add the CTO to **every functional team you created** as admin:
+
+```
+add_team_member({ team: "<team-slug>", agent_name: "cto", role: "admin", project: "<project-name>" })
+```
+
+Repeat for each team from 5a (not leadership — the CTO is already there via auto-admin).
+
+---
+
+## Phase 6 — Set goals & board
+
+### 6a. Mission
+
+```
+create_goal({
+  type: "mission",
+  title: "<one-line mission for the project>",
+  description: "<what success looks like>",
+  project: "<project-name>"
+})
+```
+
+### 6b. Project goals
+
+Break the mission into 2-4 concrete workstreams:
+
+```
+create_goal({
+  type: "project_goal",
+  title: "<workstream>",
+  parent_goal_id: "<mission ID>",
+  project: "<project-name>"
+})
+```
+
+### 6c. Backlog board
+
+```
+create_board({ name: "Backlog", slug: "backlog", description: "Main task board", project: "<project-name>" })
+```
+
+---
+
+## Phase 7 — Verify & spawn workers
+
+### 7a. Verify everything
+
+Run checks:
+
+```
+list_agents({ project: "<project-name>" })
+list_teams({ project: "<project-name>" })
+list_profiles({ project: "<project-name>" })
+list_goals({ project: "<project-name>" })
+list_boards({ project: "<project-name>" })
+```
+
+### 7b. Spawn worker commands
+
+For **each non-CTO profile** you created, output a ready-to-paste `claude` command.
+
+Use this exact template for each worker (replace `<SLUG>`, `<ROLE>`, `<NAME>`):
+
+```bash
+claude -w --dangerously-skip-permissions \
+  "You are the <ROLE> of <project-name>. Boot sequence:
+  1. register_agent({ name: '<SLUG>', project: '<project-name>', profile_slug: '<SLUG>', reports_to: 'cto' })
+  2. get_session_context() — read everything: profile, vault docs, memories, tasks
+  3. Research the technologies and patterns mentioned in your context using web search. Get up to speed.
+  4. set_memory() to persist your research findings in the relay (scope: 'agent', key: 'onboarding-research')
+  5. send_message({ to: 'cto', type: 'notification', subject: 'Ready', content: '<NAME> onboarded and ready for tasks.' })
+  6. Check your inbox and the board. Start working."
+```
+
+Output one command per profile. The user copies each into a separate terminal.
+
+### 7c. Report
+
+Summarize to the user:
+
+- **Project**: name, planet type
+- **Vault**: path, docs indexed
+- **Memories**: keys stored
+- **Teams**: list with types
+- **Profiles**: list with roles
+- **Goals**: mission + project goals
+- **Board**: ready for tasks
+- **CTO**: registered, executive, broadcast enabled
+- **Spawn commands**: listed above, ready to paste
+
+---
+
+## Phase 8 — Plan the first two sprints
+
+Now that the colony is configured, plan the work.
+
+Based on the project goals, codebase analysis, and current state of the project:
+
+### Sprint 1 (immediate priorities)
+Create 3-6 tasks for the most impactful work to do right now:
+
+```
+dispatch_task({
+  title: "<task title>",
+  description: "<what to do and acceptance criteria>",
+  profile: "<profile-slug>",
+  priority: "<p0-p3>",
+  goal_id: "<parent goal ID>",
+  board_id: "<backlog board ID>",
+  project: "<project-name>"
+})
+```
+
+### Sprint 2 (next up)
+Create 3-6 more tasks for the next wave of work. These can depend on Sprint 1 outputs.
+
+Assign profiles based on the skills needed. Distribute work across teams — don't overload one profile.
+
+---
+
+**The colony is ready.** Paste the spawn commands from Phase 7 in separate terminals to deploy your workers. They will pick up tasks from the board automatically.

--- a/install.ps1
+++ b/install.ps1
@@ -14,7 +14,7 @@
 .PARAMETER Uninstall
     Remove relay, service, and skill
 .EXAMPLE
-    irm https://raw.githubusercontent.com/Synergix-lab/claude-agentic-relay/main/install.ps1 | iex
+    irm https://raw.githubusercontent.com/Synergix-lab/WRAI.TH/main/install.ps1 | iex
     .\install.ps1 -Port 9000 -SkipProjects
     .\install.ps1 -Uninstall
 #>
@@ -27,7 +27,7 @@ param(
 
 $ErrorActionPreference = "Stop"
 
-$Repo = "Synergix-lab/claude-agentic-relay"
+$Repo = "Synergix-lab/WRAI.TH"
 $BinaryName = "agent-relay.exe"
 $TaskName = "AgentRelay"
 $InstallDir = Join-Path $env:LOCALAPPDATA "AgentRelay"

--- a/install.sh
+++ b/install.sh
@@ -3,11 +3,11 @@ set -euo pipefail
 
 # Claude Agentic Relay — Cross-platform installer (macOS + Linux)
 # Usage:
-#   curl -fsSL https://raw.githubusercontent.com/Synergix-lab/claude-agentic-relay/main/install.sh | bash
+#   curl -fsSL https://raw.githubusercontent.com/Synergix-lab/WRAI.TH/main/install.sh | bash
 #   curl -fsSL ... | bash -s -- --port 9000 --skip-projects --no-service
 #   ./install.sh --uninstall
 
-REPO="Synergix-lab/claude-agentic-relay"
+REPO="Synergix-lab/WRAI.TH"
 BINARY_NAME="agent-relay"
 SERVICE_LABEL="com.agent-relay"
 DEFAULT_PORT=8090
@@ -32,7 +32,7 @@ info()    { echo "${BLUE}${BOLD}::${RESET} $*"; }
 success() { echo "${GREEN}${BOLD}✓${RESET} $*"; }
 warn()    { echo "${YELLOW}${BOLD}!${RESET} $*"; }
 error()   { echo "${RED}${BOLD}✗${RESET} $*" >&2; }
-step()    { echo; echo "${MAGENTA}${BOLD}[$1/6]${RESET} ${BOLD}$2${RESET}"; }
+step()    { echo; echo "${MAGENTA}${BOLD}[$1/7]${RESET} ${BOLD}$2${RESET}"; }
 
 die() { error "$@"; exit 1; }
 
@@ -255,6 +255,76 @@ create_ar_symlink() {
   fi
 
   ln -sf "$bin_path" "$ar_path" 2>/dev/null || true
+}
+
+# ── Step 0: Dependency check ────────────────────────────────────────────────
+
+check_dependencies() {
+  step 0 "Checking dependencies"
+
+  local missing_required=()
+  local missing_optional=()
+
+  # Required: curl (for downloads + health check)
+  if ! command -v curl &>/dev/null; then
+    missing_required+=("curl")
+  else
+    success "curl"
+  fi
+
+  # Build deps (optional — fallback to prebuilt if missing)
+  if command -v go &>/dev/null; then
+    local go_version
+    go_version=$(go version 2>/dev/null | grep -oE 'go[0-9]+\.[0-9]+' | head -1)
+    success "go (${go_version})"
+  else
+    missing_optional+=("go (will download prebuilt binary instead of building from source)")
+  fi
+
+  if command -v cc &>/dev/null || command -v gcc &>/dev/null || command -v clang &>/dev/null; then
+    success "C compiler"
+  elif command -v go &>/dev/null; then
+    missing_optional+=("C compiler (cc/gcc/clang — needed for CGO/SQLite, will download prebuilt)")
+  fi
+
+  # git (for clone if building from source)
+  if command -v git &>/dev/null; then
+    success "git"
+  else
+    missing_optional+=("git (needed for build from source)")
+  fi
+
+  # jq — needed for hook scripts
+  if command -v jq &>/dev/null; then
+    success "jq"
+  else
+    missing_optional+=("jq (activity hooks use jq to parse JSON — hooks will be installed but won't work without it)")
+  fi
+
+  # python3 or jq — for config merging
+  if command -v python3 &>/dev/null; then
+    success "python3 (for config merging)"
+  elif command -v jq &>/dev/null; then
+    success "jq (for config merging)"
+  else
+    missing_optional+=("python3 or jq (for merging .mcp.json — will create new files but can't merge with existing)")
+  fi
+
+  # Report
+  if [[ ${#missing_required[@]} -gt 0 ]]; then
+    echo
+    for dep in "${missing_required[@]}"; do
+      error "Missing required: ${BOLD}${dep}${RESET}"
+    done
+    die "Install the missing dependencies and retry."
+  fi
+
+  if [[ ${#missing_optional[@]} -gt 0 ]]; then
+    echo
+    for dep in "${missing_optional[@]}"; do
+      warn "Optional: ${dep}"
+    done
+  fi
 }
 
 # ── Step 1: Install binary ──────────────────────────────────────────────────
@@ -503,6 +573,9 @@ install_hooks() {
 
   # Create PostToolUse hook script
   cat > "$hooks_dir/ingest-post-tool.sh" <<'HOOK_EOF'
+#!/usr/bin/env bash
+command -v jq &>/dev/null || exit 0
+
 EVENTS_DIR="$HOME/.pixel-office/events"
 mkdir -p "$EVENTS_DIR"
 
@@ -523,6 +596,9 @@ HOOK_EOF
 
   # Create Stop hook script
   cat > "$hooks_dir/ingest-stop.sh" <<'HOOK_EOF'
+#!/usr/bin/env bash
+command -v jq &>/dev/null || exit 0
+
 EVENTS_DIR="$HOME/.pixel-office/events"
 mkdir -p "$EVENTS_DIR"
 
@@ -540,7 +616,10 @@ exit 0
 HOOK_EOF
   chmod +x "$hooks_dir/ingest-stop.sh"
 
-  # Merge hooks into Claude Code settings.json
+  # Merge hooks into Claude Code settings.json (backup first)
+  if [[ -f "$settings_file" ]]; then
+    cp "$settings_file" "${settings_file}.bak" 2>/dev/null || true
+  fi
   if command -v python3 &>/dev/null; then
     python3 -c "
 import json, os
@@ -825,6 +904,9 @@ configure_project() {
       return 0
     fi
 
+    # Backup before merging
+    cp "$mcp_path" "${mcp_path}.bak" 2>/dev/null || true
+
     # Merge into existing .mcp.json using python3 or jq
     if command -v python3 &>/dev/null; then
       python3 -c "
@@ -968,6 +1050,7 @@ main() {
   fi
 
   banner
+  check_dependencies
 
   # Check port conflict
   if lsof -i ":${PORT}" &>/dev/null 2>&1 || ss -tlnp 2>/dev/null | grep -q ":${PORT} "; then

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -38,6 +38,8 @@ func Run(args []string) {
 		runConversations(rest)
 	case "memories":
 		runMemories(rest)
+	case "update":
+		runUpdate(rest)
 	default:
 		fmt.Fprintf(os.Stderr, "unknown command: %s\n\n", cmd)
 		printUsage()
@@ -103,6 +105,7 @@ commands:
   thread <id>                  show full message thread
   conversations [-p project] <agent>  list conversations for agent
   stats [-p project]           global statistics
+  update [--force]             check for updates and install latest
   memories [-p project]        list persistent memories
     -s <query>                 search memories (FTS5)
     -a <agent>                 filter by agent

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -1,0 +1,298 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+type githubRelease struct {
+	TagName string `json:"tag_name"`
+}
+
+const (
+	repo         = "Synergix-lab/WRAI.TH"
+	releaseAPI   = "https://api.github.com/repos/" + repo + "/releases/latest"
+	serviceLabel = "com.agent-relay"
+	binaryName   = "agent-relay"
+)
+
+func runUpdate(args []string) {
+	force := false
+	for _, a := range args {
+		if a == "--force" || a == "-f" {
+			force = true
+		}
+		if a == "--help" || a == "-h" {
+			fmt.Print(`usage: agent-relay update [--force]
+
+Check for updates and install the latest version.
+
+flags:
+  -f, --force   Update even if already on latest version
+  -h, --help    Show this help
+`)
+			return
+		}
+	}
+
+	// 1. Get current version
+	currentVersion := getCurrentVersion()
+	fmt.Printf("  current: %s\n", currentVersion)
+
+	// 2. Get latest version from GitHub
+	fmt.Print("  checking latest release... ")
+	latestVersion, err := getLatestVersion()
+	if err != nil {
+		fmt.Printf("\nerror: could not check latest version: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Printf("%s\n", latestVersion)
+
+	// 3. Compare
+	if !force && currentVersion == latestVersion {
+		fmt.Println("\n  already up to date")
+		return
+	}
+
+	if !force {
+		fmt.Printf("\n  update available: %s → %s\n", currentVersion, latestVersion)
+	}
+
+	// 4. Find the binary path
+	binPath, err := findBinaryPath()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Printf("  binary: %s\n", binPath)
+
+	// 5. Try build from source, fallback to download
+	if tryBuildUpdate(binPath, latestVersion) {
+		fmt.Println("  built from source")
+	} else if tryDownloadUpdate(binPath, latestVersion) {
+		fmt.Println("  downloaded prebuilt binary")
+	} else {
+		fmt.Fprintln(os.Stderr, "error: update failed — could not build or download")
+		os.Exit(1)
+	}
+
+	// 6. Restart service
+	restartService()
+
+	// 7. Verify
+	fmt.Print("\n  verifying... ")
+	newVersion := getCurrentVersion()
+	fmt.Printf("%s\n", newVersion)
+	fmt.Println("\n  update complete")
+}
+
+func getCurrentVersion() string {
+	out, err := exec.Command(binaryName, "--version").CombinedOutput()
+	if err != nil {
+		return "unknown"
+	}
+	v := strings.TrimSpace(string(out))
+	// Output is "agent-relay v0.3.1" → extract version
+	if parts := strings.Fields(v); len(parts) >= 2 {
+		return parts[len(parts)-1]
+	}
+	return v
+}
+
+func getLatestVersion() (string, error) {
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Get(releaseAPI)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		return "", fmt.Errorf("GitHub API returned %d", resp.StatusCode)
+	}
+
+	var release githubRelease
+	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
+		return "", err
+	}
+	if release.TagName == "" {
+		return "", fmt.Errorf("no releases found")
+	}
+	return release.TagName, nil
+}
+
+func findBinaryPath() (string, error) {
+	// Check if we're in the source repo
+	if _, err := os.Stat("go.mod"); err == nil {
+		if data, err := os.ReadFile("go.mod"); err == nil && strings.Contains(string(data), "agent-relay") {
+			// We're in the source repo — build in place
+			exe, _ := os.Executable()
+			if exe != "" {
+				return exe, nil
+			}
+		}
+	}
+
+	// Find installed binary
+	path, err := exec.LookPath(binaryName)
+	if err == nil {
+		// Resolve symlinks
+		resolved, err := filepath.EvalSymlinks(path)
+		if err == nil {
+			return resolved, nil
+		}
+		return path, nil
+	}
+
+	// Common paths
+	for _, p := range []string{
+		"/usr/local/bin/" + binaryName,
+		filepath.Join(os.Getenv("HOME"), ".local", "bin", binaryName),
+	} {
+		if _, err := os.Stat(p); err == nil {
+			return p, nil
+		}
+	}
+
+	return "", fmt.Errorf("cannot find %s binary", binaryName)
+}
+
+func tryBuildUpdate(binPath, version string) bool {
+	// Need go and a C compiler
+	if _, err := exec.LookPath("go"); err != nil {
+		return false
+	}
+	hasCc := false
+	for _, cc := range []string{"cc", "gcc", "clang"} {
+		if _, err := exec.LookPath(cc); err == nil {
+			hasCc = true
+			break
+		}
+	}
+	if !hasCc {
+		return false
+	}
+
+	// Clone to temp dir
+	tmpDir, err := os.MkdirTemp("", "agent-relay-update-*")
+	if err != nil {
+		return false
+	}
+	defer os.RemoveAll(tmpDir)
+
+	fmt.Print("  cloning... ")
+	cmd := exec.Command("git", "clone", "--depth", "1", "--branch", version,
+		"https://github.com/"+repo+".git", filepath.Join(tmpDir, "src"))
+	if err := cmd.Run(); err != nil {
+		// Try without --branch (tag might not exist for dev)
+		cmd = exec.Command("git", "clone", "--depth", "1",
+			"https://github.com/"+repo+".git", filepath.Join(tmpDir, "src"))
+		if err := cmd.Run(); err != nil {
+			fmt.Println("failed")
+			return false
+		}
+	}
+	fmt.Println("ok")
+
+	fmt.Print("  building... ")
+	buildCmd := exec.Command("go", "build", "-tags", "fts5",
+		"-ldflags", fmt.Sprintf("-s -w -X main.Version=%s", version),
+		"-o", filepath.Join(tmpDir, binaryName), ".")
+	buildCmd.Dir = filepath.Join(tmpDir, "src")
+	buildCmd.Env = append(os.Environ(), "CGO_ENABLED=1")
+	if err := buildCmd.Run(); err != nil {
+		fmt.Println("failed")
+		return false
+	}
+	fmt.Println("ok")
+
+	// Replace binary
+	return installBinary(filepath.Join(tmpDir, binaryName), binPath)
+}
+
+func tryDownloadUpdate(binPath, version string) bool {
+	osName := runtime.GOOS
+	arch := runtime.GOARCH
+
+	archiveName := fmt.Sprintf("agent-relay-%s-%s.tar.gz", osName, arch)
+	url := fmt.Sprintf("https://github.com/%s/releases/download/%s/%s", repo, version, archiveName)
+
+	tmpDir, err := os.MkdirTemp("", "agent-relay-dl-*")
+	if err != nil {
+		return false
+	}
+	defer os.RemoveAll(tmpDir)
+
+	fmt.Print("  downloading... ")
+	archivePath := filepath.Join(tmpDir, archiveName)
+	cmd := exec.Command("curl", "-fsSL", "-o", archivePath, url)
+	if err := cmd.Run(); err != nil {
+		fmt.Println("failed")
+		return false
+	}
+	fmt.Println("ok")
+
+	// Extract
+	cmd = exec.Command("tar", "-xzf", archivePath, "-C", tmpDir)
+	if err := cmd.Run(); err != nil {
+		return false
+	}
+
+	return installBinary(filepath.Join(tmpDir, binaryName), binPath)
+}
+
+func installBinary(src, dst string) bool {
+	// Try direct copy first
+	cmd := exec.Command("install", "-m", "755", src, dst)
+	if err := cmd.Run(); err != nil {
+		// Try with sudo
+		cmd = exec.Command("sudo", "install", "-m", "755", src, dst)
+		if err := cmd.Run(); err != nil {
+			fmt.Fprintf(os.Stderr, "  error: could not install binary to %s: %v\n", dst, err)
+			return false
+		}
+	}
+	return true
+}
+
+func restartService() {
+	fmt.Print("  restarting service... ")
+
+	switch runtime.GOOS {
+	case "darwin":
+		plist := filepath.Join(os.Getenv("HOME"), "Library", "LaunchAgents", serviceLabel+".plist")
+		if _, err := os.Stat(plist); err != nil {
+			fmt.Println("no service found (manual start)")
+			return
+		}
+		uid := os.Getuid()
+		// Stop
+		exec.Command("launchctl", "bootout", fmt.Sprintf("gui/%d", uid), plist).Run()
+		// Small delay for clean shutdown
+		time.Sleep(500 * time.Millisecond)
+		// Start
+		if err := exec.Command("launchctl", "bootstrap", fmt.Sprintf("gui/%d", uid), plist).Run(); err != nil {
+			exec.Command("launchctl", "load", plist).Run()
+		}
+		fmt.Println("ok (launchd)")
+
+	case "linux":
+		// Check if systemd service exists
+		if err := exec.Command("systemctl", "--user", "is-enabled", binaryName).Run(); err != nil {
+			fmt.Println("no service found (manual start)")
+			return
+		}
+		exec.Command("systemctl", "--user", "restart", binaryName).Run()
+		fmt.Println("ok (systemd)")
+
+	default:
+		fmt.Println("unsupported platform — restart manually")
+	}
+}

--- a/internal/relay/api.go
+++ b/internal/relay/api.go
@@ -1061,6 +1061,8 @@ func (r *Relay) apiTransitionTask(w http.ResponseWriter, req *http.Request, path
 		task, err = r.DB.CompleteTask(taskID, body.Agent, body.Project, body.Result)
 	case "blocked":
 		task, err = r.DB.BlockTask(taskID, body.Agent, body.Project, body.Reason)
+	case "cancelled":
+		task, err = r.DB.CancelTask(taskID, body.Agent, body.Project, body.Reason)
 	default:
 		http.Error(w, `{"error":"invalid status"}`, http.StatusBadRequest)
 		return

--- a/internal/relay/handlers.go
+++ b/internal/relay/handlers.go
@@ -1359,6 +1359,17 @@ func (h *Handlers) HandleListTasks(ctx context.Context, req mcp.CallToolRequest)
 		tasks = []models.Task{}
 	}
 
+	// Truncate descriptions to save tokens in list view (use get_task for full details)
+	for i := range tasks {
+		if len(tasks[i].Description) > 200 {
+			tasks[i].Description = tasks[i].Description[:200] + "…"
+		}
+		if tasks[i].Result != nil && len(*tasks[i].Result) > 200 {
+			truncated := (*tasks[i].Result)[:200] + "…"
+			tasks[i].Result = &truncated
+		}
+	}
+
 	return resultJSON(map[string]any{
 		"count": len(tasks),
 		"tasks": tasks,

--- a/internal/relay/handlers.go
+++ b/internal/relay/handlers.go
@@ -1512,6 +1512,269 @@ func (h *Handlers) HandleDeleteAgent(ctx context.Context, req mcp.CallToolReques
 	})
 }
 
+func (h *Handlers) HandleCreateProject(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	name := strings.ToLower(req.GetString("name", ""))
+	if name == "" {
+		return mcp.NewToolResultError("name is required"), nil
+	}
+	description := req.GetString("description", "")
+	cwd := req.GetString("cwd", "")
+
+	// Create project in DB
+	h.db.EnsureProject(name)
+
+	// Check if already configured
+	agents, _ := h.db.ListAgents(name)
+	if len(agents) > 0 {
+		return resultJSON(map[string]any{
+			"project": name,
+			"status":  "already_configured",
+			"agents":  len(agents),
+			"hint":    "Project already has agents. Use register_agent to join, or delete_project to start over.",
+		})
+	}
+
+	interactive := false
+	if v, ok := req.GetArguments()["interactive"]; ok {
+		if b, ok := v.(bool); ok {
+			interactive = b
+		}
+	}
+
+	// Return the onboarding mega-prompt as plain text
+	prompt := buildOnboardingPrompt(name, description, cwd, interactive)
+	return mcp.NewToolResultText(prompt), nil
+}
+
+func buildOnboardingPrompt(name, description, cwd string, interactive bool) string {
+	var b strings.Builder
+
+	b.WriteString("# Colony Setup — " + name + "\n\n")
+	b.WriteString("You are the **setup agent** for project `" + name + "` on the Agent Relay. ")
+	b.WriteString("Your job is to configure the entire relay infrastructure so multi-agent work can begin. ")
+	b.WriteString("Think of this like founding a colony in a management game — you place the buildings, assign roles, and set objectives before the workers arrive.\n\n")
+
+	if interactive {
+		b.WriteString("**MODE: INTERACTIVE** — At the end of each phase, present your findings and proposed actions to the user. Wait for their approval before executing. Do NOT create anything without confirmation.\n\n")
+	} else {
+		b.WriteString("**Before starting**, ask the user:\n\n")
+		b.WriteString("> **Auto mode** or **Interactive mode**?\n")
+		b.WriteString("> - **Auto**: I execute everything autonomously. You get a summary at the end.\n")
+		b.WriteString("> - **Interactive**: I present my findings at each phase and wait for your approval before creating anything.\n\n")
+		b.WriteString("If the user picks interactive, add CHECKPOINT pauses after Phase 2 (present analysis), before Phase 3 (approve vault docs), before Phase 5 (approve teams/profiles), and before Phase 8 (approve sprint tasks). At each checkpoint, present what you plan to do and wait for confirmation.\n\n")
+		b.WriteString("If the user picks auto (or says nothing after 10 seconds), execute everything in order without stopping.\n\n")
+	}
+
+	if description != "" {
+		b.WriteString("**Project description:** " + description + "\n\n")
+	}
+	if cwd != "" {
+		b.WriteString("**Project root:** `" + cwd + "`\n\n")
+	}
+
+	b.WriteString("---\n\n")
+
+	// Phase 1 — Learn the relay
+	b.WriteString("## Phase 1 — Learn the relay\n\n")
+	b.WriteString("The relay embeds its own documentation. Read it first:\n\n")
+	b.WriteString("```\n")
+	b.WriteString("search_vault({ query: \"boot sequence\", project: \"_relay\" })\n")
+	b.WriteString("search_vault({ query: \"profiles vault_paths soul_keys\", project: \"_relay\" })\n")
+	b.WriteString("search_vault({ query: \"memory scopes layers\", project: \"_relay\" })\n")
+	b.WriteString("search_vault({ query: \"teams permissions\", project: \"_relay\" })\n")
+	b.WriteString("search_vault({ query: \"task dispatch boards\", project: \"_relay\" })\n")
+	b.WriteString("```\n\n")
+	b.WriteString("Read the results carefully. This is how the system works.\n\n")
+
+	b.WriteString("---\n\n")
+
+	// Phase 2 — Analyze the codebase
+	b.WriteString("## Phase 2 — Analyze the codebase\n\n")
+	b.WriteString("Thoroughly explore the project to understand:\n\n")
+	b.WriteString("- **Domain**: What does this project do? Who is it for?\n")
+	b.WriteString("- **Tech stack**: Languages, frameworks, databases, package manager, runtime\n")
+	b.WriteString("- **Architecture**: Monorepo? Microservices? Key modules and data flow\n")
+	b.WriteString("- **Conventions**: Naming, code style, commit format, testing approach\n")
+	b.WriteString("- **Infrastructure**: Hosting, CI/CD, env vars, deployment\n")
+	b.WriteString("- **Auth**: How authentication works (if applicable)\n")
+	b.WriteString("- **API**: REST/GraphQL/tRPC patterns (if applicable)\n\n")
+	b.WriteString("Read at minimum: main entry point, package manifest (package.json / go.mod / Cargo.toml / etc.), config files, README, and 3-5 core source files.\n\n")
+	b.WriteString("Write down your findings — you store them as memories in Phase 4.\n\n")
+
+	if interactive {
+		b.WriteString("**CHECKPOINT:** Present your findings to the user:\n")
+		b.WriteString("- Domain summary\n- Tech stack with versions\n- Architecture overview\n- Key conventions\n")
+		b.WriteString("- Proposed project name (if different from `" + name + "`)\n")
+		b.WriteString("- List of teams you plan to create\n- List of profiles you plan to register\n\n")
+		b.WriteString("Wait for approval before continuing.\n\n")
+	}
+
+	b.WriteString("---\n\n")
+
+	// Phase 3 — Create the vault
+	b.WriteString("## Phase 3 — Create the vault\n\n")
+	b.WriteString("Create an Obsidian-compatible vault **next to** the repo (not inside it):\n\n")
+	b.WriteString("```bash\nmkdir -p ../obsidian/" + name + "\n```\n\n")
+	b.WriteString("Write markdown docs based on your analysis:\n\n")
+	b.WriteString("| File | Content |\n|------|---------|\n")
+	b.WriteString("| `architecture.md` | System overview, module map, data flow |\n")
+	b.WriteString("| `stack.md` | Full tech stack with versions |\n")
+	b.WriteString("| `conventions.md` | Code style, naming, commit format, testing |\n")
+	b.WriteString("| `api.md` | Endpoints, protocols, session lifecycle (if applicable) |\n")
+	b.WriteString("| `env.md` | Required env vars (names only, never values) |\n\n")
+	b.WriteString("Then register it with the relay:\n\n")
+	b.WriteString("```\nregister_vault({ path: \"<absolute-path-to-vault>\", project: \"" + name + "\" })\n```\n\n")
+
+	b.WriteString("---\n\n")
+
+	// Phase 4 — Store project knowledge
+	b.WriteString("## Phase 4 — Store project knowledge\n\n")
+	b.WriteString("Use `set_memory` to persist what you learned. All memories use `scope: \"project\"`, `project: \"" + name + "\"`.\n\n")
+	b.WriteString("**Required memories:**\n\n")
+	b.WriteString("| Key | Layer | Tags | Content |\n|-----|-------|------|---------|\n")
+	b.WriteString("| `stack` | constraints | `[\"stack\", \"tech\"]` | Languages, frameworks, versions |\n")
+	b.WriteString("| `architecture` | constraints | `[\"architecture\", \"system\"]` | High-level structure, modules, data flow |\n")
+	b.WriteString("| `conventions` | behavior | `[\"conventions\", \"style\"]` | Naming, style, commits, testing |\n")
+	b.WriteString("| `domain` | constraints | `[\"domain\", \"product\"]` | What the product does, target users |\n")
+	b.WriteString("| `infra` | behavior | `[\"infra\", \"hosting\"]` | Hosting, CI, databases, deployment |\n\n")
+	b.WriteString("**Optional** (add if relevant): `auth-pattern`, `api-pattern`, `db-schema-overview`, `env-vars`\n\n")
+	b.WriteString("Use `confidence: \"observed\"` since you read the codebase directly.\n\n")
+
+	b.WriteString("---\n\n")
+
+	if interactive {
+		b.WriteString("**CHECKPOINT:** Show the user the vault docs and memories you plan to create. Wait for approval.\n\n")
+		b.WriteString("---\n\n")
+	}
+
+	// Phase 5 — Create the org
+	b.WriteString("## Phase 5 — Create the org\n\n")
+	b.WriteString("### 5a. Teams\n\n")
+	b.WriteString("Create teams based on what you discovered in Phase 2. The leadership team is always required:\n\n")
+	b.WriteString("```\n")
+	b.WriteString("create_team({ name: \"Leadership\", slug: \"leadership\", type: \"admin\", description: \"Executive team — broadcast and cross-team coordination\", project: \"" + name + "\" })\n")
+	b.WriteString("```\n\n")
+	b.WriteString("Then create **only the teams that match the actual codebase**. Examples:\n")
+	b.WriteString("- Go API → `backend` team only\n")
+	b.WriteString("- Next.js fullstack → `backend` + `frontend`\n")
+	b.WriteString("- Monorepo with infra → `backend` + `frontend` + `infra`\n")
+	b.WriteString("- Python ML project → `backend` + `data`\n")
+	b.WriteString("- CLI tool → `core` team only\n\n")
+	b.WriteString("Do NOT create teams for parts of the stack that don't exist.\n\n")
+
+	b.WriteString("### 5b. Profiles\n\n")
+	b.WriteString("Register role archetypes based on the teams you created. **Derive profiles from your Phase 2 analysis, not from a template.**\n\n")
+	b.WriteString("The **CTO** profile is always required:\n```\n")
+	b.WriteString("register_profile({\n")
+	b.WriteString("  slug: \"cto\",\n  name: \"CTO\",\n")
+	b.WriteString("  role: \"Technical leader. Owns the backlog, sets priorities, coordinates all teams, reviews architecture.\",\n")
+	b.WriteString("  context_pack: \"You are the CTO of " + name + ". You make architecture decisions, manage the task board, and coordinate between tech leads. You have broadcast permissions.\",\n")
+	b.WriteString("  skills: \"[{\\\"id\\\":\\\"architecture\\\",\\\"name\\\":\\\"System Architecture\\\",\\\"tags\\\":[\\\"architecture\\\",\\\"design\\\"]},{\\\"id\\\":\\\"management\\\",\\\"name\\\":\\\"Technical Management\\\",\\\"tags\\\":[\\\"management\\\",\\\"coordination\\\"]}]\",\n")
+	b.WriteString("  soul_keys: \"[\\\"stack\\\",\\\"architecture\\\",\\\"domain\\\",\\\"conventions\\\",\\\"infra\\\"]\",\n")
+	b.WriteString("  vault_paths: \"[\\\"architecture.md\\\",\\\"stack.md\\\"]\",\n")
+	b.WriteString("  project: \"" + name + "\"\n})\n```\n\n")
+	b.WriteString("For each additional team, create **one tech lead profile**. Use the actual stack in skills/context_pack:\n```\n")
+	b.WriteString("register_profile({\n")
+	b.WriteString("  slug: \"<team-slug>-lead\",\n  name: \"<Team> Tech Lead\",\n")
+	b.WriteString("  role: \"<what this role does, based on the actual codebase>\",\n")
+	b.WriteString("  context_pack: \"You are the <role> for " + name + ". <specific responsibilities based on what you found>\",\n")
+	b.WriteString("  skills: \"<JSON array — use ACTUAL languages/frameworks/tools from Phase 2>\",\n")
+	b.WriteString("  soul_keys: \"<JSON array — pick relevant memory keys>\",\n")
+	b.WriteString("  vault_paths: \"<JSON array — pick relevant vault docs>\",\n")
+	b.WriteString("  project: \"" + name + "\"\n})\n```\n\n")
+	b.WriteString("**Rules:**\n")
+	b.WriteString("- Only create profiles for teams that exist\n")
+	b.WriteString("- Skills must reference the real tech stack (e.g. \"Go 1.22\", \"SQLite\", \"React 19\"), never generic placeholders\n")
+	b.WriteString("- A Go-only project gets 0 frontend profiles. A fullstack project gets both. Use judgment.\n\n")
+
+	b.WriteString("### 5c. Register yourself as CTO\n\n")
+	b.WriteString("```\nwhoami({ salt: \"<generate-3-random-words>\" })\n```\n\n")
+	b.WriteString("Then:\n```\n")
+	b.WriteString("register_agent({\n")
+	b.WriteString("  name: \"cto\",\n  project: \"" + name + "\",\n")
+	b.WriteString("  role: \"Technical leader and architect. Owns the backlog, coordinates teams.\",\n")
+	b.WriteString("  is_executive: true,\n  profile_slug: \"cto\",\n")
+	b.WriteString("  session_id: \"<session_id from whoami>\"\n})\n```\n\n")
+
+	b.WriteString("### 5d. Team memberships\n\n")
+	b.WriteString("Add the CTO to **every functional team you created** as admin:\n\n")
+	b.WriteString("```\nadd_team_member({ team: \"<team-slug>\", agent_name: \"cto\", role: \"admin\", project: \"" + name + "\" })\n```\n\n")
+	b.WriteString("Repeat for each team from 5a (not leadership — the CTO is already there via auto-admin).\n\n")
+
+	b.WriteString("---\n\n")
+
+	// Phase 6 — Set goals & board
+	b.WriteString("## Phase 6 — Set goals & board\n\n")
+	b.WriteString("### 6a. Mission\n\n")
+	b.WriteString("```\ncreate_goal({\n  type: \"mission\",\n  title: \"<one-line mission for the project>\",\n  description: \"<what success looks like>\",\n  project: \"" + name + "\"\n})\n```\n\n")
+	b.WriteString("### 6b. Project goals\n\n")
+	b.WriteString("Break the mission into 2-4 concrete workstreams:\n\n")
+	b.WriteString("```\ncreate_goal({\n  type: \"project_goal\",\n  title: \"<workstream>\",\n  parent_goal_id: \"<mission ID>\",\n  project: \"" + name + "\"\n})\n```\n\n")
+	b.WriteString("### 6c. Backlog board\n\n")
+	b.WriteString("```\ncreate_board({ name: \"Backlog\", slug: \"backlog\", description: \"Main task board\", project: \"" + name + "\" })\n```\n\n")
+
+	b.WriteString("---\n\n")
+
+	// Phase 7 — Verify & spawn
+	b.WriteString("## Phase 7 — Verify & spawn workers\n\n")
+	b.WriteString("### 7a. Verify everything\n\n")
+	b.WriteString("Run checks:\n\n")
+	b.WriteString("```\n")
+	b.WriteString("list_agents({ project: \"" + name + "\" })\n")
+	b.WriteString("list_teams({ project: \"" + name + "\" })\n")
+	b.WriteString("list_profiles({ project: \"" + name + "\" })\n")
+	b.WriteString("list_goals({ project: \"" + name + "\" })\n")
+	b.WriteString("list_boards({ project: \"" + name + "\" })\n")
+	b.WriteString("```\n\n")
+
+	b.WriteString("### 7b. Spawn worker commands\n\n")
+	b.WriteString("For **each non-CTO profile** you created, output a ready-to-paste `claude` command.\n\n")
+	b.WriteString("Use this exact template for each worker (replace `<SLUG>`, `<ROLE>`, `<NAME>`):\n\n")
+	b.WriteString("```bash\nclaude -w --dangerously-skip-permissions \\\n")
+	b.WriteString("  \"You are the <ROLE> of " + name + ". Boot sequence:\n")
+	b.WriteString("  1. register_agent({ name: '<SLUG>', project: '" + name + "', profile_slug: '<SLUG>', reports_to: 'cto' })\n")
+	b.WriteString("  2. get_session_context() — read everything: profile, vault docs, memories, tasks\n")
+	b.WriteString("  3. Research the technologies and patterns mentioned in your context using web search. Get up to speed.\n")
+	b.WriteString("  4. set_memory() to persist your research findings in the relay (scope: 'agent', key: 'onboarding-research')\n")
+	b.WriteString("  5. send_message({ to: 'cto', type: 'notification', subject: 'Ready', content: '<NAME> onboarded and ready for tasks.' })\n")
+	b.WriteString("  6. Check your inbox and the board. Start working.\"\n")
+	b.WriteString("```\n\n")
+	b.WriteString("Output one command per profile. The user copies each into a separate terminal.\n\n")
+
+	b.WriteString("### 7c. Report\n\n")
+	b.WriteString("Summarize to the user:\n\n")
+	b.WriteString("- **Project**: name, planet type\n")
+	b.WriteString("- **Vault**: path, docs indexed\n")
+	b.WriteString("- **Memories**: keys stored\n")
+	b.WriteString("- **Teams**: list with types\n")
+	b.WriteString("- **Profiles**: list with roles\n")
+	b.WriteString("- **Goals**: mission + project goals\n")
+	b.WriteString("- **Board**: ready for tasks\n")
+	b.WriteString("- **CTO**: registered, executive, broadcast enabled\n")
+	b.WriteString("- **Spawn commands**: listed above, ready to paste\n\n")
+	b.WriteString("---\n\n")
+
+	// Phase 8 — Sprint planning
+	b.WriteString("## Phase 8 — Plan the first two sprints\n\n")
+	b.WriteString("Now that the colony is configured, plan the work.\n\n")
+	b.WriteString("Based on the project goals, codebase analysis, and current state of the project:\n\n")
+	b.WriteString("### Sprint 1 (immediate priorities)\n")
+	b.WriteString("Create 3-6 tasks for the most impactful work to do right now:\n\n")
+	b.WriteString("```\ndispatch_task({\n  title: \"<task title>\",\n  description: \"<what to do and acceptance criteria>\",\n  profile: \"<profile-slug>\",\n  priority: \"<p0-p3>\",\n  goal_id: \"<parent goal ID>\",\n  board_id: \"<backlog board ID>\",\n  project: \"" + name + "\"\n})\n```\n\n")
+	b.WriteString("### Sprint 2 (next up)\n")
+	b.WriteString("Create 3-6 more tasks for the next wave of work. These can depend on Sprint 1 outputs.\n\n")
+	b.WriteString("Assign profiles based on the skills needed. Distribute work across teams — don't overload one profile.\n\n")
+
+	if interactive {
+		b.WriteString("**CHECKPOINT:** Present the sprint plan to the user before dispatching tasks. Wait for approval.\n\n")
+	}
+
+	b.WriteString("---\n\n")
+	b.WriteString("**The colony is ready.** Paste the spawn commands from Phase 7 in separate terminals to deploy your workers. They will pick up tasks from the board automatically.\n")
+
+	return b.String()
+}
+
 func (h *Handlers) HandleDeleteProject(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	project := req.GetString("project", "")
 	if project == "" {

--- a/internal/relay/handlers_test.go
+++ b/internal/relay/handlers_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"agent-relay/internal/db"
@@ -1166,5 +1167,62 @@ func TestOptionalString(t *testing.T) {
 	}
 	if *optionalString("hello") != "hello" {
 		t.Error("expected 'hello'")
+	}
+}
+
+func TestCreateProject(t *testing.T) {
+	h := testHandlers(t)
+
+	// New project returns onboarding prompt
+	res, err := h.HandleCreateProject(ctx, call(map[string]any{"name": "test-app"}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.IsError {
+		t.Fatal("expected success")
+	}
+	text := res.Content[0].(mcp.TextContent).Text
+	if !strings.Contains(text, "Colony Setup") {
+		t.Error("expected onboarding prompt with 'Colony Setup'")
+	}
+	if !strings.Contains(text, "test-app") {
+		t.Error("expected project name in prompt")
+	}
+	if !strings.Contains(text, "Phase 7") {
+		t.Error("expected all 7 phases")
+	}
+	if !strings.Contains(text, "--dangerously-skip-permissions") {
+		t.Error("expected spawn commands with skip-permissions flag")
+	}
+	if !strings.Contains(text, "send_message") {
+		t.Error("expected worker ping-ready instruction")
+	}
+
+	// Second call with agents already registered should return already_configured
+	h.db.EnsureProject("test-app")
+	_, _ = h.HandleRegisterAgent(ctx, call(map[string]any{
+		"name": "cto", "project": "test-app", "role": "lead",
+	}))
+	res2, err := h.HandleCreateProject(ctx, call(map[string]any{"name": "test-app"}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	data := parseJSON(t, res2)
+	if data["status"] != "already_configured" {
+		t.Errorf("expected already_configured, got %v", data["status"])
+	}
+}
+
+func TestCreateProjectValidation(t *testing.T) {
+	h := testHandlers(t)
+
+	// Missing name
+	res, err := h.HandleCreateProject(ctx, call(map[string]any{}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	msg := expectError(t, res)
+	if !strings.Contains(msg, "name is required") {
+		t.Errorf("expected 'name is required', got: %s", msg)
 	}
 }

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -105,6 +105,7 @@ func New(database *db.DB, ingester *ingest.Ingester, vaultWatcher *vault.Watcher
 		server.ServerTool{Tool: deleteAgentTool(), Handler: handlers.HandleDeleteAgent},
 		server.ServerTool{Tool: sleepAgentTool(), Handler: handlers.HandleSleepAgent},
 		// Project lifecycle
+		server.ServerTool{Tool: createProjectTool(), Handler: handlers.HandleCreateProject},
 		server.ServerTool{Tool: deleteProjectTool(), Handler: handlers.HandleDeleteProject},
 		// Soul RAG
 		server.ServerTool{Tool: queryContextTool(), Handler: handlers.HandleQueryContext},

--- a/internal/relay/tools.go
+++ b/internal/relay/tools.go
@@ -663,6 +663,19 @@ func deleteProjectTool() mcp.Tool {
 	)
 }
 
+// --- Project onboarding ---
+
+func createProjectTool() mcp.Tool {
+	return mcp.NewTool(
+		"create_project",
+		mcp.WithDescription("Set up a new project on the relay. This is the FIRST tool to call. It creates the project, analyzes your codebase, and returns a full onboarding plan that you must execute step by step — like a management game tutorial. You will become the setup agent: analyze the code, store knowledge, create the org (CTO + tech leads), set up the vault, profiles, goals, and board. Everything needed for multi-agent work."),
+		mcp.WithString("name", mcp.Description("Project name (lowercase, no spaces — e.g. 'my-app', 'acme-api')"), mcp.Required()),
+		mcp.WithString("description", mcp.Description("One-line description of the project")),
+		mcp.WithString("cwd", mcp.Description("Absolute path to the project root directory (for vault setup)")),
+		mcp.WithBoolean("interactive", mcp.Description("Interactive mode: present findings and wait for user approval at each phase instead of executing automatically. Default: false (auto mode).")),
+	)
+}
+
 // --- Soul RAG ---
 
 func queryContextTool() mcp.Tool {

--- a/internal/web/static/index.html
+++ b/internal/web/static/index.html
@@ -42,6 +42,11 @@
         <button id="tab-memories" class="header-tab">Memories <span id="memory-count" class="memory-badge">0</span></button>
         <button id="tab-tasks" class="header-tab">Tasks <span id="task-count" class="memory-badge">0</span></button>
       </div>
+      <div class="zoom-controls">
+        <button id="zoom-out" class="zoom-btn" title="Zoom out [-]">−</button>
+        <span id="zoom-level" class="zoom-level">100%</span>
+        <button id="zoom-in" class="zoom-btn" title="Zoom in [+]">+</button>
+      </div>
       <button id="help-btn" class="help-btn" title="Help [?]">?</button>
     </div>
   </header>

--- a/internal/web/static/js/api-client.js
+++ b/internal/web/static/js/api-client.js
@@ -376,6 +376,10 @@ export class APIClient {
     }
   }
 
+  async cancelTask(taskId, project, agent) {
+    return this.transitionTask(taskId, "cancelled", project, agent);
+  }
+
   async fetchAllTeams() {
     try {
       const res = await fetch("/api/teams/all");

--- a/internal/web/static/js/kanban.js
+++ b/internal/web/static/js/kanban.js
@@ -880,7 +880,7 @@ export class KanbanBoard {
   }
 
   _renderCard(task) {
-    const isFounder = task.profile_slug === 'founder' || task.profile_slug === 'user';
+    const isFounder = task.profile_slug === 'founder' || task.profile_slug === 'user' || task.profile_slug === 'human';
     const card = document.createElement('div');
     card.className = 'kb-card' + (task.priority === 'P0' ? ' kb-p0' : '') + (isFounder ? ' kb-founder' : '');
     card.draggable = true;

--- a/internal/web/static/js/main.js
+++ b/internal/web/static/js/main.js
@@ -154,7 +154,7 @@ function layoutAgents() {
 
     // If no hierarchy, simple horizontal layout centered
     if (roots.length === agentCount || agentCount <= 2) {
-      const AGENT_SPACING = Math.min(120, engine.width / (agentCount + 1));
+      const AGENT_SPACING = Math.min(180, engine.width / (agentCount + 1));
       const startX = cx - (agentCount - 1) * AGENT_SPACING / 2;
       for (let i = 0; i < keys.length; i++) {
         const av = agentViews.get(keys[i]);
@@ -191,8 +191,8 @@ function layoutAgents() {
         maxTreeDepth = Math.max(maxTreeDepth, (subtreeDepth.get(r) || 0) + 1);
       }
 
-      const V_SPACING = Math.min(100, (engine.height * 0.7) / Math.max(maxTreeDepth, 1));
-      const H_SPACING = Math.min(120, (engine.width * 0.85) / Math.max(totalRootWidth, 1));
+      const V_SPACING = Math.min(140, (engine.height * 0.7) / Math.max(maxTreeDepth, 1));
+      const H_SPACING = Math.min(180, (engine.width * 0.85) / Math.max(totalRootWidth, 1));
 
       function placeColonySubtree(key, left, top) {
         const w = subtreeWidth.get(key) || 1;
@@ -1012,10 +1012,11 @@ function showUserTaskCard(task) {
     <button class="uq-dismiss"><img src="/img/ui/icons/small/x.png" width="10" height="10" /></button>
     <span class="uq-project" data-project="${escapeHtml(taskProject)}">${escapeHtml(taskProject)}</span>
     <div class="uq-subject">${escapeHtml(task.title || "(untitled)")}</div>
-    ${task.description ? `<div class="uq-content">${escapeHtml(task.description)}</div>` : ""}
+    ${task.description ? `<div class="uq-content uq-content--md">${renderMarkdown(task.description)}</div>` : ""}
     <div class="uq-actions">
       <button class="uq-respond-btn" data-action="accept">Accept</button>
       <button class="uq-respond-btn uq-respond-btn--done" data-action="done">Complete</button>
+      <button class="uq-respond-btn uq-respond-btn--cancel" data-action="cancel">Cancel</button>
       <button class="uq-respond-btn uq-respond-btn--nav" data-action="kanban"><img src="/img/ui/icons/small/arrow_right.png" width="8" height="8" class="uq-btn-icon" />Kanban</button>
     </div>
   `;
@@ -1063,6 +1064,21 @@ function showUserTaskCard(task) {
     } else {
       btn.disabled = false;
       btn.textContent = "Done";
+    }
+  });
+
+  card.querySelector('[data-action="cancel"]').addEventListener("click", async (e) => {
+    const btn = e.target;
+    btn.disabled = true;
+    btn.textContent = "...";
+    const result = await client.cancelTask(task.id, task.project || "default", "user");
+    if (result) {
+      card.style.opacity = "0";
+      card.style.transition = "opacity 0.3s ease";
+      setTimeout(() => card.remove(), 300);
+    } else {
+      btn.disabled = false;
+      btn.textContent = "Cancel";
     }
   });
 
@@ -1703,6 +1719,16 @@ function escapeHtml(str) {
     .replace(/"/g, "&quot;");
 }
 
+/** Render markdown to HTML using marked (loaded via CDN). Falls back to escaped text. */
+function renderMarkdown(text) {
+  if (typeof marked !== "undefined") {
+    try {
+      return marked.parse(text, { gfm: true, breaks: true });
+    } catch (_) { /* fall through */ }
+  }
+  return escapeHtml(text).replace(/\n/g, "<br>");
+}
+
 // --- Memory panel ---
 
 const tabMessages = document.getElementById("tab-messages");
@@ -1909,7 +1935,7 @@ function onNewTasks(tasks) {
 
   // Notify user of tasks dispatched to them
   for (const task of tasks) {
-    const isForUser = (task.profile_slug === "user" || task.profile_slug === "founder")
+    const isForUser = (task.profile_slug === "user" || task.profile_slug === "founder" || task.profile_slug === "human")
       && task.status === "pending" && !shownUserMsgs.has("task:" + task.id);
     if (isForUser) {
       shownUserMsgs.add("task:" + task.id);
@@ -2069,7 +2095,7 @@ function renderTasks() {
   const priority = tasksPriorityFilter.value;
 
   let filtered = getViewFilteredTasks();
-  if (showMyTasksOnly) filtered = filtered.filter(t => (t.profile_slug === "user" || t.profile_slug === "founder") && t.status !== "done");
+  if (showMyTasksOnly) filtered = filtered.filter(t => (t.profile_slug === "user" || t.profile_slug === "founder" || t.profile_slug === "human") && t.status !== "done");
   if (status) filtered = filtered.filter(t => t.status === status);
   if (priority) filtered = filtered.filter(t => t.priority === priority);
 
@@ -2116,7 +2142,7 @@ function renderTasks() {
     }
 
     const el = document.createElement("div");
-    const isMine = task.profile_slug === "user" || task.profile_slug === "founder";
+    const isMine = task.profile_slug === "user" || task.profile_slug === "founder" || task.profile_slug === "human";
     el.className = "task-item" + (isMine ? " task-mine" : "");
     el.dataset.taskId = task.id;
 
@@ -2172,22 +2198,40 @@ setInterval(() => {
   if (activeTab === "tasks") loadTasks();
 }, 5000);
 
-// --- Font scale ---
+// --- Font scale (+/- zoom) ---
 
-const savedScale = localStorage.getItem("font-scale") || "1.2";
-document.body.style.setProperty("--scale", savedScale);
+const ZOOM_STEPS = [0.8, 0.9, 1.0, 1.1, 1.2, 1.4, 1.6, 1.8, 2.0];
+let currentZoomIdx = ZOOM_STEPS.indexOf(parseFloat(localStorage.getItem("font-scale") || "1"));
+if (currentZoomIdx < 0) currentZoomIdx = ZOOM_STEPS.indexOf(1.0);
 
-document.querySelectorAll(".scale-btn").forEach(btn => {
-  if (btn.dataset.scale === savedScale) btn.classList.add("active");
-  else btn.classList.remove("active");
+const zoomOutBtn = document.getElementById("zoom-out");
+const zoomInBtn = document.getElementById("zoom-in");
+const zoomLevelEl = document.getElementById("zoom-level");
 
-  btn.addEventListener("click", () => {
-    const scale = btn.dataset.scale;
-    document.body.style.setProperty("--scale", scale);
-    localStorage.setItem("font-scale", scale);
-    document.querySelectorAll(".scale-btn").forEach(b => b.classList.remove("active"));
-    btn.classList.add("active");
-  });
+function applyZoom() {
+  const scale = ZOOM_STEPS[currentZoomIdx];
+  document.body.style.setProperty("--scale", scale);
+  localStorage.setItem("font-scale", String(scale));
+  if (zoomLevelEl) zoomLevelEl.textContent = Math.round(scale * 100) + "%";
+  if (zoomOutBtn) zoomOutBtn.disabled = currentZoomIdx === 0;
+  if (zoomInBtn) zoomInBtn.disabled = currentZoomIdx === ZOOM_STEPS.length - 1;
+}
+applyZoom();
+
+if (zoomOutBtn) zoomOutBtn.addEventListener("click", () => {
+  if (currentZoomIdx > 0) { currentZoomIdx--; applyZoom(); }
+});
+if (zoomInBtn) zoomInBtn.addEventListener("click", () => {
+  if (currentZoomIdx < ZOOM_STEPS.length - 1) { currentZoomIdx++; applyZoom(); }
+});
+
+document.addEventListener("keydown", (e) => {
+  if (e.target.tagName === "INPUT" || e.target.tagName === "TEXTAREA" || e.target.isContentEditable) return;
+  if ((e.key === "+" || e.key === "=") && !e.ctrlKey && !e.metaKey) {
+    if (currentZoomIdx < ZOOM_STEPS.length - 1) { currentZoomIdx++; applyZoom(); }
+  } else if (e.key === "-" && !e.ctrlKey && !e.metaKey) {
+    if (currentZoomIdx > 0) { currentZoomIdx--; applyZoom(); }
+  }
 });
 
 // --- Agent task label integration ---
@@ -2807,3 +2851,35 @@ function toggleHelp() {
 if (helpBtn) helpBtn.addEventListener("click", toggleHelp);
 if (helpClose) helpClose.addEventListener("click", toggleHelp);
 if (helpOverlay) helpOverlay.addEventListener("click", toggleHelp);
+
+// --- Zoom controls ---
+const ZOOM_STEPS = [0.8, 0.9, 1.0, 1.1, 1.2, 1.4, 1.6, 1.8, 2.0];
+const ZOOM_DEFAULT = 2; // index of 1.0 in ZOOM_STEPS
+let zoomIndex = parseInt(localStorage.getItem("relay-zoom") ?? ZOOM_DEFAULT, 10);
+if (zoomIndex < 0 || zoomIndex >= ZOOM_STEPS.length) zoomIndex = ZOOM_DEFAULT;
+
+const zoomInBtn = document.getElementById("zoom-in");
+const zoomOutBtn = document.getElementById("zoom-out");
+const zoomLabel = document.getElementById("zoom-level");
+
+function applyZoom() {
+  const scale = ZOOM_STEPS[zoomIndex];
+  document.body.style.setProperty("--scale", scale);
+  if (zoomLabel) zoomLabel.textContent = Math.round(scale * 100) + "%";
+  localStorage.setItem("relay-zoom", zoomIndex);
+}
+applyZoom();
+
+if (zoomInBtn) zoomInBtn.addEventListener("click", () => {
+  if (zoomIndex < ZOOM_STEPS.length - 1) { zoomIndex++; applyZoom(); }
+});
+if (zoomOutBtn) zoomOutBtn.addEventListener("click", () => {
+  if (zoomIndex > 0) { zoomIndex--; applyZoom(); }
+});
+
+shortcuts.register("+", "zoom-in", "Zoom in", () => {
+  if (zoomIndex < ZOOM_STEPS.length - 1) { zoomIndex++; applyZoom(); }
+});
+shortcuts.register("-", "zoom-out", "Zoom out", () => {
+  if (zoomIndex > 0) { zoomIndex--; applyZoom(); }
+});

--- a/internal/web/static/style.css
+++ b/internal/web/static/style.css
@@ -12,12 +12,18 @@ body {
   height: 100vh;
   display: flex;
   flex-direction: column;
-  --scale: 1.2;
+  --scale: 1;
   --font-xs: calc(9px * var(--scale));
   --font-sm: calc(11px * var(--scale));
   --font-md: calc(12px * var(--scale));
   --font-lg: calc(14px * var(--scale));
   --font-xl: calc(18px * var(--scale));
+}
+
+/* Scalable UI — sidebar, header, panels (not the canvas) */
+header, .sidebar, .panel, .detail-panel, #kanban-view, #vault-view,
+.help-modal, .quest-tracker, .user-questions-hud {
+  zoom: var(--scale);
 }
 
 /* Header */
@@ -131,6 +137,36 @@ header {
 }
 
 .mode-icon { font-size: 12px; }
+
+/* Zoom controls */
+.zoom-controls {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  margin-right: 4px;
+}
+.zoom-btn {
+  background: rgba(108, 92, 231, 0.1);
+  border: 1px solid rgba(108, 92, 231, 0.2);
+  color: #8a8a9a;
+  font-size: 14px;
+  width: 22px;
+  height: 22px;
+  border-radius: 3px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.15s;
+  line-height: 1;
+}
+.zoom-btn:hover { color: #e0e0e8; background: rgba(108, 92, 231, 0.25); }
+.zoom-level {
+  font-size: 9px;
+  color: #6a6a80;
+  min-width: 30px;
+  text-align: center;
+}
 
 /* Right zone — tabs + help */
 .header-right {
@@ -878,6 +914,17 @@ main.mode-detail #vault-panel { display: none; }
   white-space: pre-wrap;
   word-break: break-word;
 }
+.uq-card .uq-content--md {
+  white-space: normal;
+}
+.uq-card .uq-content--md p { margin: 0 0 4px 0; }
+.uq-card .uq-content--md p:last-child { margin-bottom: 0; }
+.uq-card .uq-content--md strong { color: #c0c8e0; }
+.uq-card .uq-content--md code { background: rgba(255,255,255,0.06); padding: 1px 3px; border-radius: 2px; font-size: 9px; }
+.uq-card .uq-content--md ul, .uq-card .uq-content--md ol { margin: 2px 0; padding-left: 16px; }
+.uq-card .uq-content--md li { margin-bottom: 2px; }
+.uq-card .uq-content--md pre { background: rgba(0,0,0,0.3); padding: 4px 6px; border-radius: 3px; overflow-x: auto; margin: 4px 0; }
+.uq-card .uq-content--md pre code { background: none; padding: 0; }
 
 /* Dismiss */
 .uq-card .uq-dismiss {
@@ -970,6 +1017,9 @@ main.mode-detail #vault-panel { display: none; }
   display: flex;
   gap: 5px;
   margin-top: 6px;
+}
+.uq-respond-btn--cancel {
+  --uq-accent: #ff5252;
 }
 .uq-respond-btn--nav {
   --uq-accent: #6c7a9a;

--- a/main.go
+++ b/main.go
@@ -31,7 +31,7 @@ func main() {
 		case "serve":
 			startServer()
 			return
-		case "init", "status", "agents", "inbox", "send", "thread", "stats", "conversations", "memories":
+		case "init", "update", "status", "agents", "inbox", "send", "thread", "stats", "conversations", "memories":
 			cli.Run(os.Args[1:])
 			return
 		default:


### PR DESCRIPTION
## Summary
- New `create_project` MCP tool — one call sets up an entire project colony
- Returns an 8-phase onboarding prompt: learn relay → analyze codebase → vault → memories → org (teams/profiles/CTO) → goals & board → spawn worker commands → sprint planning
- Auto/interactive mode: user chooses upfront or via `interactive: true` param
- Adaptive profiles: teams and roles derived from actual codebase analysis, not hardcoded templates
- Worker spawn commands include full boot sequence: register → get_context → web research → set_memory → ping CTO ready
- Already-configured detection returns hint if project has agents

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` — 118 tests pass (2 new: TestCreateProject, TestCreateProjectValidation)
- [ ] Manual test: call `create_project({ name: "test" })` and verify prompt output
- [ ] Manual test: run full onboarding on a real project

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * create_project command with optional interactive onboarding; CLI self-update command; task Cancel action, Markdown-rendered task descriptions, and persistent zoom controls in the UI.

* **Installer**
  * Dependency checks, safer config merges with backups, improved hook installation and clearer progress/status messaging.

* **Documentation**
  * README streamlined to a single-command onboarding flow; added a comprehensive onboarding guide and updated repository/tooling references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->