### PR TITLE
feat: v0.7 — spawn engine, web terminal, command panel

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -21,6 +21,14 @@ linters:
     - revive
 
   settings:
+    errcheck:
+      exclude-functions:
+        - (io.Closer).Close
+        - (*database/sql.Rows).Close
+        - (*database/sql.Tx).Rollback
+        - (net/http.ResponseWriter).Write
+        - (*os.File).Close
+        - os.Remove
     revive:
       rules:
         - name: exported

--- a/README.md
+++ b/README.md
@@ -930,6 +930,19 @@ API endpoints: `GET /api/token-usage` (per-project), `/api/token-usage/project` 
 
 <br>
 
+## &#x1F4C4; Research Paper
+
+The architecture behind wrai.th is formalized in our paper:
+
+> **Agentic Memory Atomicity: A Transactional Memory Architecture for Ephemeral AI Agent Systems**
+> Loïc Mancino & Jérôme Chincarini — Synergix Labs, March 2026
+>
+> *81% boot token reduction, 80% knowledge convergence in 30 spawns, sub-linear cost scaling.*
+
+[Read the paper (PDF)](notebooks/paper.pdf)
+
+<br>
+
 ## &#x1F91D; Contributing
 
 Opinionated tooling built for a specific workflow. Moves fast.

--- a/go.mod
+++ b/go.mod
@@ -11,9 +11,12 @@ require (
 require (
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
 	github.com/buger/jsonparser v1.1.1 // indirect
+	github.com/creack/pty v1.1.24 // indirect
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
+	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/invopop/jsonschema v0.13.0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
+	github.com/robfig/cron/v3 v3.0.1 // indirect
 	github.com/spf13/cast v1.7.1 // indirect
 	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/bahlo/generic-list-go v0.2.0 h1:5sz/EEAK+ls5wF+NeqDpk5+iNdMDXrh3z3nPn
 github.com/bahlo/generic-list-go v0.2.0/go.mod h1:2KvAjgMlE5NNynlg/5iLrrCCZ2+5xWbdbCW3pNTGyYg=
 github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMUs=
 github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
+github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
+github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
@@ -12,6 +14,8 @@ github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
+github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/invopop/jsonschema v0.13.0 h1:KvpoAJWEjR3uD9Kbm2HWJmqsEaHt8lBUpd0qHcIi21E=
 github.com/invopop/jsonschema v0.13.0/go.mod h1:ffZ5Km5SWWRAIN6wbDXItl95euhFz2uON45H2qjYt+0=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
@@ -27,6 +31,8 @@ github.com/mattn/go-sqlite3 v1.14.24 h1:tpSp2G2KyMnnQu99ngJ47EIkWVmliIizyZBfPrBW
 github.com/mattn/go-sqlite3 v1.14.24/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
+github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/spf13/cast v1.7.1 h1:cuNEagBQEHWN1FnbGEjCXL2szYEXqfJPbP2HNUaca9Y=

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -38,6 +38,12 @@ func Run(args []string) {
 		runConversations(rest)
 	case "memories":
 		runMemories(rest)
+	case "children":
+		runChildren(rest)
+	case "schedules":
+		runSchedules(rest)
+	case "history":
+		runHistory(rest)
 	case "update":
 		runUpdate(rest)
 	default:
@@ -110,6 +116,10 @@ commands:
     -s <query>                 search memories (FTS5)
     -a <agent>                 filter by agent
     -t <tag>                   filter by tag
+  children [-p project] [agent]  list spawned child agents
+    -s <status>                filter: running, finished, killed, all
+  schedules [-p project] [agent] list cron schedules
+  history [-p project] [agent]   show cycle execution history
 
 flags:
   -p, --project <name>   filter by project (default: "default")

--- a/internal/cli/spawn.go
+++ b/internal/cli/spawn.go
@@ -1,0 +1,181 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+func runChildren(args []string) {
+	project, rest := parseProject(args)
+
+	// Parse optional flags
+	status := "all"
+	agent := ""
+	for i := 0; i < len(rest); i++ {
+		switch rest[i] {
+		case "-s", "--status":
+			if i+1 < len(rest) {
+				status = rest[i+1]
+				i++
+			}
+		default:
+			if agent == "" {
+				agent = rest[i]
+			}
+		}
+	}
+
+	d := openDB()
+	defer func() { _ = d.Close() }()
+
+	children := d.ListSpawnChildren(agent, project, status)
+
+	if len(children) == 0 {
+		fmt.Println("no spawned children found")
+		return
+	}
+
+	fmt.Printf("%s children in %s:\n\n", bold(fmt.Sprintf("%d", len(children))), project)
+
+	for _, c := range children {
+		id, _ := c["id"].(string)
+		profile, _ := c["profile"].(string)
+		st, _ := c["status"].(string)
+		parent, _ := c["parent_agent"].(string)
+		startedAt, _ := c["started_at"].(string)
+
+		shortID := id
+		if len(id) > 8 {
+			shortID = id[:8]
+		}
+
+		statusIcon := "⏳"
+		switch st {
+		case "finished":
+			statusIcon = "✓"
+		case "killed":
+			statusIcon = "✗"
+		}
+
+		duration := ""
+		if t, err := time.Parse(time.RFC3339, startedAt); err == nil {
+			duration = time.Since(t).Truncate(time.Second).String()
+		}
+
+		fmt.Printf("  %s %s  %s  parent=%s  %s  %s\n",
+			statusIcon, shortID, bold(profile), parent, st, duration)
+
+		if errMsg, ok := c["error"].(string); ok && errMsg != "" {
+			fmt.Printf("    error: %s\n", errMsg)
+		}
+	}
+}
+
+func runSchedules(args []string) {
+	project, rest := parseProject(args)
+
+	agent := ""
+	if len(rest) > 0 {
+		agent = rest[0]
+	}
+
+	d := openDB()
+	defer func() { _ = d.Close() }()
+
+	var schedules []map[string]any
+	if agent != "" {
+		schedules = d.ListSchedulesByAgent(project, agent)
+	} else {
+		schedules = d.ListSchedulesByProject(project)
+	}
+
+	if len(schedules) == 0 {
+		fmt.Println("no schedules found")
+		return
+	}
+
+	fmt.Printf("%s schedules in %s:\n\n", bold(fmt.Sprintf("%d", len(schedules))), project)
+
+	for _, s := range schedules {
+		id, _ := s["id"].(string)
+		name, _ := s["name"].(string)
+		agentName, _ := s["agent_name"].(string)
+		cronExpr, _ := s["cron_expr"].(string)
+		ttl, _ := s["ttl"].(string)
+		enabled, _ := s["enabled"].(bool)
+
+		shortID := id
+		if len(id) > 8 {
+			shortID = id[:8]
+		}
+
+		enabledStr := "enabled"
+		if !enabled {
+			enabledStr = "disabled"
+		}
+
+		fmt.Printf("  %s  %s  agent=%s  cron=%q  ttl=%s  %s\n",
+			shortID, bold(name), agentName, cronExpr, ttl, enabledStr)
+	}
+}
+
+func runHistory(args []string) {
+	project, rest := parseProject(args)
+
+	agent := ""
+	if len(rest) > 0 {
+		agent = rest[0]
+	}
+
+	d := openDB()
+	defer func() { _ = d.Close() }()
+
+	history := d.GetCycleHistory(project, agent, 20)
+
+	if len(history) == 0 {
+		fmt.Println("no cycle history found")
+		return
+	}
+
+	fmt.Printf("last %d cycles in %s:\n\n", len(history), project)
+
+	for _, h := range history {
+		agentName, _ := h["agent_name"].(string)
+		cycle, _ := h["cycle_name"].(string)
+		durationMs, _ := h["duration_ms"].(int64)
+		success, _ := h["success"].(bool)
+		createdAt, _ := h["created_at"].(string)
+		inputTokens, _ := h["input_tokens"].(int64)
+		outputTokens, _ := h["output_tokens"].(int64)
+
+		icon := "✓"
+		if !success {
+			icon = "✗"
+		}
+
+		// Trim timestamp
+		ts := createdAt
+		if len(ts) > 19 {
+			ts = ts[:19]
+		}
+
+		duration := time.Duration(durationMs) * time.Millisecond
+
+		parts := []string{
+			fmt.Sprintf("%s %s", icon, bold(agentName)),
+			cycle,
+			duration.Truncate(time.Second).String(),
+		}
+
+		if inputTokens > 0 || outputTokens > 0 {
+			parts = append(parts, fmt.Sprintf("tokens=%d/%d", inputTokens, outputTokens))
+		}
+
+		fmt.Printf("  %s  %s\n", ts, strings.Join(parts, "  "))
+
+		if errMsg, ok := h["error"].(string); ok && errMsg != "" {
+			fmt.Printf("    error: %s\n", errMsg)
+		}
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,12 +13,20 @@ type Config struct {
 	CORSOrigins []string // RELAY_CORS_ORIGINS: allowed origins (comma-separated)
 	MaxBody     int64    // RELAY_MAX_BODY: max request body in bytes
 	RateLimit   int      // RELAY_RATE_LIMIT: requests/minute per IP
+
+	// Spawn/scheduler settings
+	ClaudeBinary string // RELAY_CLAUDE_BINARY: path to claude CLI (default: "claude")
+	LocksDir     string // RELAY_LOCKS_DIR: directory for flock files (default: "/tmp/")
+	MaxPoolSize  int    // RELAY_MAX_POOL_SIZE: global max concurrent spawned children (default: 10)
 }
 
 // Load reads configuration from environment variables with safe defaults.
 func Load() Config {
 	cfg := Config{
-		APIKey: os.Getenv("RELAY_API_KEY"),
+		APIKey:       os.Getenv("RELAY_API_KEY"),
+		ClaudeBinary: "claude",
+		LocksDir:     "/tmp/",
+		MaxPoolSize:  10,
 	}
 
 	if v := os.Getenv("RELAY_CORS_ORIGINS"); v != "" {
@@ -39,6 +47,20 @@ func Load() Config {
 	if v := os.Getenv("RELAY_RATE_LIMIT"); v != "" {
 		if n, err := strconv.Atoi(v); err == nil && n > 0 {
 			cfg.RateLimit = n
+		}
+	}
+
+	if v := os.Getenv("RELAY_CLAUDE_BINARY"); v != "" {
+		cfg.ClaudeBinary = v
+	}
+
+	if v := os.Getenv("RELAY_LOCKS_DIR"); v != "" {
+		cfg.LocksDir = v
+	}
+
+	if v := os.Getenv("RELAY_MAX_POOL_SIZE"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			cfg.MaxPoolSize = n
 		}
 	}
 

--- a/internal/db/agents.go
+++ b/internal/db/agents.go
@@ -173,6 +173,32 @@ func (d *DB) GetAgentsByProfile(project, profileSlug string) ([]models.Agent, er
 	return agents, rows.Err()
 }
 
+// FindActiveAgentsBySkill returns active agents whose profile is linked to the given skill.
+func (d *DB) FindActiveAgentsBySkill(project, skillName string) ([]models.Agent, error) {
+	rows, err := d.ro().Query(
+		`SELECT `+agentColumns+` FROM agents a
+		 JOIN profiles p ON p.slug = a.profile_slug AND p.project = a.project
+		 JOIN profile_skills ps ON ps.profile_id = p.id
+		 JOIN skills s ON s.id = ps.skill_id
+		 WHERE a.project = ? AND s.name = ? AND a.status = 'active'
+		 ORDER BY ps.proficiency, a.name`,
+		project, skillName,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("find agents by skill: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	var agents []models.Agent
+	for rows.Next() {
+		a, err := scanAgent(rows)
+		if err != nil {
+			continue
+		}
+		agents = append(agents, a)
+	}
+	return agents, rows.Err()
+}
+
 func (d *DB) GetAgent(project, name string) (*models.Agent, error) {
 	a, err := scanAgent(d.ro().QueryRow("SELECT "+agentColumns+" FROM agents WHERE name = ? AND project = ?", name, project))
 	if err == sql.ErrNoRows {

--- a/internal/db/agents.go
+++ b/internal/db/agents.go
@@ -176,7 +176,10 @@ func (d *DB) GetAgentsByProfile(project, profileSlug string) ([]models.Agent, er
 // FindActiveAgentsBySkill returns active agents whose profile is linked to the given skill.
 func (d *DB) FindActiveAgentsBySkill(project, skillName string) ([]models.Agent, error) {
 	rows, err := d.ro().Query(
-		`SELECT `+agentColumns+` FROM agents a
+		`SELECT a.id, a.name, a.role, a.description, a.registered_at, a.last_seen, a.project,
+		 a.reports_to, a.profile_slug, a.status, a.deactivated_at, a.is_executive, a.session_id,
+		 a.interest_tags, a.max_context_bytes
+		 FROM agents a
 		 JOIN profiles p ON p.slug = a.profile_slug AND p.project = a.project
 		 JOIN profile_skills ps ON ps.profile_id = p.id
 		 JOIN skills s ON s.id = ps.skill_id

--- a/internal/db/custom_events.go
+++ b/internal/db/custom_events.go
@@ -1,0 +1,80 @@
+package db
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// CustomEvent is a user-defined event type with expected meta fields.
+type CustomEvent struct {
+	ID          string `json:"id"`
+	Project     string `json:"project"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	MetaFields  string `json:"meta_fields"` // JSON array of field names: ["branch","status","author"]
+	Icon        string `json:"icon"`
+	CreatedAt   string `json:"created_at"`
+}
+
+// UpsertCustomEvent creates or updates a custom event type.
+func (d *DB) UpsertCustomEvent(project, name, description, metaFields, icon string) (*CustomEvent, error) {
+	now := time.Now().UTC().Format(memoryTimeFmt)
+	id := uuid.New().String()
+	if metaFields == "" {
+		metaFields = "[]"
+	}
+
+	_, err := d.conn.Exec(`
+		INSERT INTO custom_events (id, project, name, description, meta_fields, icon, created_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(project, name) DO UPDATE SET
+			description = excluded.description,
+			meta_fields = excluded.meta_fields,
+			icon = excluded.icon`,
+		id, project, name, description, metaFields, icon, now)
+	if err != nil {
+		return nil, err
+	}
+
+	// Return the actual row (may have existing ID if updated)
+	return d.GetCustomEvent(project, name)
+}
+
+// GetCustomEvent returns a single custom event by project + name.
+func (d *DB) GetCustomEvent(project, name string) (*CustomEvent, error) {
+	row := d.ro().QueryRow(`SELECT id, project, name, description, COALESCE(meta_fields, '[]'), COALESCE(icon, ''), created_at
+		FROM custom_events WHERE project = ? AND name = ?`, project, name)
+
+	var e CustomEvent
+	err := row.Scan(&e.ID, &e.Project, &e.Name, &e.Description, &e.MetaFields, &e.Icon, &e.CreatedAt)
+	if err != nil {
+		return nil, err
+	}
+	return &e, nil
+}
+
+// ListCustomEvents returns all custom events for a project.
+func (d *DB) ListCustomEvents(project string) ([]CustomEvent, error) {
+	rows, err := d.ro().Query(`SELECT id, project, name, description, COALESCE(meta_fields, '[]'), COALESCE(icon, ''), created_at
+		FROM custom_events WHERE project = ? ORDER BY name`, project)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var result []CustomEvent
+	for rows.Next() {
+		var e CustomEvent
+		if err := rows.Scan(&e.ID, &e.Project, &e.Name, &e.Description, &e.MetaFields, &e.Icon, &e.CreatedAt); err != nil {
+			continue
+		}
+		result = append(result, e)
+	}
+	return result, nil
+}
+
+// DeleteCustomEvent removes a custom event by ID.
+func (d *DB) DeleteCustomEvent(id string) {
+	_, _ = d.conn.Exec("DELETE FROM custom_events WHERE id = ?", id)
+}

--- a/internal/db/cycle_history.go
+++ b/internal/db/cycle_history.go
@@ -1,0 +1,61 @@
+package db
+
+// RecordCycleHistory persists a cycle execution metric.
+func (d *DB) RecordCycleHistory(agentName, project, cycleName string, durationMs int64, success bool, exitCode int, errMsg string, inputTokens, outputTokens, cacheRead, cacheCreation int64) {
+	successInt := 0
+	if success {
+		successInt = 1
+	}
+	_, _ = d.conn.Exec(`INSERT INTO cycle_history (agent_name, project, cycle_name, duration_ms, success, exit_code, error, input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		agentName, project, cycleName, durationMs, successInt, exitCode, errMsg, inputTokens, outputTokens, cacheRead, cacheCreation)
+}
+
+// GetCycleHistory returns recent cycle history for an agent.
+func (d *DB) GetCycleHistory(project, agentName string, limit int) []map[string]any {
+	if limit <= 0 {
+		limit = 50
+	}
+
+	query := `SELECT agent_name, project, cycle_name, duration_ms, success, exit_code, error, input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens, created_at
+		FROM cycle_history WHERE project = ?`
+	args := []any{project}
+
+	if agentName != "" {
+		query += " AND agent_name = ?"
+		args = append(args, agentName)
+	}
+	query += " ORDER BY created_at DESC LIMIT ?"
+	args = append(args, limit)
+
+	rows, err := d.ro().Query(query, args...)
+	if err != nil {
+		return nil
+	}
+	defer rows.Close()
+
+	var result []map[string]any
+	for rows.Next() {
+		var agent, proj, cycle, errMsg, createdAt string
+		var durationMs, inputTokens, outputTokens, cacheRead, cacheCreation int64
+		var success, exitCode int
+		if err := rows.Scan(&agent, &proj, &cycle, &durationMs, &success, &exitCode, &errMsg, &inputTokens, &outputTokens, &cacheRead, &cacheCreation, &createdAt); err != nil {
+			continue
+		}
+		result = append(result, map[string]any{
+			"agent_name":            agent,
+			"project":               proj,
+			"cycle_name":            cycle,
+			"duration_ms":           durationMs,
+			"success":               success == 1,
+			"exit_code":             exitCode,
+			"error":                 errMsg,
+			"input_tokens":          inputTokens,
+			"output_tokens":         outputTokens,
+			"cache_read_tokens":     cacheRead,
+			"cache_creation_tokens": cacheCreation,
+			"created_at":            createdAt,
+		})
+	}
+	return result
+}

--- a/internal/db/cycles.go
+++ b/internal/db/cycles.go
@@ -1,0 +1,88 @@
+package db
+
+import (
+	"agent-relay/internal/models"
+	"database/sql"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// UpsertCycle creates or updates a cycle definition.
+func (d *DB) UpsertCycle(project, name, prompt string, ttl int) (*models.Cycle, error) {
+	now := time.Now().UTC().Format(memoryTimeFmt)
+	if ttl <= 0 {
+		ttl = 10
+	}
+
+	var existingID string
+	err := d.conn.QueryRow("SELECT id FROM cycles WHERE project = ? AND name = ?", project, name).Scan(&existingID)
+	if err == sql.ErrNoRows {
+		id := uuid.New().String()
+		_, err := d.conn.Exec(
+			"INSERT INTO cycles (id, project, name, prompt, ttl, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+			id, project, name, prompt, ttl, now, now,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("insert cycle: %w", err)
+		}
+		return &models.Cycle{ID: id, Project: project, Name: name, Prompt: prompt, TTL: ttl, CreatedAt: now, UpdatedAt: now}, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("check cycle: %w", err)
+	}
+
+	_, err = d.conn.Exec(
+		"UPDATE cycles SET prompt = ?, ttl = ?, updated_at = ? WHERE id = ?",
+		prompt, ttl, now, existingID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("update cycle: %w", err)
+	}
+	return &models.Cycle{ID: existingID, Project: project, Name: name, Prompt: prompt, TTL: ttl, UpdatedAt: now}, nil
+}
+
+// GetCycle returns a cycle by project + name.
+func (d *DB) GetCycle(project, name string) (*models.Cycle, error) {
+	var c models.Cycle
+	err := d.ro().QueryRow(
+		"SELECT id, project, name, prompt, ttl, created_at, updated_at FROM cycles WHERE project = ? AND name = ?",
+		project, name,
+	).Scan(&c.ID, &c.Project, &c.Name, &c.Prompt, &c.TTL, &c.CreatedAt, &c.UpdatedAt)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get cycle: %w", err)
+	}
+	return &c, nil
+}
+
+// ListCycles returns all cycles for a project.
+func (d *DB) ListCycles(project string) ([]models.Cycle, error) {
+	rows, err := d.ro().Query(
+		"SELECT id, project, name, prompt, ttl, created_at, updated_at FROM cycles WHERE project = ? ORDER BY name",
+		project,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list cycles: %w", err)
+	}
+	defer rows.Close()
+
+	var result []models.Cycle
+	for rows.Next() {
+		var c models.Cycle
+		if err := rows.Scan(&c.ID, &c.Project, &c.Name, &c.Prompt, &c.TTL, &c.CreatedAt, &c.UpdatedAt); err != nil {
+			continue
+		}
+		result = append(result, c)
+	}
+	return result, rows.Err()
+}
+
+// DeleteCycle removes a cycle by project + name.
+func (d *DB) DeleteCycle(project, name string) error {
+	_, err := d.conn.Exec("DELETE FROM cycles WHERE project = ? AND name = ?", project, name)
+	return err
+}

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -647,6 +647,75 @@ func migrate(conn *sql.DB) error {
 		PRIMARY KEY (project, agent_name)
 	)`)
 
+	// Workflows (visual DAG definitions)
+	_, _ = conn.Exec(`CREATE TABLE IF NOT EXISTS workflows (
+		id          TEXT PRIMARY KEY,
+		project     TEXT NOT NULL,
+		name        TEXT NOT NULL,
+		description TEXT DEFAULT '',
+		nodes       TEXT NOT NULL DEFAULT '[]',
+		edges       TEXT NOT NULL DEFAULT '[]',
+		enabled     INTEGER DEFAULT 1,
+		created_at  TEXT NOT NULL DEFAULT (datetime('now')),
+		updated_at  TEXT NOT NULL DEFAULT (datetime('now'))
+	)`)
+	_, _ = conn.Exec(`CREATE INDEX IF NOT EXISTS idx_workflows_project ON workflows(project)`)
+
+	// Workflow runs (execution log)
+	_, _ = conn.Exec(`CREATE TABLE IF NOT EXISTS workflow_runs (
+		id            TEXT PRIMARY KEY,
+		workflow_id   TEXT NOT NULL,
+		project       TEXT NOT NULL,
+		trigger_event TEXT,
+		trigger_meta  TEXT DEFAULT '{}',
+		status        TEXT DEFAULT 'running',
+		started_at    TEXT NOT NULL DEFAULT (datetime('now')),
+		finished_at   TEXT,
+		error         TEXT
+	)`)
+	_, _ = conn.Exec(`CREATE INDEX IF NOT EXISTS idx_workflow_runs_workflow ON workflow_runs(workflow_id)`)
+	_, _ = conn.Exec(`CREATE INDEX IF NOT EXISTS idx_workflow_runs_project ON workflow_runs(project, started_at)`)
+
+	// Workflow node runs (per-node execution within a run)
+	_, _ = conn.Exec(`CREATE TABLE IF NOT EXISTS workflow_node_runs (
+		id          TEXT PRIMARY KEY,
+		run_id      TEXT NOT NULL,
+		node_id     TEXT NOT NULL,
+		node_type   TEXT NOT NULL,
+		status      TEXT DEFAULT 'pending',
+		input       TEXT DEFAULT '{}',
+		output      TEXT DEFAULT '{}',
+		started_at  TEXT,
+		finished_at TEXT,
+		error       TEXT
+	)`)
+	_, _ = conn.Exec(`CREATE INDEX IF NOT EXISTS idx_workflow_node_runs_run ON workflow_node_runs(run_id)`)
+
+	// Custom events (user-defined event types with meta field schemas)
+	_, _ = conn.Exec(`CREATE TABLE IF NOT EXISTS custom_events (
+		id          TEXT PRIMARY KEY,
+		project     TEXT NOT NULL,
+		name        TEXT NOT NULL,
+		description TEXT DEFAULT '',
+		meta_fields TEXT DEFAULT '[]',
+		icon        TEXT DEFAULT '',
+		created_at  TEXT NOT NULL DEFAULT (datetime('now')),
+		UNIQUE(project, name)
+	)`)
+	_, _ = conn.Exec(`CREATE INDEX IF NOT EXISTS idx_custom_events_project ON custom_events(project)`)
+
+	_, _ = conn.Exec(`CREATE TABLE IF NOT EXISTS cycles (
+		id            TEXT PRIMARY KEY,
+		project       TEXT NOT NULL,
+		name          TEXT NOT NULL,
+		prompt        TEXT NOT NULL DEFAULT '',
+		ttl           INTEGER NOT NULL DEFAULT 10,
+		created_at    TEXT NOT NULL DEFAULT (datetime('now')),
+		updated_at    TEXT NOT NULL DEFAULT (datetime('now')),
+		UNIQUE(project, name)
+	)`)
+	_, _ = conn.Exec(`CREATE INDEX IF NOT EXISTS idx_cycles_project ON cycles(project)`)
+
 	// Lowercase all agent names for case-insensitive matching
 	migrateLowercaseAgentNames(conn)
 

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -341,8 +341,10 @@ func migrate(conn *sql.DB) error {
 	)`)
 	_, _ = conn.Exec(`CREATE UNIQUE INDEX IF NOT EXISTS idx_profiles_project_slug ON profiles(project, slug)`)
 	ensureColumns(conn, "profiles", map[string]string{
-		"skills":      "TEXT NOT NULL DEFAULT '[]'",
-		"vault_paths": "TEXT NOT NULL DEFAULT '[]'",
+		"skills":        "TEXT NOT NULL DEFAULT '[]'",
+		"vault_paths":   "TEXT NOT NULL DEFAULT '[]'",
+		"allowed_tools": "TEXT NOT NULL DEFAULT '[]'",
+		"pool_size":     "INTEGER NOT NULL DEFAULT 3",
 	})
 
 	// Tasks
@@ -485,6 +487,165 @@ func migrate(conn *sql.DB) error {
 	)`)
 	_, _ = conn.Exec(`CREATE INDEX IF NOT EXISTS idx_token_usage_project_time ON token_usage(project, created_at)`)
 	_, _ = conn.Exec(`CREATE INDEX IF NOT EXISTS idx_token_usage_agent_time ON token_usage(project, agent, created_at)`)
+
+	// Spawn children tracking
+	_, _ = conn.Exec(`CREATE TABLE IF NOT EXISTS spawn_children (
+		id          TEXT PRIMARY KEY,
+		parent_agent TEXT NOT NULL,
+		project     TEXT NOT NULL,
+		profile     TEXT NOT NULL,
+		pid         INTEGER,
+		status      TEXT NOT NULL DEFAULT 'running',
+		prompt      TEXT NOT NULL DEFAULT '',
+		started_at  TEXT NOT NULL,
+		finished_at TEXT,
+		exit_code   INTEGER,
+		error       TEXT DEFAULT ''
+	)`)
+	_, _ = conn.Exec(`CREATE INDEX IF NOT EXISTS idx_spawn_children_parent ON spawn_children(parent_agent, project)`)
+	_, _ = conn.Exec(`CREATE INDEX IF NOT EXISTS idx_spawn_children_status ON spawn_children(status)`)
+
+	// Schedules (cron jobs stored in DB)
+	_, _ = conn.Exec(`CREATE TABLE IF NOT EXISTS schedules (
+		id          TEXT PRIMARY KEY,
+		agent_name  TEXT NOT NULL,
+		project     TEXT NOT NULL,
+		name        TEXT NOT NULL,
+		cron_expr   TEXT NOT NULL,
+		prompt      TEXT NOT NULL DEFAULT '',
+		ttl         TEXT NOT NULL DEFAULT '10m',
+		enabled     INTEGER NOT NULL DEFAULT 1,
+		created_at  TEXT NOT NULL,
+		updated_at  TEXT NOT NULL
+	)`)
+	_, _ = conn.Exec(`CREATE UNIQUE INDEX IF NOT EXISTS idx_schedules_agent_name ON schedules(project, agent_name, name)`)
+	_, _ = conn.Exec(`CREATE INDEX IF NOT EXISTS idx_schedules_project ON schedules(project)`)
+	ensureColumns(conn, "schedules", map[string]string{
+		"allowed_tools": "TEXT NOT NULL DEFAULT ''",
+		"cycle":         "TEXT NOT NULL DEFAULT ''",
+	})
+
+	// Cycle history (execution metrics)
+	_, _ = conn.Exec(`CREATE TABLE IF NOT EXISTS cycle_history (
+		id                    INTEGER PRIMARY KEY AUTOINCREMENT,
+		agent_name            TEXT NOT NULL,
+		project               TEXT NOT NULL,
+		cycle_name            TEXT NOT NULL,
+		duration_ms           INTEGER NOT NULL,
+		success               INTEGER NOT NULL,
+		exit_code             INTEGER NOT NULL DEFAULT 0,
+		error                 TEXT DEFAULT '',
+		input_tokens          INTEGER NOT NULL DEFAULT 0,
+		output_tokens         INTEGER NOT NULL DEFAULT 0,
+		cache_read_tokens     INTEGER NOT NULL DEFAULT 0,
+		cache_creation_tokens INTEGER NOT NULL DEFAULT 0,
+		created_at            TEXT NOT NULL DEFAULT (datetime('now'))
+	)`)
+	_, _ = conn.Exec(`CREATE INDEX IF NOT EXISTS idx_cycle_history_agent ON cycle_history(agent_name, project)`)
+	_, _ = conn.Exec(`CREATE INDEX IF NOT EXISTS idx_cycle_history_time ON cycle_history(created_at)`)
+
+	// Triggers (event-driven spawn rules)
+	_, _ = conn.Exec(`CREATE TABLE IF NOT EXISTS triggers (
+		id           TEXT PRIMARY KEY,
+		project      TEXT NOT NULL,
+		event        TEXT NOT NULL,
+		match_rules  TEXT NOT NULL DEFAULT '{}',
+		profile_slug TEXT NOT NULL,
+		cycle        TEXT NOT NULL,
+		max_duration TEXT NOT NULL DEFAULT '10m',
+		enabled      INTEGER NOT NULL DEFAULT 1,
+		created_at   TEXT NOT NULL DEFAULT (datetime('now')),
+		updated_at   TEXT NOT NULL DEFAULT (datetime('now'))
+	)`)
+	_, _ = conn.Exec(`CREATE INDEX IF NOT EXISTS idx_triggers_project_event ON triggers(project, event)`)
+	ensureColumns(conn, "triggers", map[string]string{
+		"cooldown_seconds": "INTEGER DEFAULT 60",
+		"last_fired_at":    "TEXT",
+	})
+
+	// Trigger history (event-driven spawn audit log)
+	_, _ = conn.Exec(`CREATE TABLE IF NOT EXISTS trigger_history (
+		id         TEXT PRIMARY KEY,
+		trigger_id TEXT NOT NULL,
+		project    TEXT NOT NULL,
+		event      TEXT NOT NULL,
+		child_id   TEXT,
+		error      TEXT,
+		fired_at   TEXT NOT NULL
+	)`)
+	_, _ = conn.Exec(`CREATE INDEX IF NOT EXISTS idx_trigger_history_project ON trigger_history(project, fired_at)`)
+	_, _ = conn.Exec(`CREATE INDEX IF NOT EXISTS idx_trigger_history_trigger ON trigger_history(trigger_id)`)
+
+	// Poll triggers (external URL monitoring)
+	_, _ = conn.Exec(`CREATE TABLE IF NOT EXISTS poll_triggers (
+		id               TEXT PRIMARY KEY,
+		project          TEXT NOT NULL,
+		name             TEXT NOT NULL,
+		url              TEXT NOT NULL,
+		headers          TEXT DEFAULT '{}',
+		condition_path   TEXT NOT NULL,
+		condition_op     TEXT NOT NULL,
+		condition_value  TEXT NOT NULL,
+		poll_interval    TEXT NOT NULL,
+		fire_event       TEXT NOT NULL,
+		fire_meta        TEXT DEFAULT '{}',
+		enabled          INTEGER DEFAULT 1,
+		last_polled_at   TEXT,
+		last_result      TEXT,
+		last_matched     INTEGER DEFAULT 0,
+		cooldown_seconds INTEGER DEFAULT 300,
+		created_at       TEXT NOT NULL,
+		UNIQUE(project, name)
+	)`)
+	_, _ = conn.Exec(`CREATE INDEX IF NOT EXISTS idx_poll_triggers_project ON poll_triggers(project)`)
+
+	// Skill registry
+	_, _ = conn.Exec(`CREATE TABLE IF NOT EXISTS skills (
+		id          TEXT PRIMARY KEY,
+		project     TEXT NOT NULL,
+		name        TEXT NOT NULL,
+		description TEXT DEFAULT '',
+		tags        TEXT DEFAULT '[]',
+		created_at  TEXT NOT NULL,
+		UNIQUE(project, name)
+	)`)
+	_, _ = conn.Exec(`CREATE INDEX IF NOT EXISTS idx_skills_project ON skills(project)`)
+
+	_, _ = conn.Exec(`CREATE TABLE IF NOT EXISTS profile_skills (
+		profile_id  TEXT NOT NULL,
+		skill_id    TEXT NOT NULL,
+		proficiency TEXT DEFAULT 'capable',
+		PRIMARY KEY (profile_id, skill_id),
+		FOREIGN KEY (profile_id) REFERENCES profiles(id) ON DELETE CASCADE,
+		FOREIGN KEY (skill_id) REFERENCES skills(id) ON DELETE CASCADE
+	)`)
+
+	// Elevated privileges (temporary privilege escalation)
+	_, _ = conn.Exec(`CREATE TABLE IF NOT EXISTS elevated_privileges (
+		id            TEXT PRIMARY KEY,
+		project       TEXT NOT NULL,
+		agent_name    TEXT NOT NULL,
+		elevated_role TEXT NOT NULL,
+		granted_by    TEXT NOT NULL,
+		reason        TEXT DEFAULT '',
+		expires_at    TEXT NOT NULL,
+		revoked_at    TEXT,
+		created_at    TEXT NOT NULL
+	)`)
+	_, _ = conn.Exec(`CREATE INDEX IF NOT EXISTS idx_elevated_project_agent ON elevated_privileges(project, agent_name)`)
+
+	// Agent quotas (per-agent rate limits)
+	_, _ = conn.Exec(`CREATE TABLE IF NOT EXISTS agent_quotas (
+		project              TEXT NOT NULL,
+		agent_name           TEXT NOT NULL,
+		max_tokens_per_day   INTEGER DEFAULT 0,
+		max_messages_per_hour INTEGER DEFAULT 0,
+		max_tasks_per_hour   INTEGER DEFAULT 0,
+		max_spawns_per_hour  INTEGER DEFAULT 0,
+		created_at           TEXT NOT NULL,
+		updated_at           TEXT NOT NULL,
+		PRIMARY KEY (project, agent_name)
+	)`)
 
 	// Lowercase all agent names for case-insensitive matching
 	migrateLowercaseAgentNames(conn)

--- a/internal/db/elevations.go
+++ b/internal/db/elevations.go
@@ -1,0 +1,89 @@
+package db
+
+import (
+	"agent-relay/internal/models"
+	"database/sql"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// GrantElevation creates a temporary privilege escalation for an agent.
+func (d *DB) GrantElevation(project, agent, role, grantedBy, reason string, duration time.Duration) (*models.Elevation, error) {
+	now := time.Now().UTC()
+	id := uuid.New().String()
+	expiresAt := now.Add(duration).Format(memoryTimeFmt)
+
+	_, err := d.conn.Exec(`INSERT INTO elevated_privileges (id, project, agent_name, elevated_role, granted_by, reason, expires_at, created_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		id, project, agent, role, grantedBy, reason, expiresAt, now.Format(memoryTimeFmt))
+	if err != nil {
+		return nil, fmt.Errorf("grant elevation: %w", err)
+	}
+
+	return &models.Elevation{
+		ID: id, Project: project, AgentName: agent, ElevatedRole: role,
+		GrantedBy: grantedBy, Reason: reason, ExpiresAt: expiresAt,
+		CreatedAt: now.Format(memoryTimeFmt),
+	}, nil
+}
+
+// RevokeElevation immediately revokes a privilege escalation.
+func (d *DB) RevokeElevation(id string) error {
+	now := time.Now().UTC().Format(memoryTimeFmt)
+	_, err := d.conn.Exec(`UPDATE elevated_privileges SET revoked_at = ? WHERE id = ? AND revoked_at IS NULL`, now, id)
+	return err
+}
+
+// GetActiveElevation returns the active (non-expired, non-revoked) elevation for an agent.
+func (d *DB) GetActiveElevation(project, agent string) (*models.Elevation, error) {
+	now := time.Now().UTC().Format(memoryTimeFmt)
+	var e models.Elevation
+	err := d.ro().QueryRow(`SELECT id, project, agent_name, elevated_role, granted_by, reason, expires_at, revoked_at, created_at
+		FROM elevated_privileges
+		WHERE project = ? AND agent_name = ? AND revoked_at IS NULL AND expires_at > ?
+		ORDER BY created_at DESC LIMIT 1`, project, agent, now).Scan(
+		&e.ID, &e.Project, &e.AgentName, &e.ElevatedRole, &e.GrantedBy, &e.Reason, &e.ExpiresAt, &e.RevokedAt, &e.CreatedAt)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &e, nil
+}
+
+// ListActiveElevations returns all active elevations for a project.
+func (d *DB) ListActiveElevations(project string) ([]models.Elevation, error) {
+	now := time.Now().UTC().Format(memoryTimeFmt)
+	rows, err := d.ro().Query(`SELECT id, project, agent_name, elevated_role, granted_by, reason, expires_at, revoked_at, created_at
+		FROM elevated_privileges
+		WHERE project = ? AND revoked_at IS NULL AND expires_at > ?
+		ORDER BY created_at DESC`, project, now)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var result []models.Elevation
+	for rows.Next() {
+		var e models.Elevation
+		if err := rows.Scan(&e.ID, &e.Project, &e.AgentName, &e.ElevatedRole, &e.GrantedBy, &e.Reason, &e.ExpiresAt, &e.RevokedAt, &e.CreatedAt); err != nil {
+			continue
+		}
+		result = append(result, e)
+	}
+	return result, rows.Err()
+}
+
+// ExpireElevations marks all expired elevations as revoked.
+// Returns the number of elevations expired.
+func (d *DB) ExpireElevations() (int64, error) {
+	now := time.Now().UTC().Format(memoryTimeFmt)
+	result, err := d.conn.Exec(`UPDATE elevated_privileges SET revoked_at = ? WHERE revoked_at IS NULL AND expires_at <= ?`, now, now)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}

--- a/internal/db/memories.go
+++ b/internal/db/memories.go
@@ -484,6 +484,20 @@ func (d *DB) ResolveConflict(project, agentName, key, chosenValue, scope string)
 	return winner, nil
 }
 
+// GetMemoriesByLayer returns all active memories for an agent filtered by layer.
+// Cross-scope: returns agent + project + global memories (same cascade as search).
+func (d *DB) GetMemoriesByLayer(project, agentName, layer string) ([]models.Memory, error) {
+	return d.queryMemories(
+		`SELECT id, key, value, tags, scope, project, agent_name, confidence, version,
+		 supersedes, conflict_with, created_at, updated_at, archived_at, archived_by, layer
+		 FROM memories
+		 WHERE archived_at IS NULL AND layer = ?
+		   AND (scope = 'global' OR (project = ? AND (scope = 'project' OR (scope = 'agent' AND agent_name = ?))))
+		 ORDER BY updated_at DESC`,
+		layer, project, agentName,
+	)
+}
+
 // ListAllMemories returns all active memories across projects (for web UI).
 func (d *DB) ListAllMemories(limit int) ([]models.Memory, error) {
 	if limit <= 0 {

--- a/internal/db/orgs.go
+++ b/internal/db/orgs.go
@@ -417,6 +417,12 @@ func (d *DB) CanMessage(project, sender, target string) (bool, error) {
 		return true, nil
 	}
 
+	// Privilege escalation check: if sender has active elevation to admin, allow
+	elevation, err := d.GetActiveElevation(project, sender)
+	if err == nil && elevation != nil && elevation.ElevatedRole == "admin" {
+		return true, nil
+	}
+
 	return false, nil
 }
 

--- a/internal/db/poll_triggers.go
+++ b/internal/db/poll_triggers.go
@@ -1,0 +1,165 @@
+package db
+
+import (
+	"agent-relay/internal/models"
+	"database/sql"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// UpsertPollTrigger creates or updates a poll trigger by project+name.
+func (d *DB) UpsertPollTrigger(project, name, url, headers, path, op, value, interval, event, meta string, cooldown int) (*models.PollTrigger, error) {
+	now := time.Now().UTC().Format(memoryTimeFmt)
+	if headers == "" {
+		headers = "{}"
+	}
+	if meta == "" {
+		meta = "{}"
+	}
+	if cooldown <= 0 {
+		cooldown = 300
+	}
+
+	// Check if exists
+	var existingID string
+	err := d.conn.QueryRow(`SELECT id FROM poll_triggers WHERE project = ? AND name = ?`, project, name).Scan(&existingID)
+	if err == sql.ErrNoRows {
+		id := uuid.New().String()
+		_, err := d.conn.Exec(`INSERT INTO poll_triggers
+			(id, project, name, url, headers, condition_path, condition_op, condition_value, poll_interval, fire_event, fire_meta, cooldown_seconds, created_at)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			id, project, name, url, headers, path, op, value, interval, event, meta, cooldown, now)
+		if err != nil {
+			return nil, fmt.Errorf("insert poll trigger: %w", err)
+		}
+		return &models.PollTrigger{
+			ID: id, Project: project, Name: name, URL: url, Headers: headers,
+			ConditionPath: path, ConditionOp: op, ConditionValue: value,
+			PollInterval: interval, FireEvent: event, FireMeta: meta,
+			Enabled: true, CooldownSeconds: cooldown, CreatedAt: now,
+		}, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("check poll trigger: %w", err)
+	}
+
+	// Update existing
+	_, err = d.conn.Exec(`UPDATE poll_triggers SET url=?, headers=?, condition_path=?, condition_op=?, condition_value=?,
+		poll_interval=?, fire_event=?, fire_meta=?, cooldown_seconds=? WHERE id=?`,
+		url, headers, path, op, value, interval, event, meta, cooldown, existingID)
+	if err != nil {
+		return nil, fmt.Errorf("update poll trigger: %w", err)
+	}
+
+	return &models.PollTrigger{
+		ID: existingID, Project: project, Name: name, URL: url, Headers: headers,
+		ConditionPath: path, ConditionOp: op, ConditionValue: value,
+		PollInterval: interval, FireEvent: event, FireMeta: meta,
+		Enabled: true, CooldownSeconds: cooldown, CreatedAt: now,
+	}, nil
+}
+
+// ListPollTriggers returns all poll triggers for a project.
+func (d *DB) ListPollTriggers(project string) ([]models.PollTrigger, error) {
+	rows, err := d.ro().Query(`SELECT id, project, name, url, headers, condition_path, condition_op, condition_value,
+		poll_interval, fire_event, fire_meta, enabled, COALESCE(last_polled_at, ''), COALESCE(last_result, ''),
+		last_matched, cooldown_seconds, created_at
+		FROM poll_triggers WHERE project = ? ORDER BY name`, project)
+	if err != nil {
+		return nil, fmt.Errorf("list poll triggers: %w", err)
+	}
+	defer rows.Close()
+
+	var result []models.PollTrigger
+	for rows.Next() {
+		var pt models.PollTrigger
+		if err := rows.Scan(&pt.ID, &pt.Project, &pt.Name, &pt.URL, &pt.Headers, &pt.ConditionPath, &pt.ConditionOp, &pt.ConditionValue,
+			&pt.PollInterval, &pt.FireEvent, &pt.FireMeta, &pt.Enabled, &pt.LastPolledAt, &pt.LastResult,
+			&pt.LastMatched, &pt.CooldownSeconds, &pt.CreatedAt); err != nil {
+			continue
+		}
+		result = append(result, pt)
+	}
+	return result, rows.Err()
+}
+
+// GetDuePollTriggers returns enabled poll triggers that are due for polling.
+func (d *DB) GetDuePollTriggers() ([]models.PollTrigger, error) {
+	rows, err := d.ro().Query(`SELECT id, project, name, url, headers, condition_path, condition_op, condition_value,
+		poll_interval, fire_event, fire_meta, enabled, COALESCE(last_polled_at, ''), COALESCE(last_result, ''),
+		last_matched, cooldown_seconds, created_at
+		FROM poll_triggers WHERE enabled = 1 ORDER BY last_polled_at ASC`)
+	if err != nil {
+		return nil, fmt.Errorf("get due poll triggers: %w", err)
+	}
+	defer rows.Close()
+
+	now := time.Now().UTC()
+	var result []models.PollTrigger
+	for rows.Next() {
+		var pt models.PollTrigger
+		if err := rows.Scan(&pt.ID, &pt.Project, &pt.Name, &pt.URL, &pt.Headers, &pt.ConditionPath, &pt.ConditionOp, &pt.ConditionValue,
+			&pt.PollInterval, &pt.FireEvent, &pt.FireMeta, &pt.Enabled, &pt.LastPolledAt, &pt.LastResult,
+			&pt.LastMatched, &pt.CooldownSeconds, &pt.CreatedAt); err != nil {
+			continue
+		}
+
+		// Check if interval has elapsed
+		interval, err := time.ParseDuration(pt.PollInterval)
+		if err != nil {
+			continue
+		}
+		if pt.LastPolledAt == "" {
+			result = append(result, pt)
+			continue
+		}
+		lastPolled, err := time.Parse("2006-01-02T15:04:05Z", pt.LastPolledAt)
+		if err != nil {
+			result = append(result, pt)
+			continue
+		}
+		if now.Sub(lastPolled) >= interval {
+			result = append(result, pt)
+		}
+	}
+	return result, rows.Err()
+}
+
+// UpdatePollResult updates the last poll result for a trigger.
+func (d *DB) UpdatePollResult(id, result string, matched bool) error {
+	now := time.Now().UTC().Format(memoryTimeFmt)
+	m := 0
+	if matched {
+		m = 1
+	}
+	_, err := d.conn.Exec(`UPDATE poll_triggers SET last_polled_at=?, last_result=?, last_matched=? WHERE id=?`,
+		now, result, m, id)
+	return err
+}
+
+// DeletePollTrigger removes a poll trigger by ID.
+func (d *DB) DeletePollTrigger(id string) error {
+	_, err := d.conn.Exec(`DELETE FROM poll_triggers WHERE id = ?`, id)
+	return err
+}
+
+// GetPollTrigger returns a single poll trigger by ID.
+func (d *DB) GetPollTrigger(id string) (*models.PollTrigger, error) {
+	var pt models.PollTrigger
+	err := d.ro().QueryRow(`SELECT id, project, name, url, headers, condition_path, condition_op, condition_value,
+		poll_interval, fire_event, fire_meta, enabled, COALESCE(last_polled_at, ''), COALESCE(last_result, ''),
+		last_matched, cooldown_seconds, created_at
+		FROM poll_triggers WHERE id = ?`, id).Scan(
+		&pt.ID, &pt.Project, &pt.Name, &pt.URL, &pt.Headers, &pt.ConditionPath, &pt.ConditionOp, &pt.ConditionValue,
+		&pt.PollInterval, &pt.FireEvent, &pt.FireMeta, &pt.Enabled, &pt.LastPolledAt, &pt.LastResult,
+		&pt.LastMatched, &pt.CooldownSeconds, &pt.CreatedAt)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &pt, nil
+}

--- a/internal/db/profiles.go
+++ b/internal/db/profiles.go
@@ -9,15 +9,28 @@ import (
 	"github.com/google/uuid"
 )
 
-const profileColumns = "id, slug, name, role, context_pack, soul_keys, skills, vault_paths, project, org_id, created_at, updated_at"
+const profileColumns = "id, slug, name, role, context_pack, soul_keys, skills, vault_paths, allowed_tools, pool_size, project, org_id, created_at, updated_at"
 
 func scanProfile(row interface{ Scan(...any) error }) (models.Profile, error) {
 	var p models.Profile
-	err := row.Scan(&p.ID, &p.Slug, &p.Name, &p.Role, &p.ContextPack, &p.SoulKeys, &p.Skills, &p.VaultPaths, &p.Project, &p.OrgID, &p.CreatedAt, &p.UpdatedAt)
+	err := row.Scan(&p.ID, &p.Slug, &p.Name, &p.Role, &p.ContextPack, &p.SoulKeys, &p.Skills, &p.VaultPaths, &p.AllowedTools, &p.PoolSize, &p.Project, &p.OrgID, &p.CreatedAt, &p.UpdatedAt)
 	return p, err
 }
 
-func (d *DB) RegisterProfile(project, slug, name, role, contextPack, soulKeys, skills, vaultPaths string) (*models.Profile, error) {
+// ProfileOption sets optional fields when registering a profile.
+type ProfileOption func(*models.Profile)
+
+// WithAllowedTools sets the allowed tools for a profile.
+func WithAllowedTools(tools string) ProfileOption {
+	return func(p *models.Profile) { p.AllowedTools = tools }
+}
+
+// WithPoolSize sets the max concurrent spawns for a profile.
+func WithPoolSize(size int) ProfileOption {
+	return func(p *models.Profile) { p.PoolSize = size }
+}
+
+func (d *DB) RegisterProfile(project, slug, name, role, contextPack, soulKeys, skills, vaultPaths string, opts ...ProfileOption) (*models.Profile, error) {
 	now := time.Now().UTC().Format(memoryTimeFmt)
 	if soulKeys == "" {
 		soulKeys = "[]"
@@ -37,21 +50,26 @@ func (d *DB) RegisterProfile(project, slug, name, role, contextPack, soulKeys, s
 
 	if err == sql.ErrNoRows {
 		p := &models.Profile{
-			ID:          uuid.New().String(),
-			Slug:        slug,
-			Name:        name,
-			Role:        role,
-			ContextPack: contextPack,
-			SoulKeys:    soulKeys,
-			Skills:      skills,
-			VaultPaths:  vaultPaths,
-			Project:     project,
-			CreatedAt:   now,
-			UpdatedAt:   now,
+			ID:           uuid.New().String(),
+			Slug:         slug,
+			Name:         name,
+			Role:         role,
+			ContextPack:  contextPack,
+			SoulKeys:     soulKeys,
+			Skills:       skills,
+			VaultPaths:   vaultPaths,
+			AllowedTools: "[]",
+			PoolSize:     3,
+			Project:      project,
+			CreatedAt:    now,
+			UpdatedAt:    now,
+		}
+		for _, opt := range opts {
+			opt(p)
 		}
 		_, err := d.conn.Exec(
-			"INSERT INTO profiles (id, slug, name, role, context_pack, soul_keys, skills, vault_paths, project, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-			p.ID, p.Slug, p.Name, p.Role, p.ContextPack, p.SoulKeys, p.Skills, p.VaultPaths, p.Project, p.CreatedAt, p.UpdatedAt,
+			"INSERT INTO profiles (id, slug, name, role, context_pack, soul_keys, skills, vault_paths, allowed_tools, pool_size, project, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+			p.ID, p.Slug, p.Name, p.Role, p.ContextPack, p.SoulKeys, p.Skills, p.VaultPaths, p.AllowedTools, p.PoolSize, p.Project, p.CreatedAt, p.UpdatedAt,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("insert profile: %w", err)
@@ -63,13 +81,6 @@ func (d *DB) RegisterProfile(project, slug, name, role, contextPack, soulKeys, s
 	}
 
 	// Update existing
-	_, err = d.conn.Exec(
-		"UPDATE profiles SET name = ?, role = ?, context_pack = ?, soul_keys = ?, skills = ?, vault_paths = ?, updated_at = ? WHERE slug = ? AND project = ?",
-		name, role, contextPack, soulKeys, skills, vaultPaths, now, slug, project,
-	)
-	if err != nil {
-		return nil, fmt.Errorf("update profile: %w", err)
-	}
 	existing.Name = name
 	existing.Role = role
 	existing.ContextPack = contextPack
@@ -77,6 +88,17 @@ func (d *DB) RegisterProfile(project, slug, name, role, contextPack, soulKeys, s
 	existing.Skills = skills
 	existing.VaultPaths = vaultPaths
 	existing.UpdatedAt = now
+	for _, opt := range opts {
+		opt(&existing)
+	}
+
+	_, err = d.conn.Exec(
+		"UPDATE profiles SET name = ?, role = ?, context_pack = ?, soul_keys = ?, skills = ?, vault_paths = ?, allowed_tools = ?, pool_size = ?, updated_at = ? WHERE slug = ? AND project = ?",
+		existing.Name, existing.Role, existing.ContextPack, existing.SoulKeys, existing.Skills, existing.VaultPaths, existing.AllowedTools, existing.PoolSize, now, slug, project,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("update profile: %w", err)
+	}
 	return &existing, nil
 }
 
@@ -133,6 +155,12 @@ func (d *DB) ListAllProfiles() ([]models.Profile, error) {
 		profiles = append(profiles, p)
 	}
 	return profiles, rows.Err()
+}
+
+// DeleteProfile removes a profile by slug and project.
+func (d *DB) DeleteProfile(project, slug string) error {
+	_, err := d.conn.Exec("DELETE FROM profiles WHERE slug = ? AND project = ?", slug, project)
+	return err
 }
 
 // FindProfilesBySkillTag returns profiles whose skills JSON contains the given tag.

--- a/internal/db/quotas.go
+++ b/internal/db/quotas.go
@@ -61,6 +61,12 @@ func (d *DB) ListAgentQuotas(project string) ([]models.AgentQuota, error) {
 	return result, rows.Err()
 }
 
+// DeleteQuota removes a quota for an agent.
+func (d *DB) DeleteQuota(project, agentName string) error {
+	_, err := d.conn.Exec("DELETE FROM agent_quotas WHERE project = ? AND agent_name = ?", project, agentName)
+	return err
+}
+
 // CheckQuota checks if an agent has exceeded a specific quota type.
 // Returns (allowed, used, limit). If no quota is set, returns (true, 0, 0).
 func (d *DB) CheckQuota(project, agentName, quotaType string) (allowed bool, used, limit int64) {

--- a/internal/db/quotas.go
+++ b/internal/db/quotas.go
@@ -1,0 +1,164 @@
+package db
+
+import (
+	"agent-relay/internal/models"
+	"database/sql"
+	"fmt"
+	"time"
+)
+
+// SetAgentQuota creates or updates quota limits for an agent.
+func (d *DB) SetAgentQuota(project, agentName string, maxTokens, maxMessages, maxTasks, maxSpawns int64) error {
+	now := time.Now().UTC().Format(memoryTimeFmt)
+	_, err := d.conn.Exec(`INSERT INTO agent_quotas (project, agent_name, max_tokens_per_day, max_messages_per_hour, max_tasks_per_hour, max_spawns_per_hour, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(project, agent_name) DO UPDATE SET
+			max_tokens_per_day=excluded.max_tokens_per_day,
+			max_messages_per_hour=excluded.max_messages_per_hour,
+			max_tasks_per_hour=excluded.max_tasks_per_hour,
+			max_spawns_per_hour=excluded.max_spawns_per_hour,
+			updated_at=excluded.updated_at`,
+		project, agentName, maxTokens, maxMessages, maxTasks, maxSpawns, now, now)
+	return err
+}
+
+// GetAgentQuota returns the quota for an agent, or nil if none set.
+func (d *DB) GetAgentQuota(project, agentName string) (*models.AgentQuota, error) {
+	var q models.AgentQuota
+	err := d.ro().QueryRow(`SELECT project, agent_name, max_tokens_per_day, max_messages_per_hour,
+		max_tasks_per_hour, max_spawns_per_hour, created_at, updated_at
+		FROM agent_quotas WHERE project = ? AND agent_name = ?`, project, agentName).Scan(
+		&q.Project, &q.AgentName, &q.MaxTokensPerDay, &q.MaxMessagesPerHour,
+		&q.MaxTasksPerHour, &q.MaxSpawnsPerHour, &q.CreatedAt, &q.UpdatedAt)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &q, nil
+}
+
+// ListAgentQuotas returns all quotas for a project.
+func (d *DB) ListAgentQuotas(project string) ([]models.AgentQuota, error) {
+	rows, err := d.ro().Query(`SELECT project, agent_name, max_tokens_per_day, max_messages_per_hour,
+		max_tasks_per_hour, max_spawns_per_hour, created_at, updated_at
+		FROM agent_quotas WHERE project = ? ORDER BY agent_name`, project)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var result []models.AgentQuota
+	for rows.Next() {
+		var q models.AgentQuota
+		if err := rows.Scan(&q.Project, &q.AgentName, &q.MaxTokensPerDay, &q.MaxMessagesPerHour,
+			&q.MaxTasksPerHour, &q.MaxSpawnsPerHour, &q.CreatedAt, &q.UpdatedAt); err != nil {
+			continue
+		}
+		result = append(result, q)
+	}
+	return result, rows.Err()
+}
+
+// CheckQuota checks if an agent has exceeded a specific quota type.
+// Returns (allowed, used, limit). If no quota is set, returns (true, 0, 0).
+func (d *DB) CheckQuota(project, agentName, quotaType string) (allowed bool, used, limit int64) {
+	q, err := d.GetAgentQuota(project, agentName)
+	if err != nil || q == nil {
+		return true, 0, 0 // no quota = no limit
+	}
+
+	switch quotaType {
+	case "tokens":
+		if q.MaxTokensPerDay <= 0 {
+			return true, 0, 0
+		}
+		used = d.countTokenUsage24h(project, agentName)
+		return used < q.MaxTokensPerDay, used, q.MaxTokensPerDay
+
+	case "messages":
+		if q.MaxMessagesPerHour <= 0 {
+			return true, 0, 0
+		}
+		used = d.countMessages1h(project, agentName)
+		return used < q.MaxMessagesPerHour, used, q.MaxMessagesPerHour
+
+	case "tasks":
+		if q.MaxTasksPerHour <= 0 {
+			return true, 0, 0
+		}
+		used = d.countTasks1h(project, agentName)
+		return used < q.MaxTasksPerHour, used, q.MaxTasksPerHour
+
+	case "spawns":
+		if q.MaxSpawnsPerHour <= 0 {
+			return true, 0, 0
+		}
+		used = d.countSpawns1h(project, agentName)
+		return used < q.MaxSpawnsPerHour, used, q.MaxSpawnsPerHour
+
+	default:
+		return true, 0, 0
+	}
+}
+
+// GetQuotaUsage returns current usage for an agent across all quota types.
+func (d *DB) GetQuotaUsage(project, agentName string) (*models.QuotaUsage, error) {
+	q, err := d.GetAgentQuota(project, agentName)
+	if err != nil {
+		return nil, err
+	}
+	if q == nil {
+		q = &models.AgentQuota{Project: project, AgentName: agentName}
+	}
+
+	return &models.QuotaUsage{
+		AgentQuota:     *q,
+		TokensUsed24h:  d.countTokenUsage24h(project, agentName),
+		MessagesUsed1h: d.countMessages1h(project, agentName),
+		TasksUsed1h:    d.countTasks1h(project, agentName),
+		SpawnsUsed1h:   d.countSpawns1h(project, agentName),
+	}, nil
+}
+
+func (d *DB) countTokenUsage24h(project, agent string) int64 {
+	cutoff := time.Now().UTC().Add(-24 * time.Hour).Format(memoryTimeFmt)
+	var count int64
+	_ = d.ro().QueryRow(`SELECT COALESCE(SUM(bytes), 0) FROM token_usage WHERE project = ? AND agent = ? AND created_at > ?`,
+		project, agent, cutoff).Scan(&count)
+	return count
+}
+
+func (d *DB) countMessages1h(project, agent string) int64 {
+	cutoff := time.Now().UTC().Add(-1 * time.Hour).Format(memoryTimeFmt)
+	var count int64
+	_ = d.ro().QueryRow(`SELECT COUNT(*) FROM messages WHERE project = ? AND from_agent = ? AND created_at > ?`,
+		project, agent, cutoff).Scan(&count)
+	return count
+}
+
+func (d *DB) countTasks1h(project, agent string) int64 {
+	cutoff := time.Now().UTC().Add(-1 * time.Hour).Format(memoryTimeFmt)
+	var count int64
+	_ = d.ro().QueryRow(`SELECT COUNT(*) FROM tasks WHERE project = ? AND dispatched_by = ? AND dispatched_at > ?`,
+		project, agent, cutoff).Scan(&count)
+	return count
+}
+
+func (d *DB) countSpawns1h(project, agent string) int64 {
+	cutoff := time.Now().UTC().Add(-1 * time.Hour).Format(memoryTimeFmt)
+	var count int64
+	_ = d.ro().QueryRow(`SELECT COUNT(*) FROM spawn_children WHERE project = ? AND parent_agent = ? AND started_at > ?`,
+		project, agent, cutoff).Scan(&count)
+	return count
+}
+
+// checkQuotaError returns a formatted error string if quota exceeded, empty string if OK.
+func (d *DB) CheckQuotaError(project, agent, quotaType string) string {
+	allowed, used, limit := d.CheckQuota(project, agent, quotaType)
+	if allowed {
+		return ""
+	}
+	return fmt.Sprintf("quota exceeded: %s %d/%d for agent '%s'", quotaType, used, limit, agent)
+}

--- a/internal/db/schedules.go
+++ b/internal/db/schedules.go
@@ -1,0 +1,104 @@
+package db
+
+import (
+	"time"
+)
+
+// UpsertSchedule creates or updates a schedule.
+func (d *DB) UpsertSchedule(id, agentName, project, name, cronExpr, prompt, ttl, cycle, allowedTools string) {
+	now := time.Now().UTC().Format(time.RFC3339)
+	_, _ = d.conn.Exec(`INSERT INTO schedules (id, agent_name, project, name, cron_expr, prompt, ttl, cycle, allowed_tools, enabled, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 1, ?, ?)
+		ON CONFLICT(id) DO UPDATE SET cron_expr = ?, prompt = ?, ttl = ?, cycle = ?, allowed_tools = ?, enabled = 1, updated_at = ?`,
+		id, agentName, project, name, cronExpr, prompt, ttl, cycle, allowedTools, now, now,
+		cronExpr, prompt, ttl, cycle, allowedTools, now)
+}
+
+// DeleteSchedule removes a schedule.
+func (d *DB) DeleteSchedule(id string) {
+	_, _ = d.conn.Exec(`DELETE FROM schedules WHERE id = ?`, id)
+}
+
+// GetSchedule returns a single schedule by ID.
+func (d *DB) GetSchedule(id string) map[string]any {
+	var agentName, project, name, cronExpr, prompt, ttl, cycle, allowedTools, createdAt, updatedAt string
+	var enabled int
+	err := d.ro().QueryRow(`SELECT agent_name, project, name, cron_expr, prompt, ttl, cycle, allowed_tools, enabled, created_at, updated_at
+		FROM schedules WHERE id = ?`, id).Scan(&agentName, &project, &name, &cronExpr, &prompt, &ttl, &cycle, &allowedTools, &enabled, &createdAt, &updatedAt)
+	if err != nil {
+		return nil
+	}
+	return map[string]any{
+		"id":            id,
+		"agent_name":    agentName,
+		"project":       project,
+		"name":          name,
+		"cron_expr":     cronExpr,
+		"prompt":        prompt,
+		"ttl":           ttl,
+		"cycle":         cycle,
+		"allowed_tools": allowedTools,
+		"enabled":       enabled == 1,
+		"created_at":    createdAt,
+		"updated_at":    updatedAt,
+	}
+}
+
+// ListSchedulesByAgent returns schedules for an agent in a project.
+func (d *DB) ListSchedulesByAgent(project, agentName string) []map[string]any {
+	rows, err := d.ro().Query(`SELECT id, agent_name, project, name, cron_expr, prompt, ttl, cycle, allowed_tools, enabled, created_at, updated_at
+		FROM schedules WHERE project = ? AND agent_name = ? ORDER BY name`, project, agentName)
+	if err != nil {
+		return nil
+	}
+	defer rows.Close()
+	return scanScheduleRows(rows)
+}
+
+// ListSchedulesByProject returns all schedules for a project.
+func (d *DB) ListSchedulesByProject(project string) []map[string]any {
+	rows, err := d.ro().Query(`SELECT id, agent_name, project, name, cron_expr, prompt, ttl, cycle, allowed_tools, enabled, created_at, updated_at
+		FROM schedules WHERE project = ? ORDER BY agent_name, name`, project)
+	if err != nil {
+		return nil
+	}
+	defer rows.Close()
+	return scanScheduleRows(rows)
+}
+
+// ListAllEnabledSchedules returns all enabled schedules across all projects.
+func (d *DB) ListAllEnabledSchedules() []map[string]any {
+	rows, err := d.ro().Query(`SELECT id, agent_name, project, name, cron_expr, prompt, ttl, cycle, allowed_tools, enabled, created_at, updated_at
+		FROM schedules WHERE enabled = 1 ORDER BY project, agent_name, name`)
+	if err != nil {
+		return nil
+	}
+	defer rows.Close()
+	return scanScheduleRows(rows)
+}
+
+func scanScheduleRows(rows interface{ Next() bool; Scan(...any) error }) []map[string]any {
+	var result []map[string]any
+	for rows.Next() {
+		var id, agentName, project, name, cronExpr, prompt, ttl, cycle, allowedTools, createdAt, updatedAt string
+		var enabled int
+		if err := rows.Scan(&id, &agentName, &project, &name, &cronExpr, &prompt, &ttl, &cycle, &allowedTools, &enabled, &createdAt, &updatedAt); err != nil {
+			continue
+		}
+		result = append(result, map[string]any{
+			"id":            id,
+			"agent_name":    agentName,
+			"project":       project,
+			"name":          name,
+			"cron_expr":     cronExpr,
+			"prompt":        prompt,
+			"ttl":           ttl,
+			"cycle":         cycle,
+			"allowed_tools": allowedTools,
+			"enabled":       enabled == 1,
+			"created_at":    createdAt,
+			"updated_at":    updatedAt,
+		})
+	}
+	return result
+}

--- a/internal/db/schedules.go
+++ b/internal/db/schedules.go
@@ -77,7 +77,10 @@ func (d *DB) ListAllEnabledSchedules() []map[string]any {
 	return scanScheduleRows(rows)
 }
 
-func scanScheduleRows(rows interface{ Next() bool; Scan(...any) error }) []map[string]any {
+func scanScheduleRows(rows interface {
+	Next() bool
+	Scan(...any) error
+}) []map[string]any {
 	var result []map[string]any
 	for rows.Next() {
 		var id, agentName, project, name, cronExpr, prompt, ttl, cycle, allowedTools, createdAt, updatedAt string

--- a/internal/db/skills.go
+++ b/internal/db/skills.go
@@ -57,6 +57,19 @@ func (d *DB) ListSkills(project string) ([]models.Skill, error) {
 	return result, rows.Err()
 }
 
+// DeleteSkill removes a skill and its profile links.
+func (d *DB) DeleteSkill(project, name string) error {
+	// Get skill ID first
+	var id string
+	err := d.conn.QueryRow("SELECT id FROM skills WHERE project = ? AND name = ?", project, name).Scan(&id)
+	if err != nil {
+		return err
+	}
+	_, _ = d.conn.Exec("DELETE FROM profile_skills WHERE skill_id = ?", id)
+	_, err = d.conn.Exec("DELETE FROM skills WHERE id = ?", id)
+	return err
+}
+
 // LinkProfileSkill creates a link between a profile and a skill.
 func (d *DB) LinkProfileSkill(profileID, skillID, proficiency string) error {
 	if proficiency == "" {
@@ -65,6 +78,47 @@ func (d *DB) LinkProfileSkill(profileID, skillID, proficiency string) error {
 	_, err := d.conn.Exec(`INSERT OR REPLACE INTO profile_skills (profile_id, skill_id, proficiency) VALUES (?, ?, ?)`,
 		profileID, skillID, proficiency)
 	return err
+}
+
+// UnlinkProfileSkill removes the link between a profile and a skill.
+func (d *DB) UnlinkProfileSkill(profileID, skillID string) error {
+	_, err := d.conn.Exec(`DELETE FROM profile_skills WHERE profile_id = ? AND skill_id = ?`, profileID, skillID)
+	return err
+}
+
+// GetProfileSkillLinks returns all skills linked to a profile with proficiency info.
+func (d *DB) GetProfileSkillLinks(profileID string) ([]map[string]any, error) {
+	rows, err := d.ro().Query(
+		`SELECT s.id, s.name, s.description, COALESCE(ps.proficiency, 'capable')
+		 FROM skills s
+		 JOIN profile_skills ps ON ps.skill_id = s.id
+		 WHERE ps.profile_id = ?
+		 ORDER BY s.name`, profileID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var result []map[string]any
+	for rows.Next() {
+		var id, name, desc, prof string
+		if err := rows.Scan(&id, &name, &desc, &prof); err != nil {
+			continue
+		}
+		result = append(result, map[string]any{"id": id, "name": name, "description": desc, "proficiency": prof})
+	}
+	return result, rows.Err()
+}
+
+// GetSkillByName returns a skill by project + name.
+func (d *DB) GetSkillByName(project, name string) (*models.Skill, error) {
+	var s models.Skill
+	err := d.ro().QueryRow(`SELECT id, project, name, description, tags, created_at FROM skills WHERE project = ? AND name = ?`, project, name).
+		Scan(&s.ID, &s.Project, &s.Name, &s.Description, &s.Tags, &s.CreatedAt)
+	if err != nil {
+		return nil, err
+	}
+	return &s, nil
 }
 
 // FindProfilesBySkill returns profiles linked to a specific skill via the structured registry.

--- a/internal/db/skills.go
+++ b/internal/db/skills.go
@@ -1,0 +1,137 @@
+package db
+
+import (
+	"agent-relay/internal/models"
+	"database/sql"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// UpsertSkill creates or updates a skill in the catalog.
+func (d *DB) UpsertSkill(project, name, description, tags string) (*models.Skill, error) {
+	now := time.Now().UTC().Format(memoryTimeFmt)
+	if tags == "" {
+		tags = "[]"
+	}
+
+	var existingID string
+	err := d.conn.QueryRow(`SELECT id FROM skills WHERE project = ? AND name = ?`, project, name).Scan(&existingID)
+	if err == sql.ErrNoRows {
+		id := uuid.New().String()
+		_, err := d.conn.Exec(`INSERT INTO skills (id, project, name, description, tags, created_at) VALUES (?, ?, ?, ?, ?, ?)`,
+			id, project, name, description, tags, now)
+		if err != nil {
+			return nil, fmt.Errorf("insert skill: %w", err)
+		}
+		return &models.Skill{ID: id, Project: project, Name: name, Description: description, Tags: tags, CreatedAt: now}, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("check skill: %w", err)
+	}
+
+	_, err = d.conn.Exec(`UPDATE skills SET description=?, tags=? WHERE id=?`, description, tags, existingID)
+	if err != nil {
+		return nil, fmt.Errorf("update skill: %w", err)
+	}
+	return &models.Skill{ID: existingID, Project: project, Name: name, Description: description, Tags: tags, CreatedAt: now}, nil
+}
+
+// ListSkills returns all skills for a project.
+func (d *DB) ListSkills(project string) ([]models.Skill, error) {
+	rows, err := d.ro().Query(`SELECT id, project, name, description, tags, created_at FROM skills WHERE project = ? ORDER BY name`, project)
+	if err != nil {
+		return nil, fmt.Errorf("list skills: %w", err)
+	}
+	defer rows.Close()
+
+	var result []models.Skill
+	for rows.Next() {
+		var s models.Skill
+		if err := rows.Scan(&s.ID, &s.Project, &s.Name, &s.Description, &s.Tags, &s.CreatedAt); err != nil {
+			continue
+		}
+		result = append(result, s)
+	}
+	return result, rows.Err()
+}
+
+// LinkProfileSkill creates a link between a profile and a skill.
+func (d *DB) LinkProfileSkill(profileID, skillID, proficiency string) error {
+	if proficiency == "" {
+		proficiency = "capable"
+	}
+	_, err := d.conn.Exec(`INSERT OR REPLACE INTO profile_skills (profile_id, skill_id, proficiency) VALUES (?, ?, ?)`,
+		profileID, skillID, proficiency)
+	return err
+}
+
+// FindProfilesBySkill returns profiles linked to a specific skill via the structured registry.
+func (d *DB) FindProfilesBySkill(project, skillName string) ([]models.Profile, error) {
+	rows, err := d.ro().Query(
+		`SELECT `+profileColumns+` FROM profiles p
+		 JOIN profile_skills ps ON ps.profile_id = p.id
+		 JOIN skills s ON s.id = ps.skill_id
+		 WHERE p.project = ? AND s.name = ?
+		 ORDER BY CASE ps.proficiency WHEN 'expert' THEN 0 WHEN 'capable' THEN 1 ELSE 2 END, p.slug`,
+		project, skillName,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("find profiles by skill: %w", err)
+	}
+	defer rows.Close()
+
+	var profiles []models.Profile
+	for rows.Next() {
+		p, err := scanProfile(rows)
+		if err != nil {
+			continue
+		}
+		profiles = append(profiles, p)
+	}
+	return profiles, rows.Err()
+}
+
+// FindBestProfileForSkill returns the best profile for a skill (expert first, then capable).
+func (d *DB) FindBestProfileForSkill(project, skillName string) (*models.Profile, error) {
+	profiles, err := d.FindProfilesBySkill(project, skillName)
+	if err != nil {
+		return nil, err
+	}
+	if len(profiles) == 0 {
+		// Fallback to LIKE search on skills JSON
+		fallback, err := d.FindProfilesBySkillTag(project, skillName)
+		if err != nil || len(fallback) == 0 {
+			return nil, nil
+		}
+		return &fallback[0], nil
+	}
+	return &profiles[0], nil
+}
+
+// GetSkillProfileLinks returns profiles linked to a skill with proficiency info.
+func (d *DB) GetSkillProfileLinks(project, skillName string) ([]map[string]any, error) {
+	rows, err := d.ro().Query(
+		`SELECT p.slug, p.name, ps.proficiency FROM profiles p
+		 JOIN profile_skills ps ON ps.profile_id = p.id
+		 JOIN skills s ON s.id = ps.skill_id
+		 WHERE p.project = ? AND s.name = ?
+		 ORDER BY ps.proficiency, p.slug`,
+		project, skillName,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var result []map[string]any
+	for rows.Next() {
+		var slug, name, prof string
+		if err := rows.Scan(&slug, &name, &prof); err != nil {
+			continue
+		}
+		result = append(result, map[string]any{"slug": slug, "name": name, "proficiency": prof})
+	}
+	return result, rows.Err()
+}

--- a/internal/db/skills.go
+++ b/internal/db/skills.go
@@ -70,7 +70,9 @@ func (d *DB) LinkProfileSkill(profileID, skillID, proficiency string) error {
 // FindProfilesBySkill returns profiles linked to a specific skill via the structured registry.
 func (d *DB) FindProfilesBySkill(project, skillName string) ([]models.Profile, error) {
 	rows, err := d.ro().Query(
-		`SELECT `+profileColumns+` FROM profiles p
+		`SELECT p.id, p.slug, p.name, p.role, p.context_pack, p.soul_keys, p.skills, p.vault_paths,
+		 p.allowed_tools, p.pool_size, p.project, p.org_id, p.created_at, p.updated_at
+		 FROM profiles p
 		 JOIN profile_skills ps ON ps.profile_id = p.id
 		 JOIN skills s ON s.id = ps.skill_id
 		 WHERE p.project = ? AND s.name = ?

--- a/internal/db/spawn.go
+++ b/internal/db/spawn.go
@@ -1,0 +1,132 @@
+package db
+
+import (
+	"time"
+)
+
+// InsertSpawnChild records a spawned child in the database.
+func (d *DB) InsertSpawnChild(id, parentAgent, project, profile, prompt string) {
+	_, _ = d.conn.Exec(`INSERT INTO spawn_children (id, parent_agent, project, profile, prompt, status, started_at)
+		VALUES (?, ?, ?, ?, ?, 'running', ?)`,
+		id, parentAgent, project, profile, prompt, time.Now().UTC().Format(time.RFC3339))
+}
+
+// UpdateSpawnChild updates a child's status after completion.
+func (d *DB) UpdateSpawnChild(id, status string, exitCode int, errMsg string) {
+	_, _ = d.conn.Exec(`UPDATE spawn_children SET status = ?, exit_code = ?, error = ?, finished_at = ? WHERE id = ?`,
+		status, exitCode, errMsg, time.Now().UTC().Format(time.RFC3339), id)
+}
+
+// ListSpawnChildren returns children for a parent agent, optionally filtered by status.
+func (d *DB) ListSpawnChildren(parentAgent, project, status string) []map[string]any {
+	query := `SELECT id, parent_agent, project, profile, status, started_at, finished_at, exit_code, error
+		FROM spawn_children WHERE parent_agent = ? AND project = ?`
+	args := []any{parentAgent, project}
+
+	if status != "" && status != "all" {
+		query += " AND status = ?"
+		args = append(args, status)
+	}
+	query += " ORDER BY started_at DESC LIMIT 50"
+
+	rows, err := d.ro().Query(query, args...)
+	if err != nil {
+		return nil
+	}
+	defer rows.Close()
+
+	var result []map[string]any
+	for rows.Next() {
+		var id, parent, proj, prof, st, startedAt string
+		var finishedAt, errMsg *string
+		var exitCode *int
+		if err := rows.Scan(&id, &parent, &proj, &prof, &st, &startedAt, &finishedAt, &exitCode, &errMsg); err != nil {
+			continue
+		}
+		m := map[string]any{
+			"id":           id,
+			"parent_agent": parent,
+			"project":      proj,
+			"profile":      prof,
+			"status":       st,
+			"started_at":   startedAt,
+		}
+		if finishedAt != nil {
+			m["finished_at"] = *finishedAt
+		}
+		if exitCode != nil {
+			m["exit_code"] = *exitCode
+		}
+		if errMsg != nil && *errMsg != "" {
+			m["error"] = *errMsg
+		}
+		result = append(result, m)
+	}
+	return result
+}
+
+// GetSpawnChild returns a single child by ID.
+func (d *DB) GetSpawnChild(id string) map[string]any {
+	var parent, project, profile, status, startedAt string
+	var finishedAt, errMsg *string
+	var exitCode *int
+	err := d.ro().QueryRow(`SELECT parent_agent, project, profile, status, started_at, finished_at, exit_code, error
+		FROM spawn_children WHERE id = ?`, id).Scan(&parent, &project, &profile, &status, &startedAt, &finishedAt, &exitCode, &errMsg)
+	if err != nil {
+		return nil
+	}
+	m := map[string]any{
+		"id":           id,
+		"parent_agent": parent,
+		"project":      project,
+		"profile":      profile,
+		"status":       status,
+		"started_at":   startedAt,
+	}
+	if finishedAt != nil {
+		m["finished_at"] = *finishedAt
+	}
+	if exitCode != nil {
+		m["exit_code"] = *exitCode
+	}
+	if errMsg != nil && *errMsg != "" {
+		m["error"] = *errMsg
+	}
+	return m
+}
+
+// ListRunningChildren returns all children with status "running" across all agents/projects.
+func (d *DB) ListRunningChildren() []map[string]any {
+	rows, err := d.ro().Query(`SELECT id, parent_agent, project, profile, status, started_at, finished_at, exit_code, error
+		FROM spawn_children WHERE status = 'running' ORDER BY started_at`)
+	if err != nil {
+		return nil
+	}
+	defer rows.Close()
+
+	var result []map[string]any
+	for rows.Next() {
+		var id, parent, proj, prof, st, startedAt string
+		var finishedAt, errMsg *string
+		var exitCode *int
+		if err := rows.Scan(&id, &parent, &proj, &prof, &st, &startedAt, &finishedAt, &exitCode, &errMsg); err != nil {
+			continue
+		}
+		result = append(result, map[string]any{
+			"id":           id,
+			"parent_agent": parent,
+			"project":      proj,
+			"profile":      prof,
+			"status":       st,
+			"started_at":   startedAt,
+		})
+	}
+	return result
+}
+
+// GetActiveSpawnCount returns the number of running children for a project.
+func (d *DB) GetActiveSpawnCount(project string) int {
+	var count int
+	_ = d.ro().QueryRow(`SELECT COUNT(*) FROM spawn_children WHERE project = ? AND status = 'running'`, project).Scan(&count)
+	return count
+}

--- a/internal/db/triggers.go
+++ b/internal/db/triggers.go
@@ -1,0 +1,171 @@
+package db
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Trigger represents an event-driven spawn rule.
+type Trigger struct {
+	ID              string `json:"id"`
+	Project         string `json:"project"`
+	Event           string `json:"event"`        // task_pending, pr_opened, message_received
+	MatchRules      string `json:"match_rules"`  // JSON: {"profile": "backend-lead", "age": ">30s"}
+	ProfileSlug     string `json:"profile_slug"` // which profile to spawn
+	Cycle           string `json:"cycle"`        // which cycle to run
+	MaxDuration     string `json:"max_duration"`
+	Enabled         bool   `json:"enabled"`
+	CooldownSeconds int    `json:"cooldown_seconds"`
+	LastFiredAt     string `json:"last_fired_at,omitempty"`
+}
+
+// TriggerFire records a single trigger firing event.
+type TriggerFire struct {
+	ID        string `json:"id"`
+	TriggerID string `json:"trigger_id"`
+	Project   string `json:"project"`
+	Event     string `json:"event"`
+	ChildID   string `json:"child_id,omitempty"`
+	Error     string `json:"error,omitempty"`
+	FiredAt   string `json:"fired_at"`
+}
+
+// UpsertTrigger creates or updates a trigger.
+func (d *DB) UpsertTrigger(project, event, matchRules, profileSlug, cycle, maxDuration string) (*Trigger, error) {
+	now := time.Now().UTC().Format(memoryTimeFmt)
+	id := uuid.New().String()
+	if maxDuration == "" {
+		maxDuration = "10m"
+	}
+	if matchRules == "" {
+		matchRules = "{}"
+	}
+
+	_, err := d.conn.Exec(`
+		INSERT INTO triggers (id, project, event, match_rules, profile_slug, cycle, max_duration, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		id, project, event, matchRules, profileSlug, cycle, maxDuration, now, now)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Trigger{
+		ID:              id,
+		Project:         project,
+		Event:           event,
+		MatchRules:      matchRules,
+		ProfileSlug:     profileSlug,
+		Cycle:           cycle,
+		MaxDuration:     maxDuration,
+		Enabled:         true,
+		CooldownSeconds: 60,
+	}, nil
+}
+
+// ListTriggers returns all enabled triggers for a project and event type.
+func (d *DB) ListTriggers(project, event string) []Trigger {
+	query := `SELECT id, project, event, match_rules, profile_slug, cycle, max_duration, enabled,
+		COALESCE(cooldown_seconds, 60), COALESCE(last_fired_at, '')
+		FROM triggers WHERE project = ? AND enabled = 1`
+	args := []any{project}
+
+	if event != "" {
+		query += " AND event = ?"
+		args = append(args, event)
+	}
+	query += " ORDER BY created_at"
+
+	rows, err := d.ro().Query(query, args...)
+	if err != nil {
+		return nil
+	}
+	defer rows.Close()
+
+	var result []Trigger
+	for rows.Next() {
+		var t Trigger
+		if err := rows.Scan(&t.ID, &t.Project, &t.Event, &t.MatchRules, &t.ProfileSlug, &t.Cycle, &t.MaxDuration, &t.Enabled, &t.CooldownSeconds, &t.LastFiredAt); err != nil {
+			continue
+		}
+		result = append(result, t)
+	}
+	return result
+}
+
+// ListAllTriggers returns all triggers for a project (including disabled).
+func (d *DB) ListAllTriggers(project string) []Trigger {
+	rows, err := d.ro().Query(`SELECT id, project, event, match_rules, profile_slug, cycle, max_duration, enabled,
+		COALESCE(cooldown_seconds, 60), COALESCE(last_fired_at, '')
+		FROM triggers WHERE project = ? ORDER BY event, created_at`, project)
+	if err != nil {
+		return nil
+	}
+	defer rows.Close()
+
+	var result []Trigger
+	for rows.Next() {
+		var t Trigger
+		if err := rows.Scan(&t.ID, &t.Project, &t.Event, &t.MatchRules, &t.ProfileSlug, &t.Cycle, &t.MaxDuration, &t.Enabled, &t.CooldownSeconds, &t.LastFiredAt); err != nil {
+			continue
+		}
+		result = append(result, t)
+	}
+	return result
+}
+
+// DeleteTrigger removes a trigger by ID.
+func (d *DB) DeleteTrigger(id string) {
+	_, _ = d.conn.Exec("DELETE FROM triggers WHERE id = ?", id)
+}
+
+// ToggleTrigger enables or disables a trigger.
+func (d *DB) ToggleTrigger(id string, enabled bool) {
+	now := time.Now().UTC().Format(memoryTimeFmt)
+	e := 0
+	if enabled {
+		e = 1
+	}
+	_, _ = d.conn.Exec("UPDATE triggers SET enabled = ?, updated_at = ? WHERE id = ?", e, now, id)
+}
+
+// RecordTriggerFire logs a trigger firing event and updates last_fired_at.
+func (d *DB) RecordTriggerFire(triggerID, project, event, childID string, err error) {
+	now := time.Now().UTC().Format(memoryTimeFmt)
+	id := uuid.New().String()
+
+	errStr := ""
+	if err != nil {
+		errStr = err.Error()
+	}
+
+	_, _ = d.conn.Exec(`INSERT INTO trigger_history (id, trigger_id, project, event, child_id, error, fired_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?)`, id, triggerID, project, event, childID, errStr, now)
+
+	// Update last_fired_at on the trigger
+	_, _ = d.conn.Exec(`UPDATE triggers SET last_fired_at = ? WHERE id = ?`, now, triggerID)
+}
+
+// GetTriggerHistory returns recent trigger fire events for a project.
+func (d *DB) GetTriggerHistory(project string, limit int) []TriggerFire {
+	if limit <= 0 {
+		limit = 50
+	}
+
+	rows, err := d.ro().Query(`SELECT id, trigger_id, project, event, COALESCE(child_id, ''), COALESCE(error, ''), fired_at
+		FROM trigger_history WHERE project = ? ORDER BY fired_at DESC LIMIT ?`, project, limit)
+	if err != nil {
+		return nil
+	}
+	defer rows.Close()
+
+	var result []TriggerFire
+	for rows.Next() {
+		var f TriggerFire
+		if err := rows.Scan(&f.ID, &f.TriggerID, &f.Project, &f.Event, &f.ChildID, &f.Error, &f.FiredAt); err != nil {
+			continue
+		}
+		result = append(result, f)
+	}
+	return result
+}

--- a/internal/db/vault.go
+++ b/internal/db/vault.go
@@ -251,6 +251,44 @@ func (d *DB) GetVaultDocsByPaths(project string, patterns []string, maxTotalByte
 	return docs, nil
 }
 
+// GetVaultDocsIndex returns path + title only (no content) for matching patterns. Used for prompt injection.
+func (d *DB) GetVaultDocsIndex(project string, patterns []string) ([]models.VaultDocRef, error) {
+	if len(patterns) == 0 {
+		return nil, nil
+	}
+
+	var refs []models.VaultDocRef
+	for _, pattern := range patterns {
+		var rows *sql.Rows
+		var err error
+
+		if strings.Contains(pattern, "*") {
+			like := strings.ReplaceAll(pattern, "*", "%")
+			rows, err = d.ro().Query(
+				"SELECT path, title FROM vault_docs WHERE project = ? AND path LIKE ? ORDER BY path",
+				project, like,
+			)
+		} else {
+			rows, err = d.ro().Query(
+				"SELECT path, title FROM vault_docs WHERE project = ? AND path = ?",
+				project, pattern,
+			)
+		}
+		if err != nil {
+			continue
+		}
+		for rows.Next() {
+			var ref models.VaultDocRef
+			if err := rows.Scan(&ref.Path, &ref.Title); err != nil {
+				break
+			}
+			refs = append(refs, ref)
+		}
+		_ = rows.Close()
+	}
+	return refs, nil
+}
+
 // GetVaultDocsByTags returns vault docs where tags match any of the given tags.
 func (d *DB) GetVaultDocsByTags(project string, tags []string, maxTotalBytes int) ([]models.VaultDoc, error) {
 	if len(tags) == 0 {

--- a/internal/db/workflows.go
+++ b/internal/db/workflows.go
@@ -1,0 +1,304 @@
+package db
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Workflow represents a visual DAG workflow definition.
+type Workflow struct {
+	ID          string `json:"id"`
+	Project     string `json:"project"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Nodes       string `json:"nodes"`   // JSON array of node definitions
+	Edges       string `json:"edges"`   // JSON array of edge definitions
+	Enabled     bool   `json:"enabled"`
+	CreatedAt   string `json:"created_at"`
+	UpdatedAt   string `json:"updated_at"`
+}
+
+// WorkflowRun represents a single execution of a workflow.
+type WorkflowRun struct {
+	ID           string `json:"id"`
+	WorkflowID   string `json:"workflow_id"`
+	Project      string `json:"project"`
+	TriggerEvent string `json:"trigger_event,omitempty"`
+	TriggerMeta  string `json:"trigger_meta,omitempty"`
+	Status       string `json:"status"` // running, completed, failed, partial
+	StartedAt    string `json:"started_at"`
+	FinishedAt   string `json:"finished_at,omitempty"`
+	Error        string `json:"error,omitempty"`
+}
+
+// WorkflowNodeRun represents per-node execution within a workflow run.
+type WorkflowNodeRun struct {
+	ID         string `json:"id"`
+	RunID      string `json:"run_id"`
+	NodeID     string `json:"node_id"`
+	NodeType   string `json:"node_type"`
+	Status     string `json:"status"` // pending, running, completed, failed, skipped
+	Input      string `json:"input,omitempty"`
+	Output     string `json:"output,omitempty"`
+	StartedAt  string `json:"started_at,omitempty"`
+	FinishedAt string `json:"finished_at,omitempty"`
+	Error      string `json:"error,omitempty"`
+}
+
+// CreateWorkflow inserts a new workflow definition.
+func (d *DB) CreateWorkflow(project, name, description, nodesJSON, edgesJSON string) (*Workflow, error) {
+	now := time.Now().UTC().Format(memoryTimeFmt)
+	id := uuid.New().String()
+	if nodesJSON == "" {
+		nodesJSON = "[]"
+	}
+	if edgesJSON == "" {
+		edgesJSON = "[]"
+	}
+
+	_, err := d.conn.Exec(`
+		INSERT INTO workflows (id, project, name, description, nodes, edges, enabled, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, 1, ?, ?)`,
+		id, project, name, description, nodesJSON, edgesJSON, now, now)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Workflow{
+		ID:          id,
+		Project:     project,
+		Name:        name,
+		Description: description,
+		Nodes:       nodesJSON,
+		Edges:       edgesJSON,
+		Enabled:     true,
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}, nil
+}
+
+// UpdateWorkflow updates a workflow definition by ID.
+func (d *DB) UpdateWorkflow(id, name, description, nodesJSON, edgesJSON string) (*Workflow, error) {
+	now := time.Now().UTC().Format(memoryTimeFmt)
+
+	_, err := d.conn.Exec(`
+		UPDATE workflows SET name = ?, description = ?, nodes = ?, edges = ?, updated_at = ?
+		WHERE id = ?`,
+		name, description, nodesJSON, edgesJSON, now, id)
+	if err != nil {
+		return nil, err
+	}
+
+	return d.GetWorkflow(id)
+}
+
+// GetWorkflow returns a single workflow by ID.
+func (d *DB) GetWorkflow(id string) (*Workflow, error) {
+	row := d.ro().QueryRow(`SELECT id, project, name, COALESCE(description, ''), nodes, edges, enabled, created_at, updated_at
+		FROM workflows WHERE id = ?`, id)
+
+	var w Workflow
+	var enabled int
+	if err := row.Scan(&w.ID, &w.Project, &w.Name, &w.Description, &w.Nodes, &w.Edges, &enabled, &w.CreatedAt, &w.UpdatedAt); err != nil {
+		return nil, err
+	}
+	w.Enabled = enabled == 1
+	return &w, nil
+}
+
+// ListWorkflows returns all workflows for a project.
+func (d *DB) ListWorkflows(project string) ([]Workflow, error) {
+	rows, err := d.ro().Query(`SELECT id, project, name, COALESCE(description, ''), nodes, edges, enabled, created_at, updated_at
+		FROM workflows WHERE project = ? ORDER BY created_at`, project)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var result []Workflow
+	for rows.Next() {
+		var w Workflow
+		var enabled int
+		if err := rows.Scan(&w.ID, &w.Project, &w.Name, &w.Description, &w.Nodes, &w.Edges, &enabled, &w.CreatedAt, &w.UpdatedAt); err != nil {
+			continue
+		}
+		w.Enabled = enabled == 1
+		result = append(result, w)
+	}
+	return result, nil
+}
+
+// DeleteWorkflow removes a workflow and cascades to runs and node runs.
+func (d *DB) DeleteWorkflow(id string) error {
+	tx, err := d.conn.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	// Delete node runs for all runs of this workflow
+	_, err = tx.Exec(`DELETE FROM workflow_node_runs WHERE run_id IN (
+		SELECT id FROM workflow_runs WHERE workflow_id = ?)`, id)
+	if err != nil {
+		return err
+	}
+
+	// Delete runs
+	_, err = tx.Exec(`DELETE FROM workflow_runs WHERE workflow_id = ?`, id)
+	if err != nil {
+		return err
+	}
+
+	// Delete workflow
+	_, err = tx.Exec(`DELETE FROM workflows WHERE id = ?`, id)
+	if err != nil {
+		return err
+	}
+
+	return tx.Commit()
+}
+
+// ToggleWorkflow enables or disables a workflow.
+func (d *DB) ToggleWorkflow(id string, enabled bool) {
+	now := time.Now().UTC().Format(memoryTimeFmt)
+	e := 0
+	if enabled {
+		e = 1
+	}
+	_, _ = d.conn.Exec("UPDATE workflows SET enabled = ?, updated_at = ? WHERE id = ?", e, now, id)
+}
+
+// CreateWorkflowRun inserts a new workflow run.
+func (d *DB) CreateWorkflowRun(workflowID, project, triggerEvent, triggerMeta string) (*WorkflowRun, error) {
+	now := time.Now().UTC().Format(memoryTimeFmt)
+	id := uuid.New().String()
+	if triggerMeta == "" {
+		triggerMeta = "{}"
+	}
+
+	_, err := d.conn.Exec(`
+		INSERT INTO workflow_runs (id, workflow_id, project, trigger_event, trigger_meta, status, started_at)
+		VALUES (?, ?, ?, ?, ?, 'running', ?)`,
+		id, workflowID, project, triggerEvent, triggerMeta, now)
+	if err != nil {
+		return nil, err
+	}
+
+	return &WorkflowRun{
+		ID:           id,
+		WorkflowID:   workflowID,
+		Project:      project,
+		TriggerEvent: triggerEvent,
+		TriggerMeta:  triggerMeta,
+		Status:       "running",
+		StartedAt:    now,
+	}, nil
+}
+
+// FinishWorkflowRun marks a workflow run as finished with status and optional error.
+func (d *DB) FinishWorkflowRun(id, status, errMsg string) {
+	now := time.Now().UTC().Format(memoryTimeFmt)
+	_, _ = d.conn.Exec(`UPDATE workflow_runs SET status = ?, finished_at = ?, error = ? WHERE id = ?`,
+		status, now, errMsg, id)
+}
+
+// ListWorkflowRuns returns recent runs for a workflow.
+func (d *DB) ListWorkflowRuns(workflowID string, limit int) ([]WorkflowRun, error) {
+	if limit <= 0 {
+		limit = 50
+	}
+
+	rows, err := d.ro().Query(`SELECT id, workflow_id, project, COALESCE(trigger_event, ''), COALESCE(trigger_meta, '{}'),
+		status, started_at, COALESCE(finished_at, ''), COALESCE(error, '')
+		FROM workflow_runs WHERE workflow_id = ? ORDER BY started_at DESC LIMIT ?`, workflowID, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var result []WorkflowRun
+	for rows.Next() {
+		var r WorkflowRun
+		if err := rows.Scan(&r.ID, &r.WorkflowID, &r.Project, &r.TriggerEvent, &r.TriggerMeta, &r.Status, &r.StartedAt, &r.FinishedAt, &r.Error); err != nil {
+			continue
+		}
+		result = append(result, r)
+	}
+	return result, nil
+}
+
+// GetWorkflowRun returns a single workflow run by ID.
+func (d *DB) GetWorkflowRun(id string) (*WorkflowRun, error) {
+	row := d.ro().QueryRow(`SELECT id, workflow_id, project, COALESCE(trigger_event, ''), COALESCE(trigger_meta, '{}'),
+		status, started_at, COALESCE(finished_at, ''), COALESCE(error, '')
+		FROM workflow_runs WHERE id = ?`, id)
+
+	var r WorkflowRun
+	if err := row.Scan(&r.ID, &r.WorkflowID, &r.Project, &r.TriggerEvent, &r.TriggerMeta, &r.Status, &r.StartedAt, &r.FinishedAt, &r.Error); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+// CreateNodeRun inserts a new workflow node run with status=pending.
+func (d *DB) CreateNodeRun(runID, nodeID, nodeType string) (*WorkflowNodeRun, error) {
+	id := uuid.New().String()
+
+	_, err := d.conn.Exec(`
+		INSERT INTO workflow_node_runs (id, run_id, node_id, node_type, status, input, output)
+		VALUES (?, ?, ?, ?, 'pending', '{}', '{}')`,
+		id, runID, nodeID, nodeType)
+	if err != nil {
+		return nil, err
+	}
+
+	return &WorkflowNodeRun{
+		ID:       id,
+		RunID:    runID,
+		NodeID:   nodeID,
+		NodeType: nodeType,
+		Status:   "pending",
+		Input:    "{}",
+		Output:   "{}",
+	}, nil
+}
+
+// UpdateNodeRun updates a node run's status, output, error, and timestamps.
+func (d *DB) UpdateNodeRun(id, status, outputJSON, errMsg string) {
+	now := time.Now().UTC().Format(memoryTimeFmt)
+
+	switch status {
+	case "running":
+		_, _ = d.conn.Exec(`UPDATE workflow_node_runs SET status = ?, started_at = ? WHERE id = ?`,
+			status, now, id)
+	case "completed", "failed", "skipped":
+		_, _ = d.conn.Exec(`UPDATE workflow_node_runs SET status = ?, output = ?, error = ?, finished_at = ? WHERE id = ?`,
+			status, outputJSON, errMsg, now, id)
+	default:
+		_, _ = d.conn.Exec(`UPDATE workflow_node_runs SET status = ?, output = ?, error = ? WHERE id = ?`,
+			status, outputJSON, errMsg, id)
+	}
+}
+
+// ListNodeRuns returns all node runs for a workflow run.
+func (d *DB) ListNodeRuns(runID string) ([]WorkflowNodeRun, error) {
+	rows, err := d.ro().Query(`SELECT id, run_id, node_id, node_type, status,
+		COALESCE(input, '{}'), COALESCE(output, '{}'),
+		COALESCE(started_at, ''), COALESCE(finished_at, ''), COALESCE(error, '')
+		FROM workflow_node_runs WHERE run_id = ? ORDER BY started_at NULLS LAST`, runID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var result []WorkflowNodeRun
+	for rows.Next() {
+		var n WorkflowNodeRun
+		if err := rows.Scan(&n.ID, &n.RunID, &n.NodeID, &n.NodeType, &n.Status, &n.Input, &n.Output, &n.StartedAt, &n.FinishedAt, &n.Error); err != nil {
+			continue
+		}
+		result = append(result, n)
+	}
+	return result, nil
+}

--- a/internal/db/workflows.go
+++ b/internal/db/workflows.go
@@ -12,8 +12,8 @@ type Workflow struct {
 	Project     string `json:"project"`
 	Name        string `json:"name"`
 	Description string `json:"description"`
-	Nodes       string `json:"nodes"`   // JSON array of node definitions
-	Edges       string `json:"edges"`   // JSON array of edge definitions
+	Nodes       string `json:"nodes"` // JSON array of node definitions
+	Edges       string `json:"edges"` // JSON array of edge definitions
 	Enabled     bool   `json:"enabled"`
 	CreatedAt   string `json:"created_at"`
 	UpdatedAt   string `json:"updated_at"`

--- a/internal/lock/lock.go
+++ b/internal/lock/lock.go
@@ -1,0 +1,165 @@
+package lock
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+)
+
+// Lock represents a file-based lock with flock.
+type Lock struct {
+	Path      string
+	AgentName string
+	file      *os.File
+}
+
+// LockInfo stores metadata written inside the lock file.
+type LockInfo struct {
+	PID       int
+	Timestamp time.Time
+	Cycle     string
+	TTL       time.Duration
+}
+
+// Manager handles lock acquisition and release.
+type Manager struct {
+	Dir    string
+	Prefix string
+	Logger *slog.Logger
+}
+
+// NewManager creates a new lock manager.
+func NewManager(dir, prefix string, logger *slog.Logger) *Manager {
+	return &Manager{
+		Dir:    dir,
+		Prefix: prefix,
+		Logger: logger,
+	}
+}
+
+// lockPath returns the lock file path for an agent.
+func (m *Manager) lockPath(agent string) string {
+	return filepath.Join(m.Dir, fmt.Sprintf("%s%s.lock", m.Prefix, agent))
+}
+
+// Acquire tries to get an exclusive lock for the agent.
+// Returns the Lock on success, nil if already locked.
+func (m *Manager) Acquire(agent, cycle string, ttl time.Duration) (*Lock, error) {
+	path := m.lockPath(agent)
+
+	// Check if existing lock is expired
+	if info, err := m.ReadInfo(agent); err == nil {
+		if time.Since(info.Timestamp) > info.TTL {
+			m.Logger.Warn("stale lock detected, removing",
+				"agent", agent,
+				"age", time.Since(info.Timestamp),
+				"ttl", info.TTL,
+			)
+			os.Remove(path)
+		}
+	}
+
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0644)
+	if err != nil {
+		return nil, fmt.Errorf("opening lock file: %w", err)
+	}
+
+	// Try non-blocking flock
+	err = syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
+	if err != nil {
+		f.Close()
+		return nil, nil // Already locked
+	}
+
+	// Write lock info
+	info := fmt.Sprintf("%d\n%s\n%s\n%s",
+		os.Getpid(),
+		time.Now().UTC().Format(time.RFC3339),
+		cycle,
+		ttl.String(),
+	)
+	_ = f.Truncate(0)
+	_, _ = f.Seek(0, 0)
+	_, _ = f.WriteString(info)
+	_ = f.Sync()
+
+	m.Logger.Info("lock acquired", "agent", agent, "cycle", cycle)
+
+	return &Lock{
+		Path:      path,
+		AgentName: agent,
+		file:      f,
+	}, nil
+}
+
+// Release releases the lock.
+func (l *Lock) Release() error {
+	if l.file == nil {
+		return nil
+	}
+	_ = syscall.Flock(int(l.file.Fd()), syscall.LOCK_UN)
+	l.file.Close()
+	os.Remove(l.Path)
+	return nil
+}
+
+// IsLocked checks if an agent currently has a lock.
+func (m *Manager) IsLocked(agent string) bool {
+	path := m.lockPath(agent)
+
+	f, err := os.OpenFile(path, os.O_RDWR, 0644)
+	if err != nil {
+		return false
+	}
+	defer f.Close()
+
+	err = syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
+	if err != nil {
+		return true // Can't acquire = someone else holds it
+	}
+
+	// We got it, release immediately
+	_ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+	return false
+}
+
+// ReadInfo reads the lock file metadata.
+func (m *Manager) ReadInfo(agent string) (*LockInfo, error) {
+	path := m.lockPath(agent)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	if len(lines) < 4 {
+		return nil, fmt.Errorf("invalid lock file format")
+	}
+
+	pid, err := strconv.Atoi(lines[0])
+	if err != nil {
+		return nil, fmt.Errorf("invalid PID in lock: %w", err)
+	}
+
+	ts, err := time.Parse(time.RFC3339, lines[1])
+	if err != nil {
+		return nil, fmt.Errorf("invalid timestamp in lock: %w", err)
+	}
+
+	ttl, err := time.ParseDuration(lines[3])
+	if err != nil {
+		return nil, fmt.Errorf("invalid TTL in lock: %w", err)
+	}
+
+	return &LockInfo{
+		PID:       pid,
+		Timestamp: ts,
+		Cycle:     lines[2],
+		TTL:       ttl,
+	}, nil
+}

--- a/internal/lock/queue.go
+++ b/internal/lock/queue.go
@@ -1,0 +1,57 @@
+package lock
+
+import (
+	"log/slog"
+	"sync"
+)
+
+// PriorityQueue manages pending cycles per agent.
+// Only one cycle can be queued per agent (latest wins).
+type PriorityQueue struct {
+	mu      sync.Mutex
+	pending map[string]string // agent -> pending cycle name
+	logger  *slog.Logger
+}
+
+// NewPriorityQueue creates a new priority queue.
+func NewPriorityQueue(logger *slog.Logger) *PriorityQueue {
+	return &PriorityQueue{
+		pending: make(map[string]string),
+		logger:  logger,
+	}
+}
+
+// Enqueue adds a cycle to the queue. Replaces any existing pending cycle.
+func (q *PriorityQueue) Enqueue(agent string, cycle string) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	if existing, ok := q.pending[agent]; ok {
+		q.logger.Info("cycle replaced in queue",
+			"agent", agent,
+			"new", cycle,
+			"replaced", existing,
+		)
+	}
+	q.pending[agent] = cycle
+	q.logger.Info("cycle queued", "agent", agent, "cycle", cycle)
+}
+
+// Dequeue returns and removes the next pending cycle for the agent.
+func (q *PriorityQueue) Dequeue(agent string) (string, bool) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	cycle, ok := q.pending[agent]
+	if ok {
+		delete(q.pending, agent)
+	}
+	return cycle, ok
+}
+
+// Clear removes all pending cycles for an agent.
+func (q *PriorityQueue) Clear(agent string) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	delete(q.pending, agent)
+}

--- a/internal/models/cycle.go
+++ b/internal/models/cycle.go
@@ -1,0 +1,12 @@
+package models
+
+// Cycle defines a reusable execution template for agent spawns.
+type Cycle struct {
+	ID        string `json:"id"`
+	Project   string `json:"project"`
+	Name      string `json:"name"`
+	Prompt    string `json:"prompt"`
+	TTL       int    `json:"ttl"` // minutes
+	CreatedAt string `json:"created_at"`
+	UpdatedAt string `json:"updated_at"`
+}

--- a/internal/models/elevation.go
+++ b/internal/models/elevation.go
@@ -1,0 +1,14 @@
+package models
+
+// Elevation represents a temporary privilege escalation for an agent.
+type Elevation struct {
+	ID           string  `json:"id"`
+	Project      string  `json:"project"`
+	AgentName    string  `json:"agent_name"`
+	ElevatedRole string  `json:"elevated_role"` // admin, lead
+	GrantedBy    string  `json:"granted_by"`
+	Reason       string  `json:"reason"`
+	ExpiresAt    string  `json:"expires_at"`
+	RevokedAt    *string `json:"revoked_at,omitempty"`
+	CreatedAt    string  `json:"created_at"`
+}

--- a/internal/models/poll_trigger.go
+++ b/internal/models/poll_trigger.go
@@ -6,13 +6,13 @@ type PollTrigger struct {
 	Project         string `json:"project"`
 	Name            string `json:"name"`
 	URL             string `json:"url"`
-	Headers         string `json:"headers"`          // JSON: {"Authorization": "Bearer ..."}
-	ConditionPath   string `json:"condition_path"`   // dot-notation: "workflow_runs.0.conclusion"
-	ConditionOp     string `json:"condition_op"`     // eq, neq, contains, gt, lt
-	ConditionValue  string `json:"condition_value"`  // "success"
-	PollInterval    string `json:"poll_interval"`    // "2m", "5m", "1h"
-	FireEvent       string `json:"fire_event"`       // event name to fire when condition met
-	FireMeta        string `json:"fire_meta"`        // JSON: extra metadata
+	Headers         string `json:"headers"`         // JSON: {"Authorization": "Bearer ..."}
+	ConditionPath   string `json:"condition_path"`  // dot-notation: "workflow_runs.0.conclusion"
+	ConditionOp     string `json:"condition_op"`    // eq, neq, contains, gt, lt
+	ConditionValue  string `json:"condition_value"` // "success"
+	PollInterval    string `json:"poll_interval"`   // "2m", "5m", "1h"
+	FireEvent       string `json:"fire_event"`      // event name to fire when condition met
+	FireMeta        string `json:"fire_meta"`       // JSON: extra metadata
 	Enabled         bool   `json:"enabled"`
 	LastPolledAt    string `json:"last_polled_at,omitempty"`
 	LastResult      string `json:"last_result,omitempty"`

--- a/internal/models/poll_trigger.go
+++ b/internal/models/poll_trigger.go
@@ -1,0 +1,22 @@
+package models
+
+// PollTrigger defines a URL to check periodically and fire events when conditions match.
+type PollTrigger struct {
+	ID              string `json:"id"`
+	Project         string `json:"project"`
+	Name            string `json:"name"`
+	URL             string `json:"url"`
+	Headers         string `json:"headers"`          // JSON: {"Authorization": "Bearer ..."}
+	ConditionPath   string `json:"condition_path"`   // dot-notation: "workflow_runs.0.conclusion"
+	ConditionOp     string `json:"condition_op"`     // eq, neq, contains, gt, lt
+	ConditionValue  string `json:"condition_value"`  // "success"
+	PollInterval    string `json:"poll_interval"`    // "2m", "5m", "1h"
+	FireEvent       string `json:"fire_event"`       // event name to fire when condition met
+	FireMeta        string `json:"fire_meta"`        // JSON: extra metadata
+	Enabled         bool   `json:"enabled"`
+	LastPolledAt    string `json:"last_polled_at,omitempty"`
+	LastResult      string `json:"last_result,omitempty"`
+	LastMatched     bool   `json:"last_matched"`
+	CooldownSeconds int    `json:"cooldown_seconds"`
+	CreatedAt       string `json:"created_at"`
+}

--- a/internal/models/profile.go
+++ b/internal/models/profile.go
@@ -6,11 +6,11 @@ type Profile struct {
 	Name         string  `json:"name"`
 	Role         string  `json:"role"`
 	ContextPack  string  `json:"context_pack"`
-	SoulKeys     string  `json:"soul_keys"`      // JSON array
-	Skills       string  `json:"skills"`          // JSON array of skill objects
-	VaultPaths   string  `json:"vault_paths"`     // JSON array of glob patterns
-	AllowedTools string  `json:"allowed_tools"`   // JSON array of tool patterns
-	PoolSize     int     `json:"pool_size"`        // Max concurrent spawns for this profile
+	SoulKeys     string  `json:"soul_keys"`     // JSON array
+	Skills       string  `json:"skills"`        // JSON array of skill objects
+	VaultPaths   string  `json:"vault_paths"`   // JSON array of glob patterns
+	AllowedTools string  `json:"allowed_tools"` // JSON array of tool patterns
+	PoolSize     int     `json:"pool_size"`     // Max concurrent spawns for this profile
 	Project      string  `json:"project"`
 	OrgID        *string `json:"org_id,omitempty"`
 	CreatedAt    string  `json:"created_at"`

--- a/internal/models/profile.go
+++ b/internal/models/profile.go
@@ -1,16 +1,18 @@
 package models
 
 type Profile struct {
-	ID          string  `json:"id"`
-	Slug        string  `json:"slug"`
-	Name        string  `json:"name"`
-	Role        string  `json:"role"`
-	ContextPack string  `json:"context_pack"`
-	SoulKeys    string  `json:"soul_keys"`   // JSON array
-	Skills      string  `json:"skills"`      // JSON array of skill objects
-	VaultPaths  string  `json:"vault_paths"` // JSON array of glob patterns
-	Project     string  `json:"project"`
-	OrgID       *string `json:"org_id,omitempty"`
-	CreatedAt   string  `json:"created_at"`
-	UpdatedAt   string  `json:"updated_at"`
+	ID           string  `json:"id"`
+	Slug         string  `json:"slug"`
+	Name         string  `json:"name"`
+	Role         string  `json:"role"`
+	ContextPack  string  `json:"context_pack"`
+	SoulKeys     string  `json:"soul_keys"`      // JSON array
+	Skills       string  `json:"skills"`          // JSON array of skill objects
+	VaultPaths   string  `json:"vault_paths"`     // JSON array of glob patterns
+	AllowedTools string  `json:"allowed_tools"`   // JSON array of tool patterns
+	PoolSize     int     `json:"pool_size"`        // Max concurrent spawns for this profile
+	Project      string  `json:"project"`
+	OrgID        *string `json:"org_id,omitempty"`
+	CreatedAt    string  `json:"created_at"`
+	UpdatedAt    string  `json:"updated_at"`
 }

--- a/internal/models/quota.go
+++ b/internal/models/quota.go
@@ -1,0 +1,22 @@
+package models
+
+// AgentQuota defines rate limits for an agent within a project.
+type AgentQuota struct {
+	Project            string `json:"project"`
+	AgentName          string `json:"agent_name"`
+	MaxTokensPerDay    int64  `json:"max_tokens_per_day"`
+	MaxMessagesPerHour int64  `json:"max_messages_per_hour"`
+	MaxTasksPerHour    int64  `json:"max_tasks_per_hour"`
+	MaxSpawnsPerHour   int64  `json:"max_spawns_per_hour"`
+	CreatedAt          string `json:"created_at"`
+	UpdatedAt          string `json:"updated_at"`
+}
+
+// QuotaUsage shows current usage against limits for an agent.
+type QuotaUsage struct {
+	AgentQuota
+	TokensUsed24h  int64 `json:"tokens_used_24h"`
+	MessagesUsed1h int64 `json:"messages_used_1h"`
+	TasksUsed1h    int64 `json:"tasks_used_1h"`
+	SpawnsUsed1h   int64 `json:"spawns_used_1h"`
+}

--- a/internal/models/skill.go
+++ b/internal/models/skill.go
@@ -1,0 +1,18 @@
+package models
+
+// Skill is a structured capability in the skill catalog.
+type Skill struct {
+	ID          string `json:"id"`
+	Project     string `json:"project"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Tags        string `json:"tags"` // JSON array
+	CreatedAt   string `json:"created_at"`
+}
+
+// ProfileSkill links a profile to a skill with a proficiency level.
+type ProfileSkill struct {
+	ProfileID   string `json:"profile_id"`
+	SkillID     string `json:"skill_id"`
+	Proficiency string `json:"proficiency"` // capable, expert, learning
+}

--- a/internal/models/vault.go
+++ b/internal/models/vault.go
@@ -13,6 +13,12 @@ type VaultDoc struct {
 	IndexedAt string `json:"indexed_at"`
 }
 
+// VaultDocRef is a lightweight reference (no content) for prompt index injection.
+type VaultDocRef struct {
+	Path  string `json:"path"`
+	Title string `json:"title"`
+}
+
 type VaultSearchResult struct {
 	Path    string  `json:"path"`
 	Title   string  `json:"title"`

--- a/internal/relay/api.go
+++ b/internal/relay/api.go
@@ -161,6 +161,81 @@ func (r *Relay) ServeAPI(w http.ResponseWriter, req *http.Request) {
 		r.apiGetTokenUsageByAgent(w, req)
 	case path == "/token-usage/timeseries" && req.Method == http.MethodGet:
 		r.apiGetTokenTimeSeries(w, req)
+	// Spawn endpoints
+	case path == "/spawn/children" && req.Method == http.MethodGet:
+		r.apiGetSpawnChildren(w, req)
+	case path == "/spawn/children" && req.Method == http.MethodPost:
+		r.apiSpawnChild(w, req)
+	case strings.HasPrefix(path, "/spawn/children/") && strings.HasSuffix(path, "/kill") && req.Method == http.MethodPost:
+		r.apiKillSpawnChild(w, path)
+	case strings.HasPrefix(path, "/spawn/children/") && req.Method == http.MethodGet:
+		r.apiGetSpawnChild(w, path)
+	// Schedule endpoints
+	case path == "/schedules" && req.Method == http.MethodGet:
+		r.apiGetSchedules(w, req)
+	case path == "/schedules" && req.Method == http.MethodPost:
+		r.apiCreateSchedule(w, req)
+	case strings.HasPrefix(path, "/schedules/") && strings.HasSuffix(path, "/trigger") && req.Method == http.MethodPost:
+		r.apiTriggerSchedule(w, path)
+	case strings.HasPrefix(path, "/schedules/") && req.Method == http.MethodPut:
+		r.apiUpdateSchedule(w, req, path)
+	case strings.HasPrefix(path, "/schedules/") && req.Method == http.MethodGet:
+		r.apiGetSchedule(w, path)
+	case strings.HasPrefix(path, "/schedules/") && req.Method == http.MethodDelete:
+		r.apiDeleteSchedule(w, path)
+	// Cycle history
+	case path == "/cycle-history" && req.Method == http.MethodGet:
+		r.apiGetCycleHistory(w, req)
+	// Triggers (event-driven spawn rules)
+	case path == "/triggers" && req.Method == http.MethodGet:
+		r.apiGetTriggers(w, req)
+	case path == "/triggers" && req.Method == http.MethodPost:
+		r.apiCreateTrigger(w, req)
+	case strings.HasPrefix(path, "/triggers/") && req.Method == http.MethodDelete:
+		r.apiDeleteTrigger(w, path)
+	// Agent OS spawn (profile + cycle)
+	case path == "/spawn/context" && req.Method == http.MethodPost:
+		r.apiSpawnWithContext(w, req)
+	// Trigger history + webhooks + signal handlers
+	case path == "/trigger-history" && req.Method == http.MethodGet:
+		r.apiGetTriggerHistory(w, req)
+	case strings.HasPrefix(path, "/webhooks/") && req.Method == http.MethodPost:
+		r.apiWebhook(w, req, path)
+	case path == "/signal-handlers" && req.Method == http.MethodPost:
+		r.apiCreateSignalHandler(w, req)
+	// Poll triggers (external URL monitoring)
+	case path == "/poll-triggers" && req.Method == http.MethodGet:
+		r.apiGetPollTriggers(w, req)
+	case path == "/poll-triggers" && req.Method == http.MethodPost:
+		r.apiCreatePollTrigger(w, req)
+	case strings.HasPrefix(path, "/poll-triggers/") && strings.HasSuffix(path, "/test") && req.Method == http.MethodPost:
+		r.apiTestPollTrigger(w, path)
+	case strings.HasPrefix(path, "/poll-triggers/") && req.Method == http.MethodDelete:
+		r.apiDeletePollTrigger(w, path)
+	// Skill registry
+	case path == "/skills" && req.Method == http.MethodGet:
+		r.apiGetSkills(w, req)
+	case path == "/skills" && req.Method == http.MethodPost:
+		r.apiCreateSkill(w, req)
+	case strings.HasPrefix(path, "/skills/") && strings.HasSuffix(path, "/profiles") && req.Method == http.MethodGet:
+		r.apiGetSkillProfiles(w, req, path)
+	// Service discovery
+	case path == "/discover" && req.Method == http.MethodGet:
+		r.apiDiscover(w, req)
+	// Per-agent quotas
+	case path == "/quotas" && req.Method == http.MethodGet:
+		r.apiGetQuotas(w, req)
+	case strings.HasPrefix(path, "/quotas/") && req.Method == http.MethodGet:
+		r.apiGetAgentQuota(w, req, path)
+	case strings.HasPrefix(path, "/quotas/") && req.Method == http.MethodPut:
+		r.apiSetAgentQuota(w, req, path)
+	// Privilege escalation
+	case path == "/elevations" && req.Method == http.MethodGet:
+		r.apiGetElevations(w, req)
+	case path == "/elevations" && req.Method == http.MethodPost:
+		r.apiGrantElevation(w, req)
+	case strings.HasPrefix(path, "/elevations/") && req.Method == http.MethodDelete:
+		r.apiRevokeElevation(w, path)
 	default:
 		http.Error(w, `{"error":"not found"}`, http.StatusNotFound)
 	}

--- a/internal/relay/api.go
+++ b/internal/relay/api.go
@@ -107,9 +107,18 @@ func (r *Relay) ServeAPI(w http.ResponseWriter, req *http.Request) {
 		r.apiDeleteTask(w, req, path)
 	case strings.HasPrefix(path, "/tasks/") && req.Method == http.MethodGet:
 		r.apiGetTask(w, req, path)
+	// Agent management
+	case strings.HasPrefix(path, "/agents/") && req.Method == http.MethodDelete:
+		r.apiDeactivateAgent(w, req, path)
 	// Profile endpoints
 	case path == "/profiles" && req.Method == http.MethodGet:
 		r.apiGetProfiles(w, req)
+	case path == "/profiles" && req.Method == http.MethodPost:
+		r.apiCreateProfile(w, req)
+	case strings.HasPrefix(path, "/profiles/") && req.Method == http.MethodPut:
+		r.apiUpdateProfile(w, req, path)
+	case strings.HasPrefix(path, "/profiles/") && req.Method == http.MethodDelete:
+		r.apiDeleteProfile(w, req, path)
 	case strings.HasPrefix(path, "/profiles/") && req.Method == http.MethodGet:
 		r.apiGetProfile(w, req, path)
 	// Org + Team endpoints
@@ -170,6 +179,13 @@ func (r *Relay) ServeAPI(w http.ResponseWriter, req *http.Request) {
 		r.apiKillSpawnChild(w, path)
 	case strings.HasPrefix(path, "/spawn/children/") && req.Method == http.MethodGet:
 		r.apiGetSpawnChild(w, path)
+	// Terminal (PTY) endpoints
+	case path == "/terminal/spawn" && req.Method == http.MethodPost:
+		r.apiTerminalSpawn(w, req)
+	case strings.HasPrefix(path, "/terminal/ws/") && req.Method == http.MethodGet:
+		r.apiTerminalWS(w, req, path)
+	case strings.HasPrefix(path, "/terminal/") && strings.HasSuffix(path, "/kill") && req.Method == http.MethodPost:
+		r.apiTerminalKill(w, path)
 	// Schedule endpoints
 	case path == "/schedules" && req.Method == http.MethodGet:
 		r.apiGetSchedules(w, req)
@@ -219,6 +235,8 @@ func (r *Relay) ServeAPI(w http.ResponseWriter, req *http.Request) {
 		r.apiCreateSkill(w, req)
 	case strings.HasPrefix(path, "/skills/") && strings.HasSuffix(path, "/profiles") && req.Method == http.MethodGet:
 		r.apiGetSkillProfiles(w, req, path)
+	case strings.HasPrefix(path, "/skills/") && req.Method == http.MethodDelete:
+		r.apiDeleteSkill(w, req, path)
 	// Service discovery
 	case path == "/discover" && req.Method == http.MethodGet:
 		r.apiDiscover(w, req)
@@ -229,6 +247,19 @@ func (r *Relay) ServeAPI(w http.ResponseWriter, req *http.Request) {
 		r.apiGetAgentQuota(w, req, path)
 	case strings.HasPrefix(path, "/quotas/") && req.Method == http.MethodPut:
 		r.apiSetAgentQuota(w, req, path)
+	case strings.HasPrefix(path, "/quotas/") && req.Method == http.MethodDelete:
+		r.apiDeleteQuota(w, req, path)
+	// Cycles CRUD
+	case path == "/cycles" && req.Method == http.MethodGet:
+		r.apiGetCycles(w, req)
+	case path == "/cycles" && req.Method == http.MethodPost:
+		r.apiCreateCycle(w, req)
+	case strings.HasPrefix(path, "/cycles/") && req.Method == http.MethodGet:
+		r.apiGetCycle(w, req, path)
+	case strings.HasPrefix(path, "/cycles/") && req.Method == http.MethodPut:
+		r.apiUpdateCycle(w, req, path)
+	case strings.HasPrefix(path, "/cycles/") && req.Method == http.MethodDelete:
+		r.apiDeleteCycle(w, req, path)
 	// Privilege escalation
 	case path == "/elevations" && req.Method == http.MethodGet:
 		r.apiGetElevations(w, req)
@@ -236,6 +267,30 @@ func (r *Relay) ServeAPI(w http.ResponseWriter, req *http.Request) {
 		r.apiGrantElevation(w, req)
 	case strings.HasPrefix(path, "/elevations/") && req.Method == http.MethodDelete:
 		r.apiRevokeElevation(w, path)
+	// Custom events (user-defined event types)
+	case path == "/custom-events" && req.Method == http.MethodGet:
+		r.apiGetCustomEvents(w, req)
+	case path == "/custom-events" && req.Method == http.MethodPost:
+		r.apiCreateCustomEvent(w, req)
+	case strings.HasPrefix(path, "/custom-events/") && req.Method == http.MethodDelete:
+		r.apiDeleteCustomEvent(w, path)
+	// Workflow endpoints
+	case path == "/workflows" && req.Method == http.MethodGet:
+		r.apiGetWorkflows(w, req)
+	case path == "/workflows" && req.Method == http.MethodPost:
+		r.apiCreateWorkflow(w, req)
+	case strings.HasPrefix(path, "/workflows/") && strings.HasSuffix(path, "/execute") && req.Method == http.MethodPost:
+		r.apiExecuteWorkflow(w, req, path)
+	case strings.HasPrefix(path, "/workflows/") && strings.HasSuffix(path, "/runs") && req.Method == http.MethodGet:
+		r.apiGetWorkflowRuns(w, req, path)
+	case strings.HasPrefix(path, "/workflows/") && req.Method == http.MethodPut:
+		r.apiUpdateWorkflow(w, req, path)
+	case strings.HasPrefix(path, "/workflows/") && req.Method == http.MethodDelete:
+		r.apiDeleteWorkflow(w, path)
+	case strings.HasPrefix(path, "/workflows/") && req.Method == http.MethodGet:
+		r.apiGetWorkflow(w, path)
+	case strings.HasPrefix(path, "/workflow-runs/") && req.Method == http.MethodGet:
+		r.apiGetWorkflowRunDetail(w, path)
 	default:
 		http.Error(w, `{"error":"not found"}`, http.StatusNotFound)
 	}

--- a/internal/relay/api_spawn.go
+++ b/internal/relay/api_spawn.go
@@ -582,6 +582,28 @@ func (r *Relay) apiGetSkills(w http.ResponseWriter, req *http.Request) {
 	if project == "" {
 		project = "default"
 	}
+
+	// If agent slug is given, return skills linked to that profile with proficiency
+	if agent := req.URL.Query().Get("agent"); agent != "" {
+		profile, err := r.DB.GetProfile(project, agent)
+		if err != nil || profile == nil {
+			writeJSON(w, []any{})
+			return
+		}
+		links, err := r.DB.GetProfileSkillLinks(profile.ID)
+		if err != nil || links == nil {
+			writeJSON(w, []any{})
+			return
+		}
+		// Add agent field so the frontend can filter
+		for i := range links {
+			links[i]["agent"] = agent
+		}
+		b, _ := json.Marshal(links)
+		w.Write(b)
+		return
+	}
+
 	skills, err := r.DB.ListSkills(project)
 	if err != nil {
 		apiError(w, http.StatusInternalServerError, "list skills failed", err)
@@ -601,6 +623,8 @@ func (r *Relay) apiCreateSkill(w http.ResponseWriter, req *http.Request) {
 		Name        string `json:"name"`
 		Description string `json:"description"`
 		Tags        string `json:"tags"`
+		Agent       string `json:"agent"`       // optional: auto-link to this profile
+		Proficiency int    `json:"proficiency"` // 1-5, mapped to text
 	}
 	if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
 		apiError(w, http.StatusBadRequest, "invalid JSON", err)
@@ -619,6 +643,23 @@ func (r *Relay) apiCreateSkill(w http.ResponseWriter, req *http.Request) {
 		apiError(w, http.StatusInternalServerError, "create skill failed", err)
 		return
 	}
+
+	// Auto-link to profile if agent is specified
+	if body.Agent != "" {
+		profile, err := r.DB.GetProfile(body.Project, body.Agent)
+		if err == nil && profile != nil {
+			prof := "capable"
+			if body.Proficiency >= 5 {
+				prof = "expert"
+			} else if body.Proficiency >= 3 {
+				prof = "capable"
+			} else if body.Proficiency >= 1 {
+				prof = "learning"
+			}
+			_ = r.DB.LinkProfileSkill(profile.ID, skill.ID, prof)
+		}
+	}
+
 	b, _ := json.Marshal(skill)
 	w.WriteHeader(http.StatusCreated)
 	w.Write(b)
@@ -820,4 +861,256 @@ func (r *Relay) apiRevokeElevation(w http.ResponseWriter, path string) {
 	}
 	b, _ := json.Marshal(map[string]any{"id": id, "status": "revoked"})
 	w.Write(b)
+}
+
+// --- Agent management ---
+
+// DELETE /api/agents/:name?project=X
+func (r *Relay) apiDeactivateAgent(w http.ResponseWriter, req *http.Request, path string) {
+	name := strings.TrimPrefix(path, "/agents/")
+	name = strings.TrimSuffix(name, "/")
+	project := req.URL.Query().Get("project")
+	if project == "" {
+		project = "default"
+	}
+
+	if err := r.DB.DeactivateAgent(project, name); err != nil {
+		apiError(w, http.StatusInternalServerError, "deactivate agent failed", err)
+		return
+	}
+	writeJSON(w, map[string]any{"agent": name, "status": "deactivated"})
+}
+
+// --- Profile management ---
+
+// POST /api/profiles
+func (r *Relay) apiCreateProfile(w http.ResponseWriter, req *http.Request) {
+	var body struct {
+		Project      string `json:"project"`
+		Slug         string `json:"slug"`
+		Name         string `json:"name"`
+		Role         string `json:"role"`
+		ContextPack  string `json:"context_pack"`
+		SoulKeys     string `json:"soul_keys"`
+		Skills       string `json:"skills"`
+		VaultPaths   string `json:"vault_paths"`
+		AllowedTools string `json:"allowed_tools"`
+		PoolSize     int    `json:"pool_size"`
+	}
+	if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
+		apiError(w, http.StatusBadRequest, "invalid JSON", err)
+		return
+	}
+	if body.Project == "" {
+		body.Project = "default"
+	}
+	if body.Slug == "" {
+		http.Error(w, `{"error":"slug is required"}`, http.StatusBadRequest)
+		return
+	}
+
+	var opts []db.ProfileOption
+	if body.AllowedTools != "" {
+		opts = append(opts, db.WithAllowedTools(body.AllowedTools))
+	}
+	if body.PoolSize > 0 {
+		opts = append(opts, db.WithPoolSize(body.PoolSize))
+	}
+
+	profile, err := r.DB.RegisterProfile(body.Project, body.Slug, body.Name, body.Role, body.ContextPack, body.SoulKeys, body.Skills, body.VaultPaths, opts...)
+	if err != nil {
+		apiError(w, http.StatusInternalServerError, "create profile failed", err)
+		return
+	}
+	b, _ := json.Marshal(profile)
+	w.WriteHeader(http.StatusCreated)
+	w.Write(b)
+}
+
+// PUT /api/profiles/:slug?project=X
+func (r *Relay) apiUpdateProfile(w http.ResponseWriter, req *http.Request, path string) {
+	slug := strings.TrimPrefix(path, "/profiles/")
+	slug = strings.TrimSuffix(slug, "/")
+	project := req.URL.Query().Get("project")
+	if project == "" {
+		project = "default"
+	}
+
+	var body struct {
+		Name         string `json:"name"`
+		Role         string `json:"role"`
+		ContextPack  string `json:"context_pack"`
+		SoulKeys     string `json:"soul_keys"`
+		Skills       string `json:"skills"`
+		VaultPaths   string `json:"vault_paths"`
+		AllowedTools string `json:"allowed_tools"`
+		PoolSize     int    `json:"pool_size"`
+	}
+	if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
+		apiError(w, http.StatusBadRequest, "invalid JSON", err)
+		return
+	}
+
+	var opts []db.ProfileOption
+	if body.AllowedTools != "" {
+		opts = append(opts, db.WithAllowedTools(body.AllowedTools))
+	}
+	if body.PoolSize > 0 {
+		opts = append(opts, db.WithPoolSize(body.PoolSize))
+	}
+
+	profile, err := r.DB.RegisterProfile(project, slug, body.Name, body.Role, body.ContextPack, body.SoulKeys, body.Skills, body.VaultPaths, opts...)
+	if err != nil {
+		apiError(w, http.StatusInternalServerError, "update profile failed", err)
+		return
+	}
+	writeJSON(w, profile)
+}
+
+// DELETE /api/profiles/:slug?project=X
+func (r *Relay) apiDeleteProfile(w http.ResponseWriter, req *http.Request, path string) {
+	slug := strings.TrimPrefix(path, "/profiles/")
+	slug = strings.TrimSuffix(slug, "/")
+	project := req.URL.Query().Get("project")
+	if project == "" {
+		project = "default"
+	}
+
+	if err := r.DB.DeleteProfile(project, slug); err != nil {
+		apiError(w, http.StatusInternalServerError, "delete profile failed", err)
+		return
+	}
+	writeJSON(w, map[string]any{"slug": slug, "status": "deleted"})
+}
+
+// DELETE /api/skills/:name?project=X
+func (r *Relay) apiDeleteSkill(w http.ResponseWriter, req *http.Request, path string) {
+	name := strings.TrimPrefix(path, "/skills/")
+	name = strings.TrimSuffix(name, "/")
+	project := req.URL.Query().Get("project")
+	if project == "" {
+		project = "default"
+	}
+
+	if err := r.DB.DeleteSkill(project, name); err != nil {
+		apiError(w, http.StatusInternalServerError, "delete skill failed", err)
+		return
+	}
+	writeJSON(w, map[string]any{"name": name, "status": "deleted"})
+}
+
+// DELETE /api/quotas/:agent?project=X
+func (r *Relay) apiDeleteQuota(w http.ResponseWriter, req *http.Request, path string) {
+	agent := strings.TrimPrefix(path, "/quotas/")
+	agent = strings.TrimSuffix(agent, "/")
+	project := req.URL.Query().Get("project")
+	if project == "" {
+		project = "default"
+	}
+
+	if err := r.DB.DeleteQuota(project, agent); err != nil {
+		apiError(w, http.StatusInternalServerError, "delete quota failed", err)
+		return
+	}
+	writeJSON(w, map[string]any{"agent": agent, "status": "deleted"})
+}
+
+// --- Cycles CRUD ---
+
+func (r *Relay) apiGetCycles(w http.ResponseWriter, req *http.Request) {
+	project := req.URL.Query().Get("project")
+	if project == "" {
+		project = "default"
+	}
+	cycles, err := r.DB.ListCycles(project)
+	if err != nil {
+		apiError(w, http.StatusInternalServerError, "list cycles", err)
+		return
+	}
+	if cycles == nil {
+		cycles = []models.Cycle{}
+	}
+	writeJSON(w, cycles)
+}
+
+func (r *Relay) apiGetCycle(w http.ResponseWriter, req *http.Request, path string) {
+	name := strings.TrimPrefix(path, "/cycles/")
+	name = strings.TrimSuffix(name, "/")
+	project := req.URL.Query().Get("project")
+	if project == "" {
+		project = "default"
+	}
+	cycle, err := r.DB.GetCycle(project, name)
+	if err != nil {
+		apiError(w, http.StatusInternalServerError, "get cycle", err)
+		return
+	}
+	if cycle == nil {
+		apiError(w, http.StatusNotFound, "cycle not found", nil)
+		return
+	}
+	writeJSON(w, cycle)
+}
+
+func (r *Relay) apiCreateCycle(w http.ResponseWriter, req *http.Request) {
+	var body struct {
+		Project string `json:"project"`
+		Name    string `json:"name"`
+		Prompt  string `json:"prompt"`
+		TTL     int    `json:"ttl"`
+	}
+	if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
+		apiError(w, http.StatusBadRequest, "invalid JSON", err)
+		return
+	}
+	if body.Project == "" {
+		body.Project = "default"
+	}
+	if body.Name == "" {
+		apiError(w, http.StatusBadRequest, "name required", nil)
+		return
+	}
+	cycle, err := r.DB.UpsertCycle(body.Project, body.Name, body.Prompt, body.TTL)
+	if err != nil {
+		apiError(w, http.StatusInternalServerError, "create cycle", err)
+		return
+	}
+	writeJSON(w, cycle)
+}
+
+func (r *Relay) apiUpdateCycle(w http.ResponseWriter, req *http.Request, path string) {
+	name := strings.TrimPrefix(path, "/cycles/")
+	name = strings.TrimSuffix(name, "/")
+	var body struct {
+		Project string `json:"project"`
+		Prompt  string `json:"prompt"`
+		TTL     int    `json:"ttl"`
+	}
+	if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
+		apiError(w, http.StatusBadRequest, "invalid JSON", err)
+		return
+	}
+	if body.Project == "" {
+		body.Project = "default"
+	}
+	cycle, err := r.DB.UpsertCycle(body.Project, name, body.Prompt, body.TTL)
+	if err != nil {
+		apiError(w, http.StatusInternalServerError, "update cycle", err)
+		return
+	}
+	writeJSON(w, cycle)
+}
+
+func (r *Relay) apiDeleteCycle(w http.ResponseWriter, req *http.Request, path string) {
+	name := strings.TrimPrefix(path, "/cycles/")
+	name = strings.TrimSuffix(name, "/")
+	project := req.URL.Query().Get("project")
+	if project == "" {
+		project = "default"
+	}
+	if err := r.DB.DeleteCycle(project, name); err != nil {
+		apiError(w, http.StatusInternalServerError, "delete cycle", err)
+		return
+	}
+	writeJSON(w, map[string]any{"name": name, "status": "deleted"})
 }

--- a/internal/relay/api_spawn.go
+++ b/internal/relay/api_spawn.go
@@ -1,0 +1,823 @@
+package relay
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"agent-relay/internal/db"
+	"agent-relay/internal/models"
+)
+
+func (r *Relay) apiGetSpawnChildren(w http.ResponseWriter, req *http.Request) {
+	project := req.URL.Query().Get("project")
+	if project == "" {
+		project = "default"
+	}
+	agent := req.URL.Query().Get("agent")
+	status := req.URL.Query().Get("status")
+	if status == "" {
+		status = "all"
+	}
+
+	children := r.DB.ListSpawnChildren(agent, project, status)
+	if children == nil {
+		children = []map[string]any{}
+	}
+	b, _ := json.Marshal(children)
+	w.Write(b)
+}
+
+func (r *Relay) apiKillSpawnChild(w http.ResponseWriter, path string) {
+	// /spawn/children/{id}/kill
+	parts := strings.Split(strings.TrimPrefix(path, "/spawn/children/"), "/")
+	if len(parts) < 2 {
+		http.Error(w, `{"error":"invalid path"}`, http.StatusBadRequest)
+		return
+	}
+	childID := parts[0]
+
+	if r.SpawnMgr == nil {
+		http.Error(w, `{"error":"spawn not available"}`, http.StatusServiceUnavailable)
+		return
+	}
+
+	if err := r.SpawnMgr.KillChild(childID); err != nil {
+		apiError(w, http.StatusNotFound, "kill failed", err)
+		return
+	}
+	b, _ := json.Marshal(map[string]any{"child_id": childID, "status": "killed"})
+	w.Write(b)
+}
+
+func (r *Relay) apiSpawnChild(w http.ResponseWriter, req *http.Request) {
+	var body struct {
+		Agent        string `json:"agent"`
+		Project      string `json:"project"`
+		Profile      string `json:"profile"`
+		Prompt       string `json:"prompt"`
+		TTL          string `json:"ttl"`
+		AllowedTools string `json:"allowed_tools"`
+	}
+	if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
+		apiError(w, http.StatusBadRequest, "invalid JSON", err)
+		return
+	}
+	if body.Project == "" {
+		body.Project = "default"
+	}
+	if body.TTL == "" {
+		body.TTL = "10m"
+	}
+	if body.Profile == "" || body.Prompt == "" || body.Agent == "" {
+		http.Error(w, `{"error":"agent, profile, and prompt are required"}`, http.StatusBadRequest)
+		return
+	}
+
+	if r.SpawnMgr == nil {
+		http.Error(w, `{"error":"spawn not available"}`, http.StatusServiceUnavailable)
+		return
+	}
+
+	childID, err := r.SpawnMgr.Spawn(body.Agent, body.Project, body.Profile, body.Prompt, body.TTL, body.AllowedTools)
+	if err != nil {
+		apiError(w, http.StatusConflict, "spawn failed", err)
+		return
+	}
+
+	b, _ := json.Marshal(map[string]any{"child_id": childID, "profile": body.Profile, "status": "running"})
+	w.WriteHeader(http.StatusCreated)
+	w.Write(b)
+}
+
+func (r *Relay) apiGetSpawnChild(w http.ResponseWriter, path string) {
+	id := strings.TrimPrefix(path, "/spawn/children/")
+	id = strings.TrimSuffix(id, "/")
+
+	child := r.DB.GetSpawnChild(id)
+	if child == nil {
+		http.Error(w, `{"error":"child not found"}`, http.StatusNotFound)
+		return
+	}
+	b, _ := json.Marshal(child)
+	w.Write(b)
+}
+
+func (r *Relay) apiGetSchedules(w http.ResponseWriter, req *http.Request) {
+	project := req.URL.Query().Get("project")
+	if project == "" {
+		project = "default"
+	}
+	agent := req.URL.Query().Get("agent")
+
+	var schedules []map[string]any
+	if agent != "" {
+		schedules = r.DB.ListSchedulesByAgent(project, agent)
+	} else {
+		schedules = r.DB.ListSchedulesByProject(project)
+	}
+	if schedules == nil {
+		schedules = []map[string]any{}
+	}
+	b, _ := json.Marshal(schedules)
+	w.Write(b)
+}
+
+func (r *Relay) apiCreateSchedule(w http.ResponseWriter, req *http.Request) {
+	var body struct {
+		Agent        string `json:"agent"`
+		Project      string `json:"project"`
+		Name         string `json:"name"`
+		CronExpr     string `json:"cron_expr"`
+		Prompt       string `json:"prompt"`
+		TTL          string `json:"ttl"`
+		Cycle        string `json:"cycle"`
+		AllowedTools string `json:"allowed_tools"`
+	}
+	if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
+		apiError(w, http.StatusBadRequest, "invalid JSON", err)
+		return
+	}
+	if body.Project == "" {
+		body.Project = "default"
+	}
+	if body.TTL == "" {
+		body.TTL = "10m"
+	}
+
+	if r.SpawnMgr == nil {
+		http.Error(w, `{"error":"scheduler not available"}`, http.StatusServiceUnavailable)
+		return
+	}
+
+	id := body.Name + "-" + body.Agent // simple deterministic ID
+	if err := r.SpawnMgr.Schedule(id, body.Agent, body.Project, body.Name, body.CronExpr, body.Prompt, body.TTL, body.Cycle, body.AllowedTools); err != nil {
+		apiError(w, http.StatusBadRequest, "schedule failed", err)
+		return
+	}
+
+	b, _ := json.Marshal(map[string]any{"schedule_id": id, "status": "created"})
+	w.WriteHeader(http.StatusCreated)
+	w.Write(b)
+}
+
+func (r *Relay) apiTriggerSchedule(w http.ResponseWriter, path string) {
+	// /schedules/{id}/trigger
+	id := strings.TrimSuffix(strings.TrimPrefix(path, "/schedules/"), "/trigger")
+
+	if r.SpawnMgr == nil {
+		http.Error(w, `{"error":"scheduler not available"}`, http.StatusServiceUnavailable)
+		return
+	}
+
+	if err := r.SpawnMgr.TriggerCycle(id); err != nil {
+		apiError(w, http.StatusNotFound, "trigger failed", err)
+		return
+	}
+
+	b, _ := json.Marshal(map[string]any{"schedule_id": id, "status": "triggered"})
+	w.Write(b)
+}
+
+func (r *Relay) apiGetSchedule(w http.ResponseWriter, path string) {
+	id := strings.TrimPrefix(path, "/schedules/")
+	id = strings.TrimSuffix(id, "/")
+
+	schedule := r.DB.GetSchedule(id)
+	if schedule == nil {
+		http.Error(w, `{"error":"schedule not found"}`, http.StatusNotFound)
+		return
+	}
+	b, _ := json.Marshal(schedule)
+	w.Write(b)
+}
+
+func (r *Relay) apiUpdateSchedule(w http.ResponseWriter, req *http.Request, path string) {
+	id := strings.TrimPrefix(path, "/schedules/")
+	id = strings.TrimSuffix(id, "/")
+
+	existing := r.DB.GetSchedule(id)
+	if existing == nil {
+		http.Error(w, `{"error":"schedule not found"}`, http.StatusNotFound)
+		return
+	}
+
+	var body struct {
+		CronExpr     *string `json:"cron_expr"`
+		Prompt       *string `json:"prompt"`
+		TTL          *string `json:"ttl"`
+		Cycle        *string `json:"cycle"`
+		AllowedTools *string `json:"allowed_tools"`
+	}
+	if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
+		apiError(w, http.StatusBadRequest, "invalid JSON", err)
+		return
+	}
+
+	if r.SpawnMgr == nil {
+		http.Error(w, `{"error":"scheduler not available"}`, http.StatusServiceUnavailable)
+		return
+	}
+
+	// Merge with existing values
+	cronExpr, _ := existing["cron_expr"].(string)
+	prompt, _ := existing["prompt"].(string)
+	ttl, _ := existing["ttl"].(string)
+	cycle, _ := existing["cycle"].(string)
+	allowedTools, _ := existing["allowed_tools"].(string)
+	agentName, _ := existing["agent_name"].(string)
+	project, _ := existing["project"].(string)
+	name, _ := existing["name"].(string)
+
+	if body.CronExpr != nil {
+		cronExpr = *body.CronExpr
+	}
+	if body.Prompt != nil {
+		prompt = *body.Prompt
+	}
+	if body.TTL != nil {
+		ttl = *body.TTL
+	}
+	if body.Cycle != nil {
+		cycle = *body.Cycle
+	}
+	if body.AllowedTools != nil {
+		allowedTools = *body.AllowedTools
+	}
+
+	if err := r.SpawnMgr.Schedule(id, agentName, project, name, cronExpr, prompt, ttl, cycle, allowedTools); err != nil {
+		apiError(w, http.StatusBadRequest, "update failed", err)
+		return
+	}
+
+	b, _ := json.Marshal(map[string]any{"schedule_id": id, "status": "updated"})
+	w.Write(b)
+}
+
+func (r *Relay) apiDeleteSchedule(w http.ResponseWriter, path string) {
+	id := strings.TrimPrefix(path, "/schedules/")
+
+	if r.SpawnMgr == nil {
+		http.Error(w, `{"error":"scheduler not available"}`, http.StatusServiceUnavailable)
+		return
+	}
+
+	r.SpawnMgr.Unschedule(id)
+	b, _ := json.Marshal(map[string]any{"schedule_id": id, "status": "deleted"})
+	w.Write(b)
+}
+
+func (r *Relay) apiGetCycleHistory(w http.ResponseWriter, req *http.Request) {
+	project := req.URL.Query().Get("project")
+	if project == "" {
+		project = "default"
+	}
+	agent := req.URL.Query().Get("agent")
+
+	history := r.DB.GetCycleHistory(project, agent, 50)
+	if history == nil {
+		history = []map[string]any{}
+	}
+	b, _ := json.Marshal(history)
+	w.Write(b)
+}
+
+// --- Triggers (event-driven spawn rules) ---
+
+func (r *Relay) apiGetTriggers(w http.ResponseWriter, req *http.Request) {
+	project := req.URL.Query().Get("project")
+	if project == "" {
+		project = "default"
+	}
+	event := req.URL.Query().Get("event")
+
+	var triggers []db.Trigger
+	if event != "" {
+		triggers = r.DB.ListTriggers(project, event)
+	} else {
+		triggers = r.DB.ListAllTriggers(project)
+	}
+	if triggers == nil {
+		triggers = []db.Trigger{}
+	}
+	b, _ := json.Marshal(triggers)
+	w.Write(b)
+}
+
+func (r *Relay) apiCreateTrigger(w http.ResponseWriter, req *http.Request) {
+	var body struct {
+		Project     string `json:"project"`
+		Event       string `json:"event"`
+		MatchRules  string `json:"match_rules"`
+		ProfileSlug string `json:"profile_slug"`
+		Cycle       string `json:"cycle"`
+		MaxDuration string `json:"max_duration"`
+	}
+	if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
+		apiError(w, http.StatusBadRequest, "invalid JSON", err)
+		return
+	}
+	if body.Project == "" {
+		body.Project = "default"
+	}
+	if body.Event == "" || body.ProfileSlug == "" || body.Cycle == "" {
+		http.Error(w, `{"error":"event, profile_slug, and cycle are required"}`, http.StatusBadRequest)
+		return
+	}
+
+	trigger, err := r.DB.UpsertTrigger(body.Project, body.Event, body.MatchRules, body.ProfileSlug, body.Cycle, body.MaxDuration)
+	if err != nil {
+		apiError(w, http.StatusInternalServerError, "create trigger failed", err)
+		return
+	}
+
+	b, _ := json.Marshal(trigger)
+	w.WriteHeader(http.StatusCreated)
+	w.Write(b)
+}
+
+func (r *Relay) apiDeleteTrigger(w http.ResponseWriter, path string) {
+	id := strings.TrimPrefix(path, "/triggers/")
+	id = strings.TrimSuffix(id, "/")
+	r.DB.DeleteTrigger(id)
+	b, _ := json.Marshal(map[string]any{"id": id, "status": "deleted"})
+	w.Write(b)
+}
+
+// --- Agent OS spawn (profile + cycle → assembled context) ---
+
+func (r *Relay) apiSpawnWithContext(w http.ResponseWriter, req *http.Request) {
+	var body struct {
+		Project string `json:"project"`
+		Profile string `json:"profile"`
+		Cycle   string `json:"cycle"`
+		TaskID  string `json:"task_id"`
+	}
+	if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
+		apiError(w, http.StatusBadRequest, "invalid JSON", err)
+		return
+	}
+	if body.Project == "" {
+		body.Project = "default"
+	}
+	if body.Profile == "" {
+		http.Error(w, `{"error":"profile is required"}`, http.StatusBadRequest)
+		return
+	}
+
+	if r.SpawnMgr == nil {
+		http.Error(w, `{"error":"spawn not available"}`, http.StatusServiceUnavailable)
+		return
+	}
+
+	childID, err := r.SpawnMgr.SpawnWithContext(body.Project, body.Profile, body.Cycle, body.TaskID)
+	if err != nil {
+		apiError(w, http.StatusConflict, "spawn failed", err)
+		return
+	}
+
+	b, _ := json.Marshal(map[string]any{
+		"child_id": childID,
+		"profile":  body.Profile,
+		"cycle":    body.Cycle,
+		"status":   "running",
+	})
+	w.WriteHeader(http.StatusCreated)
+	w.Write(b)
+}
+
+// --- Webhook receiver ---
+
+// POST /api/webhooks/:project/:event
+func (r *Relay) apiWebhook(w http.ResponseWriter, req *http.Request, path string) {
+	// path = /webhooks/<project>/<event>
+	parts := strings.SplitN(strings.TrimPrefix(path, "/webhooks/"), "/", 2)
+	if len(parts) < 2 || parts[0] == "" || parts[1] == "" {
+		http.Error(w, `{"error":"path must be /webhooks/:project/:event"}`, http.StatusBadRequest)
+		return
+	}
+	project := parts[0]
+	event := parts[1]
+
+	body, err := io.ReadAll(io.LimitReader(req.Body, 1<<20)) // 1MB max
+	if err != nil {
+		apiError(w, http.StatusBadRequest, "read body failed", err)
+		return
+	}
+
+	meta := flattenJSON(body)
+	if meta == nil {
+		meta = map[string]string{}
+	}
+
+	fires, skipped := r.Handlers.fireTriggersSync(project, event, meta)
+	if fires == nil {
+		fires = []webhookResult{}
+	}
+	if skipped == nil {
+		skipped = []webhookSkipped{}
+	}
+
+	b, _ := json.Marshal(map[string]any{"fires": fires, "skipped": skipped})
+	w.Write(b)
+}
+
+// --- Signal handlers (convenience endpoint) ---
+
+// POST /api/signal-handlers — creates a trigger with event = "signal:<name>"
+func (r *Relay) apiCreateSignalHandler(w http.ResponseWriter, req *http.Request) {
+	var body struct {
+		Project     string `json:"project"`
+		Signal      string `json:"signal"`       // e.g. "interrupt", "alert"
+		MatchRules  string `json:"match_rules"`
+		ProfileSlug string `json:"profile_slug"`
+		Cycle       string `json:"cycle"`
+		MaxDuration string `json:"max_duration"`
+	}
+	if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
+		apiError(w, http.StatusBadRequest, "invalid JSON", err)
+		return
+	}
+	if body.Project == "" {
+		body.Project = "default"
+	}
+	if body.Signal == "" || body.ProfileSlug == "" || body.Cycle == "" {
+		http.Error(w, `{"error":"signal, profile_slug, and cycle are required"}`, http.StatusBadRequest)
+		return
+	}
+
+	event := "signal:" + body.Signal
+	trigger, err := r.DB.UpsertTrigger(body.Project, event, body.MatchRules, body.ProfileSlug, body.Cycle, body.MaxDuration)
+	if err != nil {
+		apiError(w, http.StatusInternalServerError, "create signal handler failed", err)
+		return
+	}
+
+	b, _ := json.Marshal(trigger)
+	w.WriteHeader(http.StatusCreated)
+	w.Write(b)
+}
+
+// --- Trigger history ---
+
+// GET /api/trigger-history?project=X&limit=N
+func (r *Relay) apiGetTriggerHistory(w http.ResponseWriter, req *http.Request) {
+	project := req.URL.Query().Get("project")
+	if project == "" {
+		project = "default"
+	}
+	limit := 50
+	if l := req.URL.Query().Get("limit"); l != "" {
+		if n, err := strconv.Atoi(l); err == nil && n > 0 {
+			limit = n
+		}
+	}
+
+	history := r.DB.GetTriggerHistory(project, limit)
+	if history == nil {
+		history = []db.TriggerFire{}
+	}
+	b, _ := json.Marshal(history)
+	w.Write(b)
+}
+
+// --- Poll Triggers ---
+
+// GET /api/poll-triggers?project=X
+func (r *Relay) apiGetPollTriggers(w http.ResponseWriter, req *http.Request) {
+	project := req.URL.Query().Get("project")
+	if project == "" {
+		project = "default"
+	}
+	triggers, err := r.DB.ListPollTriggers(project)
+	if err != nil {
+		apiError(w, http.StatusInternalServerError, "list poll triggers failed", err)
+		return
+	}
+	if triggers == nil {
+		triggers = []models.PollTrigger{}
+	}
+	b, _ := json.Marshal(triggers)
+	w.Write(b)
+}
+
+// POST /api/poll-triggers
+func (r *Relay) apiCreatePollTrigger(w http.ResponseWriter, req *http.Request) {
+	var body struct {
+		Project        string `json:"project"`
+		Name           string `json:"name"`
+		URL            string `json:"url"`
+		Headers        string `json:"headers"`
+		ConditionPath  string `json:"condition_path"`
+		ConditionOp    string `json:"condition_op"`
+		ConditionValue string `json:"condition_value"`
+		PollInterval   string `json:"poll_interval"`
+		FireEvent      string `json:"fire_event"`
+		FireMeta       string `json:"fire_meta"`
+		Cooldown       int    `json:"cooldown_seconds"`
+	}
+	if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
+		apiError(w, http.StatusBadRequest, "invalid JSON", err)
+		return
+	}
+	if body.Project == "" {
+		body.Project = "default"
+	}
+	if body.Name == "" || body.URL == "" || body.ConditionPath == "" || body.ConditionOp == "" || body.FireEvent == "" {
+		http.Error(w, `{"error":"name, url, condition_path, condition_op, and fire_event are required"}`, http.StatusBadRequest)
+		return
+	}
+	if body.PollInterval == "" {
+		body.PollInterval = "5m"
+	}
+
+	pt, err := r.DB.UpsertPollTrigger(body.Project, body.Name, body.URL, body.Headers,
+		body.ConditionPath, body.ConditionOp, body.ConditionValue, body.PollInterval,
+		body.FireEvent, body.FireMeta, body.Cooldown)
+	if err != nil {
+		apiError(w, http.StatusInternalServerError, "create poll trigger failed", err)
+		return
+	}
+	b, _ := json.Marshal(pt)
+	w.WriteHeader(http.StatusCreated)
+	w.Write(b)
+}
+
+// DELETE /api/poll-triggers/:id
+func (r *Relay) apiDeletePollTrigger(w http.ResponseWriter, path string) {
+	id := strings.TrimPrefix(path, "/poll-triggers/")
+	id = strings.TrimSuffix(id, "/")
+	if err := r.DB.DeletePollTrigger(id); err != nil {
+		apiError(w, http.StatusInternalServerError, "delete poll trigger failed", err)
+		return
+	}
+	b, _ := json.Marshal(map[string]any{"id": id, "status": "deleted"})
+	w.Write(b)
+}
+
+// POST /api/poll-triggers/:id/test
+func (r *Relay) apiTestPollTrigger(w http.ResponseWriter, path string) {
+	// path = /poll-triggers/<id>/test
+	id := strings.TrimSuffix(strings.TrimPrefix(path, "/poll-triggers/"), "/test")
+	matched, value, err := r.Handlers.PollOnceByID(id)
+	if err != nil {
+		apiError(w, http.StatusBadRequest, "poll test failed", err)
+		return
+	}
+	b, _ := json.Marshal(map[string]any{
+		"matched": matched,
+		"value":   value,
+	})
+	w.Write(b)
+}
+
+// --- Skills ---
+
+// GET /api/skills?project=X
+func (r *Relay) apiGetSkills(w http.ResponseWriter, req *http.Request) {
+	project := req.URL.Query().Get("project")
+	if project == "" {
+		project = "default"
+	}
+	skills, err := r.DB.ListSkills(project)
+	if err != nil {
+		apiError(w, http.StatusInternalServerError, "list skills failed", err)
+		return
+	}
+	if skills == nil {
+		skills = []models.Skill{}
+	}
+	b, _ := json.Marshal(skills)
+	w.Write(b)
+}
+
+// POST /api/skills
+func (r *Relay) apiCreateSkill(w http.ResponseWriter, req *http.Request) {
+	var body struct {
+		Project     string `json:"project"`
+		Name        string `json:"name"`
+		Description string `json:"description"`
+		Tags        string `json:"tags"`
+	}
+	if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
+		apiError(w, http.StatusBadRequest, "invalid JSON", err)
+		return
+	}
+	if body.Project == "" {
+		body.Project = "default"
+	}
+	if body.Name == "" {
+		http.Error(w, `{"error":"name is required"}`, http.StatusBadRequest)
+		return
+	}
+
+	skill, err := r.DB.UpsertSkill(body.Project, body.Name, body.Description, body.Tags)
+	if err != nil {
+		apiError(w, http.StatusInternalServerError, "create skill failed", err)
+		return
+	}
+	b, _ := json.Marshal(skill)
+	w.WriteHeader(http.StatusCreated)
+	w.Write(b)
+}
+
+// GET /api/skills/:name/profiles?project=X
+func (r *Relay) apiGetSkillProfiles(w http.ResponseWriter, req *http.Request, path string) {
+	// path = /skills/<name>/profiles
+	name := strings.TrimSuffix(strings.TrimPrefix(path, "/skills/"), "/profiles")
+	project := req.URL.Query().Get("project")
+	if project == "" {
+		project = "default"
+	}
+
+	links, err := r.DB.GetSkillProfileLinks(project, name)
+	if err != nil {
+		apiError(w, http.StatusInternalServerError, "get skill profiles failed", err)
+		return
+	}
+	if links == nil {
+		links = []map[string]any{}
+	}
+	b, _ := json.Marshal(map[string]any{"skill": name, "profiles": links})
+	w.Write(b)
+}
+
+// --- Quotas ---
+
+// GET /api/quotas?project=X
+func (r *Relay) apiGetQuotas(w http.ResponseWriter, req *http.Request) {
+	project := req.URL.Query().Get("project")
+	if project == "" {
+		project = "default"
+	}
+	quotas, err := r.DB.ListAgentQuotas(project)
+	if err != nil {
+		apiError(w, http.StatusInternalServerError, "list quotas failed", err)
+		return
+	}
+	if quotas == nil {
+		quotas = []models.AgentQuota{}
+	}
+	b, _ := json.Marshal(quotas)
+	w.Write(b)
+}
+
+// GET /api/quotas/:agent?project=X
+func (r *Relay) apiGetAgentQuota(w http.ResponseWriter, req *http.Request, path string) {
+	agent := strings.TrimPrefix(path, "/quotas/")
+	agent = strings.TrimSuffix(agent, "/")
+	project := req.URL.Query().Get("project")
+	if project == "" {
+		project = "default"
+	}
+
+	usage, err := r.DB.GetQuotaUsage(project, agent)
+	if err != nil {
+		apiError(w, http.StatusInternalServerError, "get quota failed", err)
+		return
+	}
+	b, _ := json.Marshal(usage)
+	w.Write(b)
+}
+
+// PUT /api/quotas/:agent
+func (r *Relay) apiSetAgentQuota(w http.ResponseWriter, req *http.Request, path string) {
+	agent := strings.TrimPrefix(path, "/quotas/")
+	agent = strings.TrimSuffix(agent, "/")
+
+	var body struct {
+		Project            string `json:"project"`
+		MaxTokensPerDay    int64  `json:"max_tokens_per_day"`
+		MaxMessagesPerHour int64  `json:"max_messages_per_hour"`
+		MaxTasksPerHour    int64  `json:"max_tasks_per_hour"`
+		MaxSpawnsPerHour   int64  `json:"max_spawns_per_hour"`
+	}
+	if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
+		apiError(w, http.StatusBadRequest, "invalid JSON", err)
+		return
+	}
+	if body.Project == "" {
+		body.Project = "default"
+	}
+
+	if err := r.DB.SetAgentQuota(body.Project, agent, body.MaxTokensPerDay, body.MaxMessagesPerHour, body.MaxTasksPerHour, body.MaxSpawnsPerHour); err != nil {
+		apiError(w, http.StatusInternalServerError, "set quota failed", err)
+		return
+	}
+
+	b, _ := json.Marshal(map[string]any{"agent": agent, "status": "updated"})
+	w.Write(b)
+}
+
+// --- Service Discovery ---
+
+// GET /api/discover?project=X&skill=Y&active_only=true
+func (r *Relay) apiDiscover(w http.ResponseWriter, req *http.Request) {
+	project := req.URL.Query().Get("project")
+	if project == "" {
+		project = "default"
+	}
+	skill := req.URL.Query().Get("skill")
+	if skill == "" {
+		http.Error(w, `{"error":"skill parameter is required"}`, http.StatusBadRequest)
+		return
+	}
+
+	agents, err := r.DB.FindActiveAgentsBySkill(project, skill)
+	if err != nil {
+		apiError(w, http.StatusInternalServerError, "discover failed", err)
+		return
+	}
+	if agents == nil {
+		agents = []models.Agent{}
+	}
+
+	// Also include profiles that have this skill (may not have active agents)
+	profiles, _ := r.DB.FindProfilesBySkill(project, skill)
+	if profiles == nil {
+		profiles = []models.Profile{}
+	}
+
+	b, _ := json.Marshal(map[string]any{
+		"skill":    skill,
+		"agents":   agents,
+		"profiles": profiles,
+	})
+	w.Write(b)
+}
+
+// --- Privilege Escalation ---
+
+// GET /api/elevations?project=X
+func (r *Relay) apiGetElevations(w http.ResponseWriter, req *http.Request) {
+	project := req.URL.Query().Get("project")
+	if project == "" {
+		project = "default"
+	}
+	elevations, err := r.DB.ListActiveElevations(project)
+	if err != nil {
+		apiError(w, http.StatusInternalServerError, "list elevations failed", err)
+		return
+	}
+	if elevations == nil {
+		elevations = []models.Elevation{}
+	}
+	b, _ := json.Marshal(elevations)
+	w.Write(b)
+}
+
+// POST /api/elevations
+func (r *Relay) apiGrantElevation(w http.ResponseWriter, req *http.Request) {
+	var body struct {
+		Project   string `json:"project"`
+		Agent     string `json:"agent"`
+		Role      string `json:"role"`       // admin, lead
+		GrantedBy string `json:"granted_by"`
+		Reason    string `json:"reason"`
+		Duration  string `json:"duration"`   // e.g. "1h", "30m"
+	}
+	if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
+		apiError(w, http.StatusBadRequest, "invalid JSON", err)
+		return
+	}
+	if body.Project == "" {
+		body.Project = "default"
+	}
+	if body.Agent == "" || body.Role == "" || body.GrantedBy == "" {
+		http.Error(w, `{"error":"agent, role, and granted_by are required"}`, http.StatusBadRequest)
+		return
+	}
+	if body.Duration == "" {
+		body.Duration = "1h"
+	}
+
+	duration, err := time.ParseDuration(body.Duration)
+	if err != nil {
+		apiError(w, http.StatusBadRequest, "invalid duration format", err)
+		return
+	}
+
+	elevation, err := r.DB.GrantElevation(body.Project, body.Agent, body.Role, body.GrantedBy, body.Reason, duration)
+	if err != nil {
+		apiError(w, http.StatusInternalServerError, "grant elevation failed", err)
+		return
+	}
+	b, _ := json.Marshal(elevation)
+	w.WriteHeader(http.StatusCreated)
+	w.Write(b)
+}
+
+// DELETE /api/elevations/:id
+func (r *Relay) apiRevokeElevation(w http.ResponseWriter, path string) {
+	id := strings.TrimPrefix(path, "/elevations/")
+	id = strings.TrimSuffix(id, "/")
+	if err := r.DB.RevokeElevation(id); err != nil {
+		apiError(w, http.StatusInternalServerError, "revoke elevation failed", err)
+		return
+	}
+	b, _ := json.Marshal(map[string]any{"id": id, "status": "revoked"})
+	w.Write(b)
+}

--- a/internal/relay/api_spawn.go
+++ b/internal/relay/api_spawn.go
@@ -431,7 +431,7 @@ func (r *Relay) apiWebhook(w http.ResponseWriter, req *http.Request, path string
 func (r *Relay) apiCreateSignalHandler(w http.ResponseWriter, req *http.Request) {
 	var body struct {
 		Project     string `json:"project"`
-		Signal      string `json:"signal"`       // e.g. "interrupt", "alert"
+		Signal      string `json:"signal"` // e.g. "interrupt", "alert"
 		MatchRules  string `json:"match_rules"`
 		ProfileSlug string `json:"profile_slug"`
 		Cycle       string `json:"cycle"`
@@ -815,10 +815,10 @@ func (r *Relay) apiGrantElevation(w http.ResponseWriter, req *http.Request) {
 	var body struct {
 		Project   string `json:"project"`
 		Agent     string `json:"agent"`
-		Role      string `json:"role"`       // admin, lead
+		Role      string `json:"role"` // admin, lead
 		GrantedBy string `json:"granted_by"`
 		Reason    string `json:"reason"`
-		Duration  string `json:"duration"`   // e.g. "1h", "30m"
+		Duration  string `json:"duration"` // e.g. "1h", "30m"
 	}
 	if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
 		apiError(w, http.StatusBadRequest, "invalid JSON", err)

--- a/internal/relay/api_test.go
+++ b/internal/relay/api_test.go
@@ -27,12 +27,14 @@ func testRelay(t *testing.T) *Relay {
 	mcpSrv := server.NewMCPServer("test", "0.0.0")
 	events := NewEventBus()
 	registry := NewSessionRegistry(mcpSrv)
+	handlers := NewHandlers(database, registry, nil, nil, events)
 
 	return &Relay{
 		MCPServer: mcpSrv,
 		DB:        database,
 		Registry:  registry,
 		Events:    events,
+		Handlers:  handlers,
 		Config:    config.Config{},
 	}
 }
@@ -783,5 +785,694 @@ func TestAPIGetActivity(t *testing.T) {
 	sessions := decodeJSONArray(t, w)
 	if len(sessions) != 0 {
 		t.Errorf("expected 0 sessions with nil ingester, got %d", len(sessions))
+	}
+}
+
+// ===== v0.6 OS Primitives =====
+
+// --- Phase 1: Triggers + Webhooks + Signal Handlers ---
+
+func TestAPITriggerCRUD(t *testing.T) {
+	r := testRelay(t)
+
+	// Create trigger
+	w := doAPI(r, "POST", "/triggers", `{"project":"p1","event":"task_pending","profile_slug":"backend","cycle":"review","match_rules":"{\"priority\":\"P0\"}"}`)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("create trigger: expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+	trigger := decodeJSON(t, w)
+	triggerID := trigger["id"].(string)
+	if trigger["event"] != "task_pending" {
+		t.Errorf("expected event=task_pending, got %v", trigger["event"])
+	}
+
+	// List triggers
+	w2 := doAPI(r, "GET", "/triggers?project=p1", "")
+	if w2.Code != http.StatusOK {
+		t.Fatalf("list triggers: expected 200, got %d", w2.Code)
+	}
+	triggers := decodeJSONArray(t, w2)
+	if len(triggers) != 1 {
+		t.Errorf("expected 1 trigger, got %d", len(triggers))
+	}
+
+	// List with event filter
+	w3 := doAPI(r, "GET", "/triggers?project=p1&event=task_pending", "")
+	if w3.Code != http.StatusOK {
+		t.Fatalf("list filtered triggers: expected 200, got %d", w3.Code)
+	}
+	filtered := decodeJSONArray(t, w3)
+	if len(filtered) != 1 {
+		t.Errorf("expected 1 filtered trigger, got %d", len(filtered))
+	}
+
+	// List with wrong event filter
+	w4 := doAPI(r, "GET", "/triggers?project=p1&event=nonexistent", "")
+	if w4.Code != http.StatusOK {
+		t.Fatalf("list filtered triggers: expected 200, got %d", w4.Code)
+	}
+	empty := decodeJSONArray(t, w4)
+	if len(empty) != 0 {
+		t.Errorf("expected 0 triggers for nonexistent event, got %d", len(empty))
+	}
+
+	// Delete trigger
+	w5 := doAPI(r, "DELETE", "/triggers/"+triggerID, "")
+	if w5.Code != http.StatusOK {
+		t.Fatalf("delete trigger: expected 200, got %d", w5.Code)
+	}
+
+	// Verify deleted
+	w6 := doAPI(r, "GET", "/triggers?project=p1", "")
+	after := decodeJSONArray(t, w6)
+	if len(after) != 0 {
+		t.Errorf("expected 0 triggers after delete, got %d", len(after))
+	}
+}
+
+func TestAPITriggerCreateMissingFields(t *testing.T) {
+	r := testRelay(t)
+	w := doAPI(r, "POST", "/triggers", `{"project":"p1","event":"task_pending"}`)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 for missing fields, got %d", w.Code)
+	}
+}
+
+func TestAPITriggerHistory(t *testing.T) {
+	r := testRelay(t)
+
+	// Record some trigger fires
+	r.DB.RecordTriggerFire("trigger-1", "p1", "task_pending", "child-1", nil)
+	r.DB.RecordTriggerFire("trigger-1", "p1", "task_completed", "child-2", nil)
+
+	w := doAPI(r, "GET", "/trigger-history?project=p1", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("trigger history: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	history := decodeJSONArray(t, w)
+	if len(history) != 2 {
+		t.Errorf("expected 2 history entries, got %d", len(history))
+	}
+}
+
+func TestAPITriggerHistoryWithLimit(t *testing.T) {
+	r := testRelay(t)
+
+	for i := 0; i < 5; i++ {
+		r.DB.RecordTriggerFire("trigger-1", "p1", "test_event", "", nil)
+	}
+
+	w := doAPI(r, "GET", "/trigger-history?project=p1&limit=2", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	history := decodeJSONArray(t, w)
+	if len(history) != 2 {
+		t.Errorf("expected 2 (limited), got %d", len(history))
+	}
+}
+
+func TestAPIWebhook(t *testing.T) {
+	r := testRelay(t)
+
+	// Create a trigger that matches "pr_opened" events
+	_, _ = r.DB.UpsertTrigger("myproj", "pr_opened", `{}`, "reviewer", "review", "10m")
+
+	// Fire webhook — no spawn manager so it should report "spawn_unavailable"
+	w := doAPI(r, "POST", "/webhooks/myproj/pr_opened", `{"author":"alice","branch":"feature-x"}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("webhook: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	data := decodeJSON(t, w)
+	skipped := data["skipped"].([]any)
+	if len(skipped) == 0 {
+		t.Error("expected at least 1 skipped (no spawn manager)")
+	}
+	// Verify trigger history was recorded
+	history := r.DB.GetTriggerHistory("myproj", 10)
+	if len(history) != 1 {
+		t.Errorf("expected 1 history entry from webhook, got %d", len(history))
+	}
+}
+
+func TestAPIWebhookWithMatchRules(t *testing.T) {
+	r := testRelay(t)
+
+	// Trigger only fires when author=alice
+	_, _ = r.DB.UpsertTrigger("proj", "pr_opened", `{"author":"alice"}`, "reviewer", "review", "10m")
+
+	// Should match
+	w := doAPI(r, "POST", "/webhooks/proj/pr_opened", `{"author":"alice"}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("webhook: expected 200, got %d", w.Code)
+	}
+	data := decodeJSON(t, w)
+	// Will be skipped (spawn_unavailable) but NOT rules_mismatch
+	skipped := data["skipped"].([]any)
+	for _, s := range skipped {
+		sk := s.(map[string]any)
+		if sk["reason"] == "rules_mismatch" {
+			t.Error("alice should match, got rules_mismatch")
+		}
+	}
+
+	// Should NOT match (bob != alice)
+	w2 := doAPI(r, "POST", "/webhooks/proj/pr_opened", `{"author":"bob"}`)
+	data2 := decodeJSON(t, w2)
+	skipped2 := data2["skipped"].([]any)
+	found := false
+	for _, s := range skipped2 {
+		sk := s.(map[string]any)
+		if sk["reason"] == "rules_mismatch" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("bob should NOT match, expected rules_mismatch")
+	}
+}
+
+func TestAPIWebhookBadPath(t *testing.T) {
+	r := testRelay(t)
+	w := doAPI(r, "POST", "/webhooks/", `{}`)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 for bad path, got %d", w.Code)
+	}
+}
+
+func TestAPISignalHandler(t *testing.T) {
+	r := testRelay(t)
+
+	w := doAPI(r, "POST", "/signal-handlers", `{"project":"p1","signal":"interrupt","profile_slug":"oncall","cycle":"triage"}`)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("create signal handler: expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+	handler := decodeJSON(t, w)
+	if handler["event"] != "signal:interrupt" {
+		t.Errorf("expected event=signal:interrupt, got %v", handler["event"])
+	}
+
+	// Verify it appears in triggers list
+	triggers := r.DB.ListTriggers("p1", "signal:interrupt")
+	if len(triggers) != 1 {
+		t.Errorf("expected 1 signal trigger, got %d", len(triggers))
+	}
+}
+
+func TestAPISignalHandlerMissingFields(t *testing.T) {
+	r := testRelay(t)
+	w := doAPI(r, "POST", "/signal-handlers", `{"project":"p1","signal":"interrupt"}`)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 for missing fields, got %d", w.Code)
+	}
+}
+
+// --- Phase 2: Poll Triggers ---
+
+func TestAPIPollTriggerCRUD(t *testing.T) {
+	r := testRelay(t)
+
+	// Create
+	w := doAPI(r, "POST", "/poll-triggers", `{
+		"project":"p1",
+		"name":"ci-status",
+		"url":"https://api.example.com/status",
+		"condition_path":"status",
+		"condition_op":"eq",
+		"condition_value":"green",
+		"poll_interval":"5m",
+		"fire_event":"ci_green",
+		"cooldown_seconds":300
+	}`)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("create poll trigger: expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+	pt := decodeJSON(t, w)
+	ptID := pt["id"].(string)
+	if pt["name"] != "ci-status" {
+		t.Errorf("expected name=ci-status, got %v", pt["name"])
+	}
+	if pt["condition_op"] != "eq" {
+		t.Errorf("expected condition_op=eq, got %v", pt["condition_op"])
+	}
+
+	// List
+	w2 := doAPI(r, "GET", "/poll-triggers?project=p1", "")
+	if w2.Code != http.StatusOK {
+		t.Fatalf("list poll triggers: expected 200, got %d", w2.Code)
+	}
+	pts := decodeJSONArray(t, w2)
+	if len(pts) != 1 {
+		t.Errorf("expected 1 poll trigger, got %d", len(pts))
+	}
+
+	// Delete
+	w3 := doAPI(r, "DELETE", "/poll-triggers/"+ptID, "")
+	if w3.Code != http.StatusOK {
+		t.Fatalf("delete poll trigger: expected 200, got %d: %s", w3.Code, w3.Body.String())
+	}
+
+	// Verify deleted
+	w4 := doAPI(r, "GET", "/poll-triggers?project=p1", "")
+	after := decodeJSONArray(t, w4)
+	if len(after) != 0 {
+		t.Errorf("expected 0 after delete, got %d", len(after))
+	}
+}
+
+func TestAPIPollTriggerUpsert(t *testing.T) {
+	r := testRelay(t)
+
+	// Create
+	doAPI(r, "POST", "/poll-triggers", `{
+		"project":"p1","name":"ci","url":"https://a.com","condition_path":"s","condition_op":"eq","condition_value":"ok","poll_interval":"1m","fire_event":"ev"
+	}`)
+
+	// Upsert same name — should update, not duplicate
+	w := doAPI(r, "POST", "/poll-triggers", `{
+		"project":"p1","name":"ci","url":"https://b.com","condition_path":"s","condition_op":"neq","condition_value":"fail","poll_interval":"2m","fire_event":"ev2"
+	}`)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("upsert: expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+	pt := decodeJSON(t, w)
+	if pt["url"] != "https://b.com" {
+		t.Errorf("expected updated url, got %v", pt["url"])
+	}
+
+	// Should still be only 1
+	w2 := doAPI(r, "GET", "/poll-triggers?project=p1", "")
+	pts := decodeJSONArray(t, w2)
+	if len(pts) != 1 {
+		t.Errorf("expected 1 after upsert, got %d", len(pts))
+	}
+}
+
+func TestAPIPollTriggerCreateMissingFields(t *testing.T) {
+	r := testRelay(t)
+	w := doAPI(r, "POST", "/poll-triggers", `{"project":"p1","name":"ci"}`)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestAPIPollTriggerTest(t *testing.T) {
+	r := testRelay(t)
+
+	// Create a poll trigger pointing to a non-existent URL
+	w := doAPI(r, "POST", "/poll-triggers", `{
+		"project":"p1","name":"test-poll",
+		"url":"http://127.0.0.1:1/nonexistent",
+		"condition_path":"status","condition_op":"eq","condition_value":"ok",
+		"poll_interval":"1m","fire_event":"test"
+	}`)
+	pt := decodeJSON(t, w)
+	ptID := pt["id"].(string)
+
+	// Test it — should fail (connection refused)
+	w2 := doAPI(r, "POST", "/poll-triggers/"+ptID+"/test", "")
+	if w2.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 for unreachable URL, got %d: %s", w2.Code, w2.Body.String())
+	}
+}
+
+func TestAPIPollTriggerTestNotFound(t *testing.T) {
+	r := testRelay(t)
+	w := doAPI(r, "POST", "/poll-triggers/nonexistent-id/test", "")
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 for nonexistent trigger, got %d", w.Code)
+	}
+}
+
+// --- Phase 3: Skills ---
+
+func TestAPISkillCRUD(t *testing.T) {
+	r := testRelay(t)
+
+	// Create
+	w := doAPI(r, "POST", "/skills", `{"project":"p1","name":"database","description":"Database management","tags":"[\"sql\",\"migrations\"]"}`)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("create skill: expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+	skill := decodeJSON(t, w)
+	if skill["name"] != "database" {
+		t.Errorf("expected name=database, got %v", skill["name"])
+	}
+
+	// List
+	w2 := doAPI(r, "GET", "/skills?project=p1", "")
+	if w2.Code != http.StatusOK {
+		t.Fatalf("list skills: expected 200, got %d", w2.Code)
+	}
+	skills := decodeJSONArray(t, w2)
+	if len(skills) != 1 {
+		t.Errorf("expected 1 skill, got %d", len(skills))
+	}
+}
+
+func TestAPISkillUpsert(t *testing.T) {
+	r := testRelay(t)
+
+	doAPI(r, "POST", "/skills", `{"project":"p1","name":"database","description":"v1"}`)
+	w := doAPI(r, "POST", "/skills", `{"project":"p1","name":"database","description":"v2"}`)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("upsert skill: expected 201, got %d", w.Code)
+	}
+	skill := decodeJSON(t, w)
+	if skill["description"] != "v2" {
+		t.Errorf("expected updated description, got %v", skill["description"])
+	}
+
+	// Should still be 1
+	w2 := doAPI(r, "GET", "/skills?project=p1", "")
+	skills := decodeJSONArray(t, w2)
+	if len(skills) != 1 {
+		t.Errorf("expected 1 after upsert, got %d", len(skills))
+	}
+}
+
+func TestAPISkillCreateMissingName(t *testing.T) {
+	r := testRelay(t)
+	w := doAPI(r, "POST", "/skills", `{"project":"p1"}`)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestAPISkillProfiles(t *testing.T) {
+	r := testRelay(t)
+
+	// Create skill and profile, link them
+	skill, _ := r.DB.UpsertSkill("p1", "database", "DB mgmt", "[]")
+	profile, _ := r.DB.RegisterProfile("p1", "dba", "DBA", "database admin", "", "[]", "[]", "[]")
+	_ = r.DB.LinkProfileSkill(profile.ID, skill.ID, "expert")
+
+	w := doAPI(r, "GET", "/skills/database/profiles?project=p1", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("skill profiles: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	data := decodeJSON(t, w)
+	profiles := data["profiles"].([]any)
+	if len(profiles) != 1 {
+		t.Errorf("expected 1 linked profile, got %d", len(profiles))
+	}
+	p := profiles[0].(map[string]any)
+	if p["slug"] != "dba" {
+		t.Errorf("expected slug=dba, got %v", p["slug"])
+	}
+	if p["proficiency"] != "expert" {
+		t.Errorf("expected proficiency=expert, got %v", p["proficiency"])
+	}
+}
+
+func TestAPISkillProfilesEmpty(t *testing.T) {
+	r := testRelay(t)
+
+	w := doAPI(r, "GET", "/skills/nonexistent/profiles?project=p1", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	data := decodeJSON(t, w)
+	profiles := data["profiles"].([]any)
+	if len(profiles) != 0 {
+		t.Errorf("expected 0 profiles, got %d", len(profiles))
+	}
+}
+
+// --- Phase 4: Quotas ---
+
+func TestAPIQuotaCRUD(t *testing.T) {
+	r := testRelay(t)
+
+	// Set quota
+	w := doAPI(r, "PUT", "/quotas/bot-a", `{"project":"p1","max_messages_per_hour":100,"max_tasks_per_hour":50,"max_spawns_per_hour":10}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("set quota: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	data := decodeJSON(t, w)
+	if data["status"] != "updated" {
+		t.Errorf("expected status=updated, got %v", data["status"])
+	}
+
+	// Get agent quota
+	w2 := doAPI(r, "GET", "/quotas/bot-a?project=p1", "")
+	if w2.Code != http.StatusOK {
+		t.Fatalf("get quota: expected 200, got %d: %s", w2.Code, w2.Body.String())
+	}
+	quota := decodeJSON(t, w2)
+	if quota["max_messages_per_hour"].(float64) != 100 {
+		t.Errorf("expected max_messages_per_hour=100, got %v", quota["max_messages_per_hour"])
+	}
+	if quota["max_tasks_per_hour"].(float64) != 50 {
+		t.Errorf("expected max_tasks_per_hour=50, got %v", quota["max_tasks_per_hour"])
+	}
+
+	// List quotas
+	w3 := doAPI(r, "GET", "/quotas?project=p1", "")
+	if w3.Code != http.StatusOK {
+		t.Fatalf("list quotas: expected 200, got %d", w3.Code)
+	}
+	quotas := decodeJSONArray(t, w3)
+	if len(quotas) != 1 {
+		t.Errorf("expected 1 quota, got %d", len(quotas))
+	}
+}
+
+func TestAPIQuotaUsageTracking(t *testing.T) {
+	r := testRelay(t)
+	_, _, _ = r.DB.RegisterAgent("p1", "bot-a", "dev", "", nil, nil, false, nil, "[]", 0)
+
+	// Set quota
+	_ = r.DB.SetAgentQuota("p1", "bot-a", 0, 100, 50, 0)
+
+	// Get usage — should be 0
+	w := doAPI(r, "GET", "/quotas/bot-a?project=p1", "")
+	data := decodeJSON(t, w)
+	if data["messages_used_1h"].(float64) != 0 {
+		t.Errorf("expected 0 messages used, got %v", data["messages_used_1h"])
+	}
+}
+
+func TestAPIQuotaUpdate(t *testing.T) {
+	r := testRelay(t)
+
+	// Set initial quota
+	doAPI(r, "PUT", "/quotas/bot-a", `{"project":"p1","max_messages_per_hour":100}`)
+
+	// Update quota
+	w := doAPI(r, "PUT", "/quotas/bot-a", `{"project":"p1","max_messages_per_hour":200,"max_tasks_per_hour":75}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("update quota: expected 200, got %d", w.Code)
+	}
+
+	// Verify
+	w2 := doAPI(r, "GET", "/quotas/bot-a?project=p1", "")
+	quota := decodeJSON(t, w2)
+	if quota["max_messages_per_hour"].(float64) != 200 {
+		t.Errorf("expected 200, got %v", quota["max_messages_per_hour"])
+	}
+}
+
+func TestAPIQuotaNoQuotaSet(t *testing.T) {
+	r := testRelay(t)
+
+	// Get quota for agent with no quota — should return zero values
+	w := doAPI(r, "GET", "/quotas/unknown-agent?project=p1", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	data := decodeJSON(t, w)
+	if data["max_messages_per_hour"].(float64) != 0 {
+		t.Errorf("expected 0, got %v", data["max_messages_per_hour"])
+	}
+}
+
+// --- Phase 5: Discover ---
+
+func TestAPIDiscover(t *testing.T) {
+	r := testRelay(t)
+
+	// Setup: skill + profile + link + active agent
+	skill, _ := r.DB.UpsertSkill("p1", "testing", "QA testing", "[]")
+	profile, _ := r.DB.RegisterProfile("p1", "qa-lead", "QA Lead", "tester", "", "[]", "[]", "[]")
+	_ = r.DB.LinkProfileSkill(profile.ID, skill.ID, "expert")
+	slug := "qa-lead"
+	_, _, _ = r.DB.RegisterAgent("p1", "qa-bot", "tester", "", nil, &slug, false, nil, "[]", 0)
+
+	w := doAPI(r, "GET", "/discover?project=p1&skill=testing", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("discover: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	data := decodeJSON(t, w)
+	agents := data["agents"].([]any)
+	profiles := data["profiles"].([]any)
+	if len(agents) != 1 {
+		t.Errorf("expected 1 agent, got %d", len(agents))
+	}
+	if len(profiles) != 1 {
+		t.Errorf("expected 1 profile, got %d", len(profiles))
+	}
+}
+
+func TestAPIDiscoverNoSkill(t *testing.T) {
+	r := testRelay(t)
+	w := doAPI(r, "GET", "/discover?project=p1", "")
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 without skill param, got %d", w.Code)
+	}
+}
+
+func TestAPIDiscoverEmpty(t *testing.T) {
+	r := testRelay(t)
+	w := doAPI(r, "GET", "/discover?project=p1&skill=nonexistent", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	data := decodeJSON(t, w)
+	agents := data["agents"].([]any)
+	if len(agents) != 0 {
+		t.Errorf("expected 0 agents, got %d", len(agents))
+	}
+}
+
+// --- Phase 6: Elevations ---
+
+func TestAPIElevationCRUD(t *testing.T) {
+	r := testRelay(t)
+
+	// Grant elevation
+	w := doAPI(r, "POST", "/elevations", `{"project":"p1","agent":"bot-a","role":"admin","granted_by":"lead","reason":"emergency","duration":"1h"}`)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("grant elevation: expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+	elev := decodeJSON(t, w)
+	elevID := elev["id"].(string)
+	if elev["elevated_role"] != "admin" {
+		t.Errorf("expected role=admin, got %v", elev["elevated_role"])
+	}
+	if elev["agent_name"] != "bot-a" {
+		t.Errorf("expected agent=bot-a, got %v", elev["agent_name"])
+	}
+
+	// List elevations
+	w2 := doAPI(r, "GET", "/elevations?project=p1", "")
+	if w2.Code != http.StatusOK {
+		t.Fatalf("list elevations: expected 200, got %d", w2.Code)
+	}
+	elevs := decodeJSONArray(t, w2)
+	if len(elevs) != 1 {
+		t.Errorf("expected 1 elevation, got %d", len(elevs))
+	}
+
+	// Revoke
+	w3 := doAPI(r, "DELETE", "/elevations/"+elevID, "")
+	if w3.Code != http.StatusOK {
+		t.Fatalf("revoke elevation: expected 200, got %d: %s", w3.Code, w3.Body.String())
+	}
+	revoked := decodeJSON(t, w3)
+	if revoked["status"] != "revoked" {
+		t.Errorf("expected status=revoked, got %v", revoked["status"])
+	}
+
+	// Verify revoked — list should be empty
+	w4 := doAPI(r, "GET", "/elevations?project=p1", "")
+	after := decodeJSONArray(t, w4)
+	if len(after) != 0 {
+		t.Errorf("expected 0 after revoke, got %d", len(after))
+	}
+}
+
+func TestAPIElevationMissingFields(t *testing.T) {
+	r := testRelay(t)
+	w := doAPI(r, "POST", "/elevations", `{"project":"p1","agent":"bot-a"}`)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 for missing fields, got %d", w.Code)
+	}
+}
+
+func TestAPIElevationBadDuration(t *testing.T) {
+	r := testRelay(t)
+	w := doAPI(r, "POST", "/elevations", `{"project":"p1","agent":"bot-a","role":"admin","granted_by":"lead","duration":"not-a-duration"}`)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 for bad duration, got %d", w.Code)
+	}
+}
+
+func TestAPIElevationDefaultDuration(t *testing.T) {
+	r := testRelay(t)
+	w := doAPI(r, "POST", "/elevations", `{"project":"p1","agent":"bot-a","role":"admin","granted_by":"lead"}`)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+	elev := decodeJSON(t, w)
+	if elev["expires_at"] == "" {
+		t.Error("expected expires_at to be set with default 1h duration")
+	}
+}
+
+func TestAPIElevationCanMessage(t *testing.T) {
+	r := testRelay(t)
+
+	// Setup: teams configured, bot-a NOT in admin team
+	_, _ = r.DB.CreateTeam("devs", "devs", "p1", "", "regular", nil, nil)
+	_, _, _ = r.DB.RegisterAgent("p1", "bot-a", "dev", "", nil, nil, false, nil, "[]", 0)
+	_, _, _ = r.DB.RegisterAgent("p1", "bot-b", "dev", "", nil, nil, false, nil, "[]", 0)
+
+	// Without elevation: should NOT be able to message bot-b (different team)
+	allowed, _ := r.DB.CanMessage("p1", "bot-a", "bot-b")
+	if allowed {
+		t.Error("expected NOT allowed without elevation")
+	}
+
+	// Grant admin elevation
+	_, _ = r.DB.GrantElevation("p1", "bot-a", "admin", "lead", "test", 1*60*60*1000*1000*1000) // 1h as Duration
+
+	// With elevation: should be able to message bot-b
+	allowed2, _ := r.DB.CanMessage("p1", "bot-a", "bot-b")
+	if !allowed2 {
+		t.Error("expected allowed WITH admin elevation")
+	}
+}
+
+// --- Cross-Phase Integration ---
+
+func TestAPIWebhookFiresAndRecordsHistory(t *testing.T) {
+	r := testRelay(t)
+
+	// Create trigger for "deploy" event
+	_, _ = r.DB.UpsertTrigger("proj", "deploy", `{}`, "deployer", "deploy-cycle", "10m")
+
+	// Fire via webhook
+	doAPI(r, "POST", "/webhooks/proj/deploy", `{"env":"production"}`)
+
+	// Check history
+	history := r.DB.GetTriggerHistory("proj", 10)
+	if len(history) != 1 {
+		t.Errorf("expected 1 history entry, got %d", len(history))
+	}
+	if history[0].Event != "deploy" {
+		t.Errorf("expected event=deploy, got %s", history[0].Event)
+	}
+}
+
+func TestAPIQuotaEnforcementDB(t *testing.T) {
+	r := testRelay(t)
+
+	// Set very low quota
+	_ = r.DB.SetAgentQuota("p1", "bot-a", 0, 1, 1, 0)
+
+	// First message should be allowed
+	allowed, _, _ := r.DB.CheckQuota("p1", "bot-a", "messages")
+	if !allowed {
+		t.Error("first message should be allowed (0 used)")
+	}
+
+	// Insert a message to count against quota
+	_, _ = r.DB.InsertMessage("p1", "bot-a", "bot-b", "notification", "", "hello", "{}", "P2", 3600, nil, nil)
+
+	// Second should be denied
+	allowed2, used, limit := r.DB.CheckQuota("p1", "bot-a", "messages")
+	if allowed2 {
+		t.Errorf("second message should be denied (used=%d, limit=%d)", used, limit)
 	}
 }

--- a/internal/relay/api_workflows.go
+++ b/internal/relay/api_workflows.go
@@ -1,0 +1,270 @@
+package relay
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"agent-relay/internal/db"
+)
+
+// --- Workflow API endpoints ---
+
+// GET /api/workflows?project=X
+func (r *Relay) apiGetWorkflows(w http.ResponseWriter, req *http.Request) {
+	project := projectFromRequest(req)
+	workflows, err := r.DB.ListWorkflows(project)
+	if err != nil {
+		apiError(w, http.StatusInternalServerError, "list workflows failed", err)
+		return
+	}
+	if workflows == nil {
+		workflows = []db.Workflow{}
+	}
+	writeJSON(w, workflows)
+}
+
+// GET /api/workflows/:id
+func (r *Relay) apiGetWorkflow(w http.ResponseWriter, path string) {
+	id := strings.TrimPrefix(path, "/workflows/")
+	id = strings.TrimSuffix(id, "/")
+	wf, err := r.DB.GetWorkflow(id)
+	if err != nil {
+		apiError(w, http.StatusNotFound, "workflow not found", err)
+		return
+	}
+	writeJSON(w, wf)
+}
+
+// POST /api/workflows
+func (r *Relay) apiCreateWorkflow(w http.ResponseWriter, req *http.Request) {
+	var body struct {
+		Project     string `json:"project"`
+		Name        string `json:"name"`
+		Description string `json:"description"`
+		Nodes       string `json:"nodes"`
+		Edges       string `json:"edges"`
+	}
+	if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
+		apiError(w, http.StatusBadRequest, "invalid JSON", err)
+		return
+	}
+	if body.Project == "" {
+		body.Project = "default"
+	}
+	if body.Name == "" {
+		http.Error(w, `{"error":"name is required"}`, http.StatusBadRequest)
+		return
+	}
+	if body.Nodes == "" {
+		body.Nodes = "[]"
+	}
+	if body.Edges == "" {
+		body.Edges = "[]"
+	}
+
+	wf, err := r.DB.CreateWorkflow(body.Project, body.Name, body.Description, body.Nodes, body.Edges)
+	if err != nil {
+		apiError(w, http.StatusInternalServerError, "create workflow failed", err)
+		return
+	}
+	b, _ := json.Marshal(wf)
+	w.WriteHeader(http.StatusCreated)
+	w.Write(b)
+}
+
+// PUT /api/workflows/:id
+func (r *Relay) apiUpdateWorkflow(w http.ResponseWriter, req *http.Request, path string) {
+	id := strings.TrimPrefix(path, "/workflows/")
+	id = strings.TrimSuffix(id, "/")
+
+	var body struct {
+		Name        string `json:"name"`
+		Description string `json:"description"`
+		Nodes       string `json:"nodes"`
+		Edges       string `json:"edges"`
+		Enabled     *bool  `json:"enabled"`
+	}
+	if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
+		apiError(w, http.StatusBadRequest, "invalid JSON", err)
+		return
+	}
+
+	// Handle enable/disable toggle
+	if body.Enabled != nil {
+		r.DB.ToggleWorkflow(id, *body.Enabled)
+	}
+
+	wf, err := r.DB.UpdateWorkflow(id, body.Name, body.Description, body.Nodes, body.Edges)
+	if err != nil {
+		apiError(w, http.StatusInternalServerError, "update workflow failed", err)
+		return
+	}
+	writeJSON(w, wf)
+}
+
+// DELETE /api/workflows/:id
+func (r *Relay) apiDeleteWorkflow(w http.ResponseWriter, path string) {
+	id := strings.TrimPrefix(path, "/workflows/")
+	id = strings.TrimSuffix(id, "/")
+	if err := r.DB.DeleteWorkflow(id); err != nil {
+		apiError(w, http.StatusInternalServerError, "delete workflow failed", err)
+		return
+	}
+	writeJSON(w, map[string]any{"id": id, "status": "deleted"})
+}
+
+// POST /api/workflows/:id/execute
+func (r *Relay) apiExecuteWorkflow(w http.ResponseWriter, req *http.Request, path string) {
+	id := strings.TrimSuffix(strings.TrimPrefix(path, "/workflows/"), "/execute")
+
+	wf, err := r.DB.GetWorkflow(id)
+	if err != nil {
+		apiError(w, http.StatusNotFound, "workflow not found", err)
+		return
+	}
+
+	// Parse optional trigger meta from request body
+	meta := make(map[string]string)
+	if req.Body != nil {
+		bodyBytes, _ := io.ReadAll(req.Body)
+		if len(bodyBytes) > 0 {
+			var parsed struct {
+				Meta map[string]string `json:"meta"`
+			}
+			if err := json.Unmarshal(bodyBytes, &parsed); err == nil && parsed.Meta != nil {
+				meta = parsed.Meta
+			}
+		}
+	}
+
+	if r.WorkflowEngine == nil {
+		http.Error(w, `{"error":"workflow engine not available"}`, http.StatusServiceUnavailable)
+		return
+	}
+
+	run, err := r.WorkflowEngine.Execute(req.Context(), wf, "manual", meta)
+	if err != nil {
+		// Run was created but failed — return the run with error
+		if run != nil {
+			writeJSON(w, run)
+			return
+		}
+		apiError(w, http.StatusInternalServerError, "execute failed", err)
+		return
+	}
+
+	writeJSON(w, run)
+}
+
+// GET /api/workflows/:id/runs?limit=N
+func (r *Relay) apiGetWorkflowRuns(w http.ResponseWriter, req *http.Request, path string) {
+	id := strings.TrimSuffix(strings.TrimPrefix(path, "/workflows/"), "/runs")
+
+	limit := 20
+	if l := req.URL.Query().Get("limit"); l != "" {
+		if n, err := parseInt(l); err == nil && n > 0 {
+			limit = n
+		}
+	}
+
+	runs, err := r.DB.ListWorkflowRuns(id, limit)
+	if err != nil {
+		apiError(w, http.StatusInternalServerError, "list runs failed", err)
+		return
+	}
+	if runs == nil {
+		runs = []db.WorkflowRun{}
+	}
+	writeJSON(w, runs)
+}
+
+// GET /api/workflow-runs/:id
+func (r *Relay) apiGetWorkflowRunDetail(w http.ResponseWriter, path string) {
+	id := strings.TrimPrefix(path, "/workflow-runs/")
+	id = strings.TrimSuffix(id, "/")
+
+	run, err := r.DB.GetWorkflowRun(id)
+	if err != nil {
+		apiError(w, http.StatusNotFound, "run not found", err)
+		return
+	}
+
+	nodeRuns, err := r.DB.ListNodeRuns(id)
+	if err != nil {
+		nodeRuns = []db.WorkflowNodeRun{}
+	}
+
+	writeJSON(w, map[string]any{
+		"run":        run,
+		"node_runs":  nodeRuns,
+	})
+}
+
+// --- Custom Events API ---
+
+// GET /api/custom-events?project=X
+func (r *Relay) apiGetCustomEvents(w http.ResponseWriter, req *http.Request) {
+	project := projectFromRequest(req)
+	events, err := r.DB.ListCustomEvents(project)
+	if err != nil {
+		apiError(w, http.StatusInternalServerError, "list custom events failed", err)
+		return
+	}
+	if events == nil {
+		events = []db.CustomEvent{}
+	}
+	writeJSON(w, events)
+}
+
+// POST /api/custom-events
+func (r *Relay) apiCreateCustomEvent(w http.ResponseWriter, req *http.Request) {
+	var body struct {
+		Project     string `json:"project"`
+		Name        string `json:"name"`
+		Description string `json:"description"`
+		MetaFields  string `json:"meta_fields"` // JSON array: ["branch","status"]
+		Icon        string `json:"icon"`
+	}
+	if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
+		apiError(w, http.StatusBadRequest, "invalid JSON", err)
+		return
+	}
+	if body.Project == "" {
+		body.Project = "default"
+	}
+	if body.Name == "" {
+		http.Error(w, `{"error":"name is required"}`, http.StatusBadRequest)
+		return
+	}
+	evt, err := r.DB.UpsertCustomEvent(body.Project, body.Name, body.Description, body.MetaFields, body.Icon)
+	if err != nil {
+		apiError(w, http.StatusInternalServerError, "create custom event failed", err)
+		return
+	}
+	b, _ := json.Marshal(evt)
+	w.WriteHeader(http.StatusCreated)
+	w.Write(b)
+}
+
+// DELETE /api/custom-events/:id
+func (r *Relay) apiDeleteCustomEvent(w http.ResponseWriter, path string) {
+	id := strings.TrimPrefix(path, "/custom-events/")
+	id = strings.TrimSuffix(id, "/")
+	r.DB.DeleteCustomEvent(id)
+	writeJSON(w, map[string]any{"id": id, "status": "deleted"})
+}
+
+// parseInt is a small helper for query param parsing.
+func parseInt(s string) (int, error) {
+	var n int
+	for _, c := range s {
+		if c < '0' || c > '9' {
+			return 0, fmt.Errorf("not a number")
+		}
+		n = n*10 + int(c-'0')
+	}
+	return n, nil
+}

--- a/internal/relay/api_workflows.go
+++ b/internal/relay/api_workflows.go
@@ -198,8 +198,8 @@ func (r *Relay) apiGetWorkflowRunDetail(w http.ResponseWriter, path string) {
 	}
 
 	writeJSON(w, map[string]any{
-		"run":        run,
-		"node_runs":  nodeRuns,
+		"run":       run,
+		"node_runs": nodeRuns,
 	})
 }
 

--- a/internal/relay/cleanup.go
+++ b/internal/relay/cleanup.go
@@ -53,7 +53,12 @@ func StartCleanup(database *db.DB, done <-chan struct{}) {
 				} else if expired > 0 {
 					log.Printf("expired %d file lock(s)", expired)
 				}
-				if purged, err := database.PurgeOldTokenUsage(90 * 24 * time.Hour); err != nil {
+				if expired, err := database.ExpireElevations(); err != nil {
+				log.Printf("expire elevations error: %v", err)
+			} else if expired > 0 {
+				log.Printf("expired %d elevation(s)", expired)
+			}
+			if purged, err := database.PurgeOldTokenUsage(90 * 24 * time.Hour); err != nil {
 					log.Printf("purge token usage error: %v", err)
 				} else if purged > 0 {
 					log.Printf("purged %d old token usage record(s)", purged)

--- a/internal/relay/cleanup.go
+++ b/internal/relay/cleanup.go
@@ -54,11 +54,11 @@ func StartCleanup(database *db.DB, done <-chan struct{}) {
 					log.Printf("expired %d file lock(s)", expired)
 				}
 				if expired, err := database.ExpireElevations(); err != nil {
-				log.Printf("expire elevations error: %v", err)
-			} else if expired > 0 {
-				log.Printf("expired %d elevation(s)", expired)
-			}
-			if purged, err := database.PurgeOldTokenUsage(90 * 24 * time.Hour); err != nil {
+					log.Printf("expire elevations error: %v", err)
+				} else if expired > 0 {
+					log.Printf("expired %d elevation(s)", expired)
+				}
+				if purged, err := database.PurgeOldTokenUsage(90 * 24 * time.Hour); err != nil {
 					log.Printf("purge token usage error: %v", err)
 				} else if purged > 0 {
 					log.Printf("purged %d old token usage record(s)", purged)

--- a/internal/relay/dispatcher.go
+++ b/internal/relay/dispatcher.go
@@ -6,8 +6,6 @@ import (
 	"log"
 	"strings"
 	"time"
-
-	"github.com/google/uuid"
 )
 
 // fireTriggers queries matching triggers for the given project/event and spawns children.
@@ -195,9 +193,4 @@ func (h *Handlers) fireTriggersSync(project, event string, meta map[string]strin
 		}
 	}
 	return
-}
-
-// newTriggerFireID generates a UUID for trigger history records.
-func newTriggerFireID() string {
-	return uuid.New().String()
 }

--- a/internal/relay/dispatcher.go
+++ b/internal/relay/dispatcher.go
@@ -11,8 +11,14 @@ import (
 )
 
 // fireTriggers queries matching triggers for the given project/event and spawns children.
+// Also fires any workflow DAGs that have matching trigger:event nodes.
 // Always called as a goroutine: go h.fireTriggers(project, event, meta)
 func (h *Handlers) fireTriggers(project, event string, meta map[string]string) {
+	// Fire workflow DAGs that match this event
+	if h.wfEngine != nil {
+		h.wfEngine.FireWorkflows(project, event, meta)
+	}
+
 	triggers := h.db.ListTriggers(project, event)
 	if len(triggers) == 0 {
 		return

--- a/internal/relay/dispatcher.go
+++ b/internal/relay/dispatcher.go
@@ -1,0 +1,196 @@
+package relay
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// fireTriggers queries matching triggers for the given project/event and spawns children.
+// Always called as a goroutine: go h.fireTriggers(project, event, meta)
+func (h *Handlers) fireTriggers(project, event string, meta map[string]string) {
+	triggers := h.db.ListTriggers(project, event)
+	if len(triggers) == 0 {
+		return
+	}
+
+	for _, t := range triggers {
+		// Cooldown check
+		if t.LastFiredAt != "" {
+			if lastFired, err := time.Parse("2006-01-02T15:04:05Z", t.LastFiredAt); err == nil {
+				cooldown := time.Duration(t.CooldownSeconds) * time.Second
+				if time.Since(lastFired) < cooldown {
+					log.Printf("[dispatcher] trigger %s skipped (cooldown %ds)", t.ID, t.CooldownSeconds)
+					continue
+				}
+			}
+		}
+
+		// Evaluate match rules
+		if !matchesRules(t.MatchRules, meta) {
+			continue
+		}
+
+		// Spawn via SpawnWithContext if spawn manager is available
+		var childID string
+		var spawnErr error
+
+		if h.spawnMgr != nil {
+			// Derive a task_id from meta if available
+			taskID := meta["task_id"]
+			childID, spawnErr = h.spawnMgr.SpawnWithContext(project, t.ProfileSlug, t.Cycle, taskID)
+		} else {
+			spawnErr = nil
+			childID = ""
+			log.Printf("[dispatcher] trigger %s matched but spawn manager not available", t.ID)
+		}
+
+		// Record the fire
+		h.db.RecordTriggerFire(t.ID, project, event, childID, spawnErr)
+
+		if spawnErr != nil {
+			log.Printf("[dispatcher] trigger %s spawn error: %v", t.ID, spawnErr)
+		} else if childID != "" {
+			log.Printf("[dispatcher] trigger %s fired → child %s (profile=%s cycle=%s)", t.ID, childID, t.ProfileSlug, t.Cycle)
+		}
+	}
+}
+
+// matchesRules evaluates whether the metadata matches the trigger's JSON rules.
+// Rules are a flat JSON object: {"key": "value"} — all must match.
+// Special prefixes: ">" for greater-than comparison on durations/numbers.
+func matchesRules(rulesJSON string, meta map[string]string) bool {
+	if rulesJSON == "" || rulesJSON == "{}" {
+		return true
+	}
+
+	var rules map[string]string
+	if err := json.Unmarshal([]byte(rulesJSON), &rules); err != nil {
+		return true // malformed rules = match all
+	}
+
+	for key, expected := range rules {
+		actual, ok := meta[key]
+		if !ok {
+			return false
+		}
+		if strings.HasPrefix(expected, ">") {
+			// Duration/numeric comparison
+			threshold := strings.TrimPrefix(expected, ">")
+			if !compareDuration(actual, threshold) {
+				return false
+			}
+		} else if actual != expected {
+			return false
+		}
+	}
+	return true
+}
+
+// compareDuration returns true if actual duration > threshold duration.
+func compareDuration(actual, threshold string) bool {
+	a, errA := time.ParseDuration(actual)
+	t, errT := time.ParseDuration(threshold)
+	if errA != nil || errT != nil {
+		return false
+	}
+	return a > t
+}
+
+// flattenJSON converts top-level JSON keys to a string map (for webhook payloads).
+func flattenJSON(data []byte) map[string]string {
+	var raw map[string]any
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return nil
+	}
+	result := make(map[string]string, len(raw))
+	for k, v := range raw {
+		switch val := v.(type) {
+		case string:
+			result[k] = val
+		case float64:
+			if val == float64(int64(val)) {
+				result[k] = fmt.Sprintf("%d", int64(val))
+			} else {
+				result[k] = fmt.Sprintf("%g", val)
+			}
+		case bool:
+			if val {
+				result[k] = "true"
+			} else {
+				result[k] = "false"
+			}
+		default:
+			b, _ := json.Marshal(val)
+			result[k] = string(b)
+		}
+	}
+	return result
+}
+
+// webhookResult is the response for POST /api/webhooks/:project/:event.
+type webhookResult struct {
+	TriggerID string `json:"trigger_id"`
+	ChildID   string `json:"child_id,omitempty"`
+}
+
+type webhookSkipped struct {
+	TriggerID string `json:"trigger_id"`
+	Reason    string `json:"reason"`
+}
+
+// fireTriggersSync is like fireTriggers but returns results (for webhook endpoint).
+func (h *Handlers) fireTriggersSync(project, event string, meta map[string]string) (fires []webhookResult, skipped []webhookSkipped) {
+	triggers := h.db.ListTriggers(project, event)
+	if len(triggers) == 0 {
+		return
+	}
+
+	for _, t := range triggers {
+		// Cooldown check
+		if t.LastFiredAt != "" {
+			if lastFired, err := time.Parse("2006-01-02T15:04:05Z", t.LastFiredAt); err == nil {
+				cooldown := time.Duration(t.CooldownSeconds) * time.Second
+				if time.Since(lastFired) < cooldown {
+					skipped = append(skipped, webhookSkipped{TriggerID: t.ID, Reason: "cooldown"})
+					continue
+				}
+			}
+		}
+
+		if !matchesRules(t.MatchRules, meta) {
+			skipped = append(skipped, webhookSkipped{TriggerID: t.ID, Reason: "rules_mismatch"})
+			continue
+		}
+
+		var childID string
+		var spawnErr error
+
+		if h.spawnMgr != nil {
+			taskID := meta["task_id"]
+			childID, spawnErr = h.spawnMgr.SpawnWithContext(project, t.ProfileSlug, t.Cycle, taskID)
+		} else {
+			skipped = append(skipped, webhookSkipped{TriggerID: t.ID, Reason: "spawn_unavailable"})
+			h.db.RecordTriggerFire(t.ID, project, event, "", nil)
+			continue
+		}
+
+		h.db.RecordTriggerFire(t.ID, project, event, childID, spawnErr)
+
+		if spawnErr != nil {
+			skipped = append(skipped, webhookSkipped{TriggerID: t.ID, Reason: spawnErr.Error()})
+		} else {
+			fires = append(fires, webhookResult{TriggerID: t.ID, ChildID: childID})
+		}
+	}
+	return
+}
+
+// newTriggerFireID generates a UUID for trigger history records.
+func newTriggerFireID() string {
+	return uuid.New().String()
+}

--- a/internal/relay/dispatcher.go
+++ b/internal/relay/dispatcher.go
@@ -19,6 +19,11 @@ func (h *Handlers) fireTriggers(project, event string, meta map[string]string) {
 	}
 
 	for _, t := range triggers {
+		// Evaluate match rules first (don't waste cooldown on non-matching events)
+		if !matchesRules(t.MatchRules, meta) {
+			continue
+		}
+
 		// Cooldown check
 		if t.LastFiredAt != "" {
 			if lastFired, err := time.Parse("2006-01-02T15:04:05Z", t.LastFiredAt); err == nil {
@@ -28,11 +33,6 @@ func (h *Handlers) fireTriggers(project, event string, meta map[string]string) {
 					continue
 				}
 			}
-		}
-
-		// Evaluate match rules
-		if !matchesRules(t.MatchRules, meta) {
-			continue
 		}
 
 		// Spawn via SpawnWithContext if spawn manager is available
@@ -151,6 +151,12 @@ func (h *Handlers) fireTriggersSync(project, event string, meta map[string]strin
 	}
 
 	for _, t := range triggers {
+		// Evaluate match rules first (don't waste cooldown on non-matching events)
+		if !matchesRules(t.MatchRules, meta) {
+			skipped = append(skipped, webhookSkipped{TriggerID: t.ID, Reason: "rules_mismatch"})
+			continue
+		}
+
 		// Cooldown check
 		if t.LastFiredAt != "" {
 			if lastFired, err := time.Parse("2006-01-02T15:04:05Z", t.LastFiredAt); err == nil {
@@ -160,11 +166,6 @@ func (h *Handlers) fireTriggersSync(project, event string, meta map[string]strin
 					continue
 				}
 			}
-		}
-
-		if !matchesRules(t.MatchRules, meta) {
-			skipped = append(skipped, webhookSkipped{TriggerID: t.ID, Reason: "rules_mismatch"})
-			continue
 		}
 
 		var childID string

--- a/internal/relay/handlers.go
+++ b/internal/relay/handlers.go
@@ -14,6 +14,7 @@ import (
 	"agent-relay/internal/db"
 	"agent-relay/internal/ingest"
 	"agent-relay/internal/models"
+	"agent-relay/internal/spawn"
 	"agent-relay/internal/vault"
 
 	"github.com/mark3labs/mcp-go/mcp"
@@ -26,6 +27,7 @@ type Handlers struct {
 	vaultWatcher *vault.Watcher
 	events       *EventBus
 	tokenCh      chan db.TokenRecord
+	spawnMgr     *spawn.Manager
 }
 
 func NewHandlers(database *db.DB, registry *SessionRegistry, ingester *ingest.Ingester, vaultWatcher *vault.Watcher, events *EventBus) *Handlers {
@@ -229,6 +231,11 @@ func (h *Handlers) HandleSendMessage(ctx context.Context, req mcp.CallToolReques
 	priority := mapPriority(req.GetString("priority", "P2"))
 	ttlSeconds := req.GetInt("ttl_seconds", 14400)
 
+	// Quota check: messages
+	if qErr := h.db.CheckQuotaError(project, from, "messages"); qErr != "" {
+		return mcp.NewToolResultError(qErr), nil
+	}
+
 	// Support "to": "conversation:<id>" shorthand
 	if conversationID == nil && strings.HasPrefix(to, "conversation:") {
 		cid := strings.TrimPrefix(to, "conversation:")
@@ -323,6 +330,15 @@ func (h *Handlers) HandleSendMessage(ctx context.Context, req mcp.CallToolReques
 		h.registry.NotifyBroadcast(project, from, subject, msg.ID)
 	} else {
 		h.registry.Notify(project, to, from, subject, msg.ID)
+	}
+
+	// Fire triggers for high-priority messages (P0/P1)
+	if priority == "P0" || priority == "P1" {
+		msgMeta := map[string]string{"priority": priority, "from": from, "to": to, "subject": subject, "message_id": msg.ID}
+		go h.fireTriggers(project, "message_received", msgMeta)
+		if priority == "P0" {
+			go h.fireTriggers(project, "signal:interrupt", msgMeta)
+		}
 	}
 
 	return h.resultJSONTracked(project, from, "send_message", msg)
@@ -1074,8 +1090,18 @@ func (h *Handlers) HandleRegisterProfile(ctx context.Context, req mcp.CallToolRe
 	soulKeys := normalizeJSONArrayParam(req, "soul_keys")
 	skills := normalizeJSONArrayParam(req, "skills")
 	vaultPaths := normalizeJSONArrayParam(req, "vault_paths")
+	allowedTools := normalizeJSONArrayParam(req, "allowed_tools")
+	poolSize := req.GetInt("pool_size", 0)
 
-	profile, err := h.db.RegisterProfile(project, slug, name, role, contextPack, soulKeys, skills, vaultPaths)
+	var opts []db.ProfileOption
+	if allowedTools != "" && allowedTools != "[]" {
+		opts = append(opts, db.WithAllowedTools(allowedTools))
+	}
+	if poolSize > 0 {
+		opts = append(opts, db.WithPoolSize(poolSize))
+	}
+
+	profile, err := h.db.RegisterProfile(project, slug, name, role, contextPack, soulKeys, skills, vaultPaths, opts...)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("failed to register profile: %v", err)), nil
 	}
@@ -1122,8 +1148,21 @@ func (h *Handlers) HandleDispatchTask(ctx context.Context, req mcp.CallToolReque
 	project := resolveProject(ctx, req)
 	agent := resolveAgent(ctx, req)
 	profile := req.GetString("profile", "")
+	requiredSkill := req.GetString("required_skill", "")
+	// Quota check: tasks
+	if qErr := h.db.CheckQuotaError(project, agent, "tasks"); qErr != "" {
+		return mcp.NewToolResultError(qErr), nil
+	}
+
+	// Auto-resolve profile from skill if not specified
+	if profile == "" && requiredSkill != "" {
+		best, _ := h.db.FindBestProfileForSkill(project, requiredSkill)
+		if best != nil {
+			profile = best.Slug
+		}
+	}
 	if profile == "" {
-		return mcp.NewToolResultError("profile is required"), nil
+		return mcp.NewToolResultError("profile is required (or provide required_skill)"), nil
 	}
 	title := req.GetString("title", "")
 	if title == "" {
@@ -1210,6 +1249,11 @@ func (h *Handlers) HandleDispatchTask(ctx context.Context, req mcp.CallToolReque
 
 	h.events.Emit(MCPEvent{Type: "task", Action: "dispatch", Agent: agent, Project: project, Target: profile, Label: title})
 
+	// Fire triggers for task_pending
+	go h.fireTriggers(project, "task_pending", map[string]string{
+		"profile": profile, "priority": priority, "task_id": task.ID, "dispatched_by": agent, "title": title,
+	})
+
 	resp := map[string]any{"task": task}
 	if autoBoard != nil {
 		resp["auto_board"] = autoBoard
@@ -1295,6 +1339,11 @@ func (h *Handlers) HandleCompleteTask(ctx context.Context, req mcp.CallToolReque
 
 	h.events.Emit(MCPEvent{Type: "task", Action: "complete", Agent: agent, Project: project, Target: task.DispatchedBy, Label: task.Title})
 
+	// Fire triggers for task_completed
+	go h.fireTriggers(project, "task_completed", map[string]string{
+		"task_id": task.ID, "profile": task.ProfileSlug, "completed_by": agent, "title": task.Title,
+	})
+
 	// Notify dispatcher
 	h.registry.Notify(project, task.DispatchedBy, agent, fmt.Sprintf("Task done: %s", task.Title), task.ID)
 
@@ -1344,6 +1393,16 @@ func (h *Handlers) HandleBlockTask(ctx context.Context, req mcp.CallToolRequest)
 	}
 
 	h.events.Emit(MCPEvent{Type: "task", Action: "block", Agent: agent, Project: project, Target: task.DispatchedBy, Label: task.Title})
+
+	// Fire triggers for task_blocked + signal:alert
+	blockMeta := map[string]string{
+		"task_id": task.ID, "profile": task.ProfileSlug, "blocked_by": agent, "title": task.Title,
+	}
+	if reason != nil {
+		blockMeta["reason"] = *reason
+	}
+	go h.fireTriggers(project, "task_blocked", blockMeta)
+	go h.fireTriggers(project, "signal:alert", blockMeta)
 
 	// Notify dispatcher — blocked is critical
 	reasonStr := ""
@@ -2126,11 +2185,24 @@ func (h *Handlers) HandleSleepAgent(ctx context.Context, req mcp.CallToolRequest
 func (h *Handlers) HandleFindProfiles(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	project := resolveProject(ctx, req)
 	tag := req.GetString("skill_tag", "")
-	if tag == "" {
-		return mcp.NewToolResultError("skill_tag is required"), nil
+	skillName := req.GetString("skill_name", "")
+
+	if tag == "" && skillName == "" {
+		return mcp.NewToolResultError("skill_tag or skill_name is required"), nil
 	}
 
-	profiles, err := h.db.FindProfilesBySkillTag(project, tag)
+	var profiles []models.Profile
+	var err error
+	searchKey := tag
+
+	// Prefer structured skill_name (JOIN) over LIKE-based skill_tag
+	if skillName != "" {
+		profiles, err = h.db.FindProfilesBySkill(project, skillName)
+		searchKey = skillName
+	} else {
+		profiles, err = h.db.FindProfilesBySkillTag(project, tag)
+	}
+
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("failed to find profiles: %v", err)), nil
 	}
@@ -2139,9 +2211,9 @@ func (h *Handlers) HandleFindProfiles(ctx context.Context, req mcp.CallToolReque
 	}
 
 	return h.resultJSONTracked(project, "", "find_profiles", map[string]any{
-		"skill_tag": tag,
-		"count":     len(profiles),
-		"profiles":  profiles,
+		"skill":    searchKey,
+		"count":    len(profiles),
+		"profiles": profiles,
 	})
 }
 

--- a/internal/relay/handlers.go
+++ b/internal/relay/handlers.go
@@ -28,6 +28,17 @@ type Handlers struct {
 	events       *EventBus
 	tokenCh      chan db.TokenRecord
 	spawnMgr     *spawn.Manager
+	wfEngine     WorkflowFirer
+}
+
+// WorkflowFirer is the interface the dispatcher uses to fire workflows.
+type WorkflowFirer interface {
+	FireWorkflows(project, event string, meta map[string]string)
+}
+
+// SetWorkflowEngine connects the workflow engine for event-driven execution.
+func (h *Handlers) SetWorkflowEngine(engine WorkflowFirer) {
+	h.wfEngine = engine
 }
 
 func NewHandlers(database *db.DB, registry *SessionRegistry, ingester *ingest.Ingester, vaultWatcher *vault.Watcher, events *EventBus) *Handlers {

--- a/internal/relay/handlers_spawn.go
+++ b/internal/relay/handlers_spawn.go
@@ -1,0 +1,275 @@
+package relay
+
+import (
+	"context"
+	"fmt"
+
+	"agent-relay/internal/spawn"
+
+	"github.com/google/uuid"
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// HandleSpawn spawns a child agent process (fork + exec).
+// Supports two modes:
+//   - Legacy: profile + prompt (raw prompt passed to claude)
+//   - Agent OS: profile + cycle (relay assembles the full context)
+func (h *Handlers) HandleSpawn(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	agent := resolveAgent(ctx, req)
+	project := resolveProject(ctx, req)
+	profile := req.GetString("profile", "")
+	prompt := req.GetString("prompt", "")
+	cycle := req.GetString("cycle", "")
+	taskID := req.GetString("task_id", "")
+	ttl := req.GetString("ttl", "10m")
+	allowedTools := req.GetString("allowed_tools", "")
+
+	if agent == "" {
+		return mcp.NewToolResultError("agent identity required (use 'as' parameter or register first)"), nil
+	}
+	if profile == "" {
+		return mcp.NewToolResultError("profile is required"), nil
+	}
+
+	// Quota check: spawns
+	if qErr := h.db.CheckQuotaError(project, agent, "spawns"); qErr != "" {
+		return mcp.NewToolResultError(qErr), nil
+	}
+
+	if h.spawnMgr == nil {
+		return mcp.NewToolResultError("spawn not available: claude binary not found"), nil
+	}
+
+	var childID string
+	var err error
+
+	if cycle != "" {
+		// Agent OS mode: relay assembles full context from profile + cycle + task
+		childID, err = h.spawnMgr.SpawnWithContext(project, profile, cycle, taskID)
+	} else {
+		// Legacy mode: raw prompt
+		if prompt == "" {
+			return mcp.NewToolResultError("either 'prompt' or 'cycle' is required"), nil
+		}
+		childID, err = h.spawnMgr.Spawn(agent, project, profile, prompt, ttl, allowedTools)
+	}
+
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("spawn failed: %v", err)), nil
+	}
+
+	h.events.Emit(MCPEvent{
+		Type:    "spawn",
+		Action:  "start",
+		Agent:   agent,
+		Project: project,
+		Label:   fmt.Sprintf("child %s (profile: %s, cycle: %s)", childID[:8], profile, cycle),
+	})
+
+	return h.resultJSONTracked(project, agent, "spawn", map[string]any{
+		"child_id": childID,
+		"profile":  profile,
+		"cycle":    cycle,
+		"status":   "running",
+		"message":  fmt.Sprintf("Child agent spawned with profile '%s'. Use list_children to monitor.", profile),
+	})
+}
+
+// HandleKillChild terminates a running child agent.
+func (h *Handlers) HandleKillChild(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	agent := resolveAgent(ctx, req)
+	project := resolveProject(ctx, req)
+	childID := req.GetString("child_id", "")
+
+	if childID == "" {
+		return mcp.NewToolResultError("child_id is required"), nil
+	}
+
+	if h.spawnMgr == nil {
+		return mcp.NewToolResultError("spawn not available"), nil
+	}
+
+	if err := h.spawnMgr.KillChild(childID); err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("kill failed: %v", err)), nil
+	}
+
+	h.events.Emit(MCPEvent{
+		Type:    "spawn",
+		Action:  "kill",
+		Agent:   agent,
+		Project: project,
+		Label:   fmt.Sprintf("killed child %s", childID[:8]),
+	})
+
+	return h.resultJSONTracked(project, agent, "kill_child", map[string]any{
+		"child_id": childID,
+		"status":   "killed",
+	})
+}
+
+// HandleListChildren lists spawned child agents.
+func (h *Handlers) HandleListChildren(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	agent := resolveAgent(ctx, req)
+	project := resolveProject(ctx, req)
+	status := req.GetString("status", "all")
+
+	if h.spawnMgr == nil {
+		return mcp.NewToolResultError("spawn not available"), nil
+	}
+
+	children := h.spawnMgr.ListChildren(agent, project, status)
+	if children == nil {
+		children = []map[string]any{}
+	}
+
+	return h.resultJSONTracked(project, agent, "list_children", map[string]any{
+		"children":     children,
+		"active_count": h.spawnMgr.ActiveCount(project),
+	})
+}
+
+// HandleSchedule creates or updates a cron schedule.
+func (h *Handlers) HandleSchedule(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	agent := resolveAgent(ctx, req)
+	project := resolveProject(ctx, req)
+	name := req.GetString("name", "")
+	cronExpr := req.GetString("cron_expr", "")
+	prompt := req.GetString("prompt", "")
+	ttl := req.GetString("ttl", "10m")
+	cycle := req.GetString("cycle", "")
+	allowedTools := req.GetString("allowed_tools", "")
+
+	if agent == "" {
+		return mcp.NewToolResultError("agent identity required"), nil
+	}
+	if name == "" {
+		return mcp.NewToolResultError("name is required"), nil
+	}
+	if cronExpr == "" {
+		return mcp.NewToolResultError("cron_expr is required"), nil
+	}
+
+	if h.spawnMgr == nil {
+		return mcp.NewToolResultError("scheduler not available"), nil
+	}
+
+	scheduleID := uuid.New().String()
+
+	if err := h.spawnMgr.Schedule(scheduleID, agent, project, name, cronExpr, prompt, ttl, cycle, allowedTools); err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("schedule failed: %v", err)), nil
+	}
+
+	h.events.Emit(MCPEvent{
+		Type:    "schedule",
+		Action:  "create",
+		Agent:   agent,
+		Project: project,
+		Label:   fmt.Sprintf("%s @ %s", name, cronExpr),
+	})
+
+	return h.resultJSONTracked(project, agent, "schedule", map[string]any{
+		"schedule_id": scheduleID,
+		"name":        name,
+		"cron_expr":   cronExpr,
+		"ttl":         ttl,
+		"message":     fmt.Sprintf("Schedule '%s' created. Agent will execute on cron: %s", name, cronExpr),
+	})
+}
+
+// HandleUnschedule removes a cron schedule.
+func (h *Handlers) HandleUnschedule(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	agent := resolveAgent(ctx, req)
+	project := resolveProject(ctx, req)
+	scheduleID := req.GetString("schedule_id", "")
+
+	if scheduleID == "" {
+		return mcp.NewToolResultError("schedule_id is required"), nil
+	}
+
+	if h.spawnMgr == nil {
+		return mcp.NewToolResultError("scheduler not available"), nil
+	}
+
+	h.spawnMgr.Unschedule(scheduleID)
+
+	h.events.Emit(MCPEvent{
+		Type:    "schedule",
+		Action:  "delete",
+		Agent:   agent,
+		Project: project,
+		Label:   scheduleID[:8],
+	})
+
+	return h.resultJSONTracked(project, agent, "unschedule", map[string]any{
+		"schedule_id": scheduleID,
+		"status":      "removed",
+	})
+}
+
+// HandleListSchedules lists cron schedules.
+func (h *Handlers) HandleListSchedules(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	agent := resolveAgent(ctx, req)
+	project := resolveProject(ctx, req)
+
+	var schedules []map[string]any
+	if agent != "" {
+		schedules = h.db.ListSchedulesByAgent(project, agent)
+	} else {
+		schedules = h.db.ListSchedulesByProject(project)
+	}
+	if schedules == nil {
+		schedules = []map[string]any{}
+	}
+
+	schedulerRunning := false
+	jobCount := 0
+	if h.spawnMgr != nil {
+		sched := h.spawnMgr.GetScheduler()
+		schedulerRunning = sched.IsRunning()
+		jobCount = sched.JobCount()
+	}
+
+	return h.resultJSONTracked(project, agent, "list_schedules", map[string]any{
+		"schedules":         schedules,
+		"scheduler_running": schedulerRunning,
+		"total_jobs":        jobCount,
+	})
+}
+
+// HandleTriggerCycle manually triggers a scheduled cycle.
+func (h *Handlers) HandleTriggerCycle(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	agent := resolveAgent(ctx, req)
+	project := resolveProject(ctx, req)
+	scheduleID := req.GetString("schedule_id", "")
+
+	if scheduleID == "" {
+		return mcp.NewToolResultError("schedule_id is required"), nil
+	}
+
+	if h.spawnMgr == nil {
+		return mcp.NewToolResultError("scheduler not available"), nil
+	}
+
+	if err := h.spawnMgr.TriggerCycle(scheduleID); err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("trigger failed: %v", err)), nil
+	}
+
+	h.events.Emit(MCPEvent{
+		Type:    "schedule",
+		Action:  "trigger",
+		Agent:   agent,
+		Project: project,
+		Label:   fmt.Sprintf("manual trigger %s", scheduleID[:8]),
+	})
+
+	return h.resultJSONTracked(project, agent, "trigger_cycle", map[string]any{
+		"schedule_id": scheduleID,
+		"status":      "triggered",
+		"message":     "Cycle triggered. It will execute asynchronously.",
+	})
+}
+
+// SetSpawnManager sets the spawn manager on the handlers (called after construction).
+func (h *Handlers) SetSpawnManager(mgr *spawn.Manager) {
+	h.spawnMgr = mgr
+}

--- a/internal/relay/poller.go
+++ b/internal/relay/poller.go
@@ -1,0 +1,191 @@
+package relay
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"agent-relay/internal/models"
+)
+
+// StartPoller runs a background goroutine that polls URLs and fires triggers.
+func (h *Handlers) StartPoller(done <-chan struct{}) {
+	ticker := time.NewTicker(30 * time.Second)
+	go func() {
+		defer ticker.Stop()
+		for {
+			select {
+			case <-done:
+				return
+			case <-ticker.C:
+				h.pollAll()
+			}
+		}
+	}()
+}
+
+func (h *Handlers) pollAll() {
+	triggers, err := h.db.GetDuePollTriggers()
+	if err != nil {
+		log.Printf("[poller] error fetching due triggers: %v", err)
+		return
+	}
+	for _, pt := range triggers {
+		matched, value, err := h.pollOnce(pt)
+		if err != nil {
+			log.Printf("[poller] %s/%s error: %v", pt.Project, pt.Name, err)
+			_ = h.db.UpdatePollResult(pt.ID, fmt.Sprintf("error: %v", err), false)
+			continue
+		}
+		_ = h.db.UpdatePollResult(pt.ID, value, matched)
+
+		if matched {
+			// Check cooldown
+			if pt.LastPolledAt != "" && pt.LastMatched {
+				if lastPolled, err := time.Parse("2006-01-02T15:04:05Z", pt.LastPolledAt); err == nil {
+					cooldown := time.Duration(pt.CooldownSeconds) * time.Second
+					if time.Since(lastPolled) < cooldown {
+						continue
+					}
+				}
+			}
+
+			// Parse fire_meta
+			meta := map[string]string{}
+			if pt.FireMeta != "" && pt.FireMeta != "{}" {
+				_ = json.Unmarshal([]byte(pt.FireMeta), &meta)
+			}
+			meta["poll_trigger"] = pt.Name
+			meta["matched_value"] = value
+
+			go h.fireTriggers(pt.Project, pt.FireEvent, meta)
+			log.Printf("[poller] %s/%s matched → firing %s", pt.Project, pt.Name, pt.FireEvent)
+		}
+	}
+}
+
+// pollOnce fetches the URL and evaluates the condition.
+func (h *Handlers) pollOnce(pt models.PollTrigger) (matched bool, value string, err error) {
+	req, err := http.NewRequest("GET", pt.URL, nil)
+	if err != nil {
+		return false, "", fmt.Errorf("create request: %w", err)
+	}
+
+	// Apply headers
+	if pt.Headers != "" && pt.Headers != "{}" {
+		var headers map[string]string
+		if err := json.Unmarshal([]byte(pt.Headers), &headers); err == nil {
+			for k, v := range headers {
+				req.Header.Set(k, v)
+			}
+		}
+	}
+
+	client := &http.Client{Timeout: 15 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return false, "", fmt.Errorf("fetch: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20)) // 1MB max
+	if err != nil {
+		return false, "", fmt.Errorf("read body: %w", err)
+	}
+
+	value, err = extractJSONPath(body, pt.ConditionPath)
+	if err != nil {
+		return false, "", fmt.Errorf("extract path %q: %w", pt.ConditionPath, err)
+	}
+
+	matched = evaluateCondition(value, pt.ConditionOp, pt.ConditionValue)
+	return matched, value, nil
+}
+
+// PollOnceByID fetches and evaluates a single poll trigger (for test endpoint).
+func (h *Handlers) PollOnceByID(id string) (matched bool, value string, err error) {
+	pt, err := h.db.GetPollTrigger(id)
+	if err != nil || pt == nil {
+		return false, "", fmt.Errorf("poll trigger not found")
+	}
+	return h.pollOnce(*pt)
+}
+
+// evaluateCondition compares a value against an expected value with the given operator.
+func evaluateCondition(value, op, expected string) bool {
+	switch op {
+	case "eq":
+		return value == expected
+	case "neq":
+		return value != expected
+	case "contains":
+		return strings.Contains(value, expected)
+	case "gt":
+		v, errV := strconv.ParseFloat(value, 64)
+		e, errE := strconv.ParseFloat(expected, 64)
+		if errV != nil || errE != nil {
+			return value > expected // string comparison fallback
+		}
+		return v > e
+	case "lt":
+		v, errV := strconv.ParseFloat(value, 64)
+		e, errE := strconv.ParseFloat(expected, 64)
+		if errV != nil || errE != nil {
+			return value < expected
+		}
+		return v < e
+	default:
+		return value == expected
+	}
+}
+
+// extractJSONPath extracts a value from JSON using dot-notation (e.g., "workflow_runs.0.conclusion").
+func extractJSONPath(body []byte, path string) (string, error) {
+	var data any
+	if err := json.Unmarshal(body, &data); err != nil {
+		return "", fmt.Errorf("parse JSON: %w", err)
+	}
+
+	parts := strings.Split(path, ".")
+	current := data
+	for _, part := range parts {
+		switch v := current.(type) {
+		case map[string]any:
+			val, ok := v[part]
+			if !ok {
+				return "", fmt.Errorf("key %q not found", part)
+			}
+			current = val
+		case []any:
+			idx, err := strconv.Atoi(part)
+			if err != nil || idx < 0 || idx >= len(v) {
+				return "", fmt.Errorf("invalid array index %q", part)
+			}
+			current = v[idx]
+		default:
+			return "", fmt.Errorf("cannot traverse %T with key %q", current, part)
+		}
+	}
+
+	switch v := current.(type) {
+	case string:
+		return v, nil
+	case float64:
+		if v == float64(int64(v)) {
+			return strconv.FormatInt(int64(v), 10), nil
+		}
+		return strconv.FormatFloat(v, 'f', -1, 64), nil
+	case bool:
+		return strconv.FormatBool(v), nil
+	case nil:
+		return "null", nil
+	default:
+		b, _ := json.Marshal(v)
+		return string(b), nil
+	}
+}

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -24,15 +24,15 @@ import (
 
 // Relay is the main struct that wires together the MCP server, DB, and notifications.
 type Relay struct {
-	MCPServer    *server.MCPServer
-	HTTP         *server.StreamableHTTPServer
-	DB           *db.DB
-	Registry     *SessionRegistry
-	Ingester     *ingest.Ingester
-	VaultWatcher *vault.Watcher
-	Events       *EventBus
-	SpawnMgr     *spawn.Manager
-	Scheduler    *scheduler.Scheduler
+	MCPServer      *server.MCPServer
+	HTTP           *server.StreamableHTTPServer
+	DB             *db.DB
+	Registry       *SessionRegistry
+	Ingester       *ingest.Ingester
+	VaultWatcher   *vault.Watcher
+	Events         *EventBus
+	SpawnMgr       *spawn.Manager
+	Scheduler      *scheduler.Scheduler
 	PTYMgr         *spawn.PTYManager
 	Handlers       *Handlers
 	WorkflowEngine *workflow.Engine

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -17,6 +17,7 @@ import (
 	"agent-relay/internal/spawn"
 	"agent-relay/internal/vault"
 	"agent-relay/internal/web"
+	"agent-relay/internal/workflow"
 
 	"github.com/mark3labs/mcp-go/server"
 )
@@ -32,10 +33,12 @@ type Relay struct {
 	Events       *EventBus
 	SpawnMgr     *spawn.Manager
 	Scheduler    *scheduler.Scheduler
-	Handlers     *Handlers
-	Config       config.Config
-	httpServer   *http.Server
-	StartedAt    time.Time
+	PTYMgr         *spawn.PTYManager
+	Handlers       *Handlers
+	WorkflowEngine *workflow.Engine
+	Config         config.Config
+	httpServer     *http.Server
+	StartedAt      time.Time
 }
 
 // New creates a fully wired Relay with all tools registered.
@@ -62,13 +65,32 @@ func New(database *db.DB, ingester *ingest.Ingester, vaultWatcher *vault.Watcher
 	sched := scheduler.New(slogger)
 
 	var spawnMgr *spawn.Manager
+	var ptyMgr *spawn.PTYManager
 	if executor.IsClaudeAvailable() {
 		spawnMgr = spawn.NewManager(database, executor, lockMgr, queue, sched, cfg.MaxPoolSize, slogger)
+		ptyMgr = spawn.NewPTYManager(executor)
 		handlers.SetSpawnManager(spawnMgr)
-		logger.Println("spawn: claude binary found, spawn/schedule enabled")
+		logger.Println("spawn: claude binary found, spawn/schedule/terminal enabled")
 	} else {
 		logger.Println("spawn: claude binary not found, spawn/schedule disabled")
 	}
+
+	// Initialize workflow engine
+	wfEngine := workflow.NewEngine(database, spawnMgr)
+	// Wire message and task functions so workflows can send messages and dispatch tasks
+	wfEngine.SetMessageFunc(func(project, from, to, msgType, subject, content string) error {
+		_, err := database.InsertMessage(project, from, to, msgType, subject, content, "{}", "P2", 0, nil, nil)
+		return err
+	})
+	wfEngine.SetTaskFunc(func(project, profile, title, desc string) (string, error) {
+		task, err := database.DispatchTask(project, profile, "workflow-engine", title, desc, "P2", nil, nil, nil)
+		if err != nil {
+			return "", err
+		}
+		return task.ID, nil
+	})
+
+	handlers.SetWorkflowEngine(wfEngine)
 
 	// Register all tools
 	mcpSrv.AddTools(
@@ -171,18 +193,20 @@ func New(database *db.DB, ingester *ingest.Ingester, vaultWatcher *vault.Watcher
 	)
 
 	return &Relay{
-		MCPServer:    mcpSrv,
-		HTTP:         httpSrv,
-		DB:           database,
-		Registry:     registry,
-		Ingester:     ingester,
-		VaultWatcher: vaultWatcher,
-		Events:       events,
-		SpawnMgr:     spawnMgr,
-		Scheduler:    sched,
-		Handlers:     handlers,
-		Config:       cfg,
-		StartedAt:    time.Now().UTC(),
+		MCPServer:      mcpSrv,
+		HTTP:           httpSrv,
+		DB:             database,
+		Registry:       registry,
+		Ingester:       ingester,
+		VaultWatcher:   vaultWatcher,
+		Events:         events,
+		SpawnMgr:       spawnMgr,
+		PTYMgr:         ptyMgr,
+		Scheduler:      sched,
+		Handlers:       handlers,
+		WorkflowEngine: wfEngine,
+		Config:         cfg,
+		StartedAt:      time.Now().UTC(),
 	}
 }
 

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -4,12 +4,17 @@ import (
 	"context"
 	"io/fs"
 	"log"
+	"log/slog"
 	"net/http"
+	"os"
 	"time"
 
 	"agent-relay/internal/config"
 	"agent-relay/internal/db"
 	"agent-relay/internal/ingest"
+	"agent-relay/internal/lock"
+	"agent-relay/internal/scheduler"
+	"agent-relay/internal/spawn"
 	"agent-relay/internal/vault"
 	"agent-relay/internal/web"
 
@@ -25,6 +30,9 @@ type Relay struct {
 	Ingester     *ingest.Ingester
 	VaultWatcher *vault.Watcher
 	Events       *EventBus
+	SpawnMgr     *spawn.Manager
+	Scheduler    *scheduler.Scheduler
+	Handlers     *Handlers
 	Config       config.Config
 	httpServer   *http.Server
 	StartedAt    time.Time
@@ -43,6 +51,24 @@ func New(database *db.DB, ingester *ingest.Ingester, vaultWatcher *vault.Watcher
 	events := NewEventBus()
 	registry := NewSessionRegistry(mcpSrv)
 	handlers := NewHandlers(database, registry, ingester, vaultWatcher, events)
+
+	// Initialize spawn infrastructure
+	logger := log.Default()
+	slogger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo}))
+
+	executor := spawn.NewExecutor(cfg.ClaudeBinary, slogger)
+	lockMgr := lock.NewManager(cfg.LocksDir, "relay-", slogger)
+	queue := lock.NewPriorityQueue(slogger)
+	sched := scheduler.New(slogger)
+
+	var spawnMgr *spawn.Manager
+	if executor.IsClaudeAvailable() {
+		spawnMgr = spawn.NewManager(database, executor, lockMgr, queue, sched, cfg.MaxPoolSize, slogger)
+		handlers.SetSpawnManager(spawnMgr)
+		logger.Println("spawn: claude binary found, spawn/schedule enabled")
+	} else {
+		logger.Println("spawn: claude binary not found, spawn/schedule disabled")
+	}
 
 	// Register all tools
 	mcpSrv.AddTools(
@@ -126,6 +152,15 @@ func New(database *db.DB, ingester *ingest.Ingester, vaultWatcher *vault.Watcher
 		server.ServerTool{Tool: removeTeamMemberTool(), Handler: handlers.HandleRemoveTeamMember},
 		server.ServerTool{Tool: getTeamInboxTool(), Handler: handlers.HandleGetTeamInbox},
 		server.ServerTool{Tool: addNotifyChannelTool(), Handler: handlers.HandleAddNotifyChannel},
+		// Spawn (fork/exec)
+		server.ServerTool{Tool: spawnTool(), Handler: handlers.HandleSpawn},
+		server.ServerTool{Tool: killChildTool(), Handler: handlers.HandleKillChild},
+		server.ServerTool{Tool: listChildrenTool(), Handler: handlers.HandleListChildren},
+		// Schedule (crontab)
+		server.ServerTool{Tool: scheduleTool(), Handler: handlers.HandleSchedule},
+		server.ServerTool{Tool: unscheduleTool(), Handler: handlers.HandleUnschedule},
+		server.ServerTool{Tool: listSchedulesTool(), Handler: handlers.HandleListSchedules},
+		server.ServerTool{Tool: triggerCycleTool(), Handler: handlers.HandleTriggerCycle},
 	)
 
 	httpSrv := server.NewStreamableHTTPServer(
@@ -143,6 +178,9 @@ func New(database *db.DB, ingester *ingest.Ingester, vaultWatcher *vault.Watcher
 		Ingester:     ingester,
 		VaultWatcher: vaultWatcher,
 		Events:       events,
+		SpawnMgr:     spawnMgr,
+		Scheduler:    sched,
+		Handlers:     handlers,
 		Config:       cfg,
 		StartedAt:    time.Now().UTC(),
 	}

--- a/internal/relay/tools.go
+++ b/internal/relay/tools.go
@@ -290,7 +290,7 @@ func resolveConflictTool() mcp.Tool {
 func registerProfileTool() mcp.Tool {
 	return mcp.NewTool(
 		"register_profile",
-		mcp.WithDescription("Create or update a profile archetype. A profile defines a reusable agent role with a context pack (soul, skills, working style)."),
+		mcp.WithDescription("Create or update a profile archetype. A profile defines a reusable agent role with a context pack (soul, skills, working style). Profiles are the 'executables' of the Agent OS — any spawn slot running this profile inherits all its knowledge."),
 		projectParam,
 		mcp.WithString("slug", mcp.Description("Unique profile identifier (e.g. 'backend', 'frontend', 'devops')"), mcp.Required()),
 		mcp.WithString("name", mcp.Description("Display name for the profile"), mcp.Required()),
@@ -299,6 +299,8 @@ func registerProfileTool() mcp.Tool {
 		mcp.WithString("soul_keys", mcp.Description("Memory keys to load at boot. Accepts JSON string '[\"key1\",\"key2\"]' or native array.")),
 		mcp.WithString("skills", mcp.Description("Skill objects. Accepts JSON string or native array. Format: [{\"id\":\"...\",\"name\":\"...\",\"tags\":[...]}]")),
 		mcp.WithString("vault_paths", mcp.Description("Vault doc path patterns to auto-inject at boot. Accepts JSON string or native array. Supports globs: [\"guides/*.md\"]. {slug} is resolved to the profile slug.")),
+		mcp.WithString("allowed_tools", mcp.Description("Tool patterns this profile can use. JSON array. Examples: [\"mcp__agent-relay__*\",\"Bash\",\"mcp__context7__*\"]. Default: all tools.")),
+		mcp.WithNumber("pool_size", mcp.Description("Max concurrent spawns for this profile (default: 3). Set to 1 for singleton managers like CTO.")),
 	)
 }
 
@@ -842,5 +844,88 @@ func addNotifyChannelTool() mcp.Tool {
 		asParam,
 		projectParam,
 		mcp.WithString("target", mcp.Description("Target agent name to allow messaging to"), mcp.Required()),
+	)
+}
+
+// --- Spawn (fork/exec) tools ---
+
+func spawnTool() mcp.Tool {
+	return mcp.NewTool(
+		"spawn",
+		mcp.WithDescription("Spawn a child agent process (fork). Two modes:\n\n1. **Agent OS mode** (recommended): pass profile + cycle. The relay assembles the full context (identity, task, knowledge, rules, tools) from the DB. The agent opens its eyes knowing everything.\n\n2. **Legacy mode**: pass profile + prompt. Raw prompt is passed directly to claude.\n\nReturns immediately with child ID — executes asynchronously. Use list_children to monitor."),
+		asParam,
+		projectParam,
+		mcp.WithString("profile", mcp.Description("Profile slug for the child agent (e.g. 'backend', 'cto'). Must match a registered profile."), mcp.Required()),
+		mcp.WithString("cycle", mcp.Description("Cycle name (Agent OS mode). The relay loads the cycle prompt from the cycles table and assembles full context (identity, task, knowledge, rules). Examples: 'heartbeat-5min', 'execute-task', 'review-pr'.")),
+		mcp.WithString("task_id", mcp.Description("Task ID to load into context (Agent OS mode). The spawned agent receives the full task details.")),
+		mcp.WithString("prompt", mcp.Description("Raw prompt (legacy mode). Used only if 'cycle' is not set.")),
+		mcp.WithString("ttl", mcp.Description("Max execution time (default: from cycle TTL or '10m'). Accepts Go duration format: '5m', '1h', '30s'.")),
+	)
+}
+
+func killChildTool() mcp.Tool {
+	return mcp.NewTool(
+		"kill_child",
+		mcp.WithDescription("Terminate a running child agent by ID. Sends SIGTERM to the subprocess."),
+		asParam,
+		projectParam,
+		mcp.WithString("child_id", mcp.Description("Child agent ID (from spawn response)"), mcp.Required()),
+	)
+}
+
+func listChildrenTool() mcp.Tool {
+	return mcp.NewTool(
+		"list_children",
+		mcp.WithDescription("List spawned child agents. Shows running and recently finished children with their status, duration, and exit codes."),
+		asParam,
+		projectParam,
+		mcp.WithString("status", mcp.Description("Filter by status: 'running', 'finished', 'killed', or 'all' (default: 'all')"),
+			mcp.Enum("running", "finished", "killed", "all"),
+		),
+	)
+}
+
+// --- Schedule (crontab) tools ---
+
+func scheduleTool() mcp.Tool {
+	return mcp.NewTool(
+		"schedule",
+		mcp.WithDescription("Create or update a cron schedule. Two modes:\n\n1. **Agent OS mode**: set 'cycle' — the relay assembles full context at each trigger (profile + vault + memories + task).\n\n2. **Legacy mode**: set 'prompt' — raw prompt passed to claude each cycle.\n\nLike `crontab -e` for agents."),
+		asParam,
+		projectParam,
+		mcp.WithString("name", mcp.Description("Schedule name (unique per agent, e.g. 'daily-review', '5min-check')"), mcp.Required()),
+		mcp.WithString("cron_expr", mcp.Description("Cron expression (5-field: minute hour day month weekday). Examples: '*/5 * * * *' (every 5min), '0 9 * * *' (daily 9am), '0 */4 * * *' (every 4h)."), mcp.Required()),
+		mcp.WithString("cycle", mcp.Description("Cycle name (Agent OS mode). Loads the cycle prompt from the cycles table and assembles full context. Examples: 'heartbeat-5min', 'heartbeat-1h'.")),
+		mcp.WithString("prompt", mcp.Description("Raw prompt (legacy mode). Used only if 'cycle' is not set.")),
+		mcp.WithString("ttl", mcp.Description("Max execution time per cycle (default: from cycle TTL or '10m')")),
+	)
+}
+
+func unscheduleTool() mcp.Tool {
+	return mcp.NewTool(
+		"unschedule",
+		mcp.WithDescription("Remove a cron schedule. The agent will no longer be triggered on this schedule."),
+		asParam,
+		projectParam,
+		mcp.WithString("schedule_id", mcp.Description("Schedule ID to remove (from list_schedules)"), mcp.Required()),
+	)
+}
+
+func listSchedulesTool() mcp.Tool {
+	return mcp.NewTool(
+		"list_schedules",
+		mcp.WithDescription("List all cron schedules for an agent or project. Like `crontab -l`."),
+		asParam,
+		projectParam,
+	)
+}
+
+func triggerCycleTool() mcp.Tool {
+	return mcp.NewTool(
+		"trigger_cycle",
+		mcp.WithDescription("Manually trigger a scheduled cycle right now, without waiting for the cron timer. Like `systemctl start`."),
+		asParam,
+		projectParam,
+		mcp.WithString("schedule_id", mcp.Description("Schedule ID to trigger (from list_schedules)"), mcp.Required()),
 	)
 }

--- a/internal/relay/ws_terminal.go
+++ b/internal/relay/ws_terminal.go
@@ -95,7 +95,7 @@ func (r *Relay) apiTerminalWS(w http.ResponseWriter, req *http.Request, path str
 		log.Printf("[ws-terminal] upgrade failed: %v", err)
 		return
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 
 	// Subscribe to PTY output — get replay + live channel
 	replay, live, subID := sess.Subscribe()
@@ -117,14 +117,14 @@ func (r *Relay) apiTerminalWS(w http.ResponseWriter, req *http.Request, path str
 			case chunk, ok := <-live:
 				if !ok {
 					// Channel closed — subscriber removed or session ended
-					conn.WriteMessage(websocket.TextMessage, []byte(`{"type":"exit"}`))
+					_ = conn.WriteMessage(websocket.TextMessage, []byte(`{"type":"exit"}`))
 					return
 				}
 				if err := conn.WriteMessage(websocket.BinaryMessage, chunk); err != nil {
 					return
 				}
 			case <-sess.Done():
-				conn.WriteMessage(websocket.TextMessage, []byte(`{"type":"exit"}`))
+				_ = conn.WriteMessage(websocket.TextMessage, []byte(`{"type":"exit"}`))
 				return
 			}
 		}
@@ -137,22 +137,23 @@ func (r *Relay) apiTerminalWS(w http.ResponseWriter, req *http.Request, path str
 			break
 		}
 
-		if msgType == websocket.TextMessage {
+		switch msgType {
+		case websocket.TextMessage:
 			var msg wsMessage
 			if json.Unmarshal(data, &msg) == nil {
 				switch msg.Type {
 				case "resize":
 					if msg.Rows > 0 && msg.Cols > 0 {
-						sess.Resize(msg.Rows, msg.Cols)
+						_ = sess.Resize(msg.Rows, msg.Cols)
 					}
 				case "input":
-					sess.Write([]byte(msg.Data))
+					_, _ = sess.Write([]byte(msg.Data))
 				case "ping":
-					conn.WriteMessage(websocket.TextMessage, []byte(`{"type":"pong"}`))
+					_ = conn.WriteMessage(websocket.TextMessage, []byte(`{"type":"pong"}`))
 				}
 			}
-		} else if msgType == websocket.BinaryMessage {
-			sess.Write(data)
+		case websocket.BinaryMessage:
+			_, _ = sess.Write(data)
 		}
 	}
 

--- a/internal/relay/ws_terminal.go
+++ b/internal/relay/ws_terminal.go
@@ -1,0 +1,176 @@
+package relay
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"strings"
+
+	"agent-relay/internal/spawn"
+
+	"github.com/gorilla/websocket"
+)
+
+var upgrader = websocket.Upgrader{
+	CheckOrigin: func(r *http.Request) bool { return true },
+}
+
+// wsMessage is a message from the browser to the terminal.
+type wsMessage struct {
+	Type string `json:"type"` // "input", "resize", "ping"
+	Data string `json:"data"`
+	Rows uint16 `json:"rows"`
+	Cols uint16 `json:"cols"`
+}
+
+// apiTerminalSpawn handles POST /api/terminal/spawn — creates a PTY session and returns the session ID.
+func (r *Relay) apiTerminalSpawn(w http.ResponseWriter, req *http.Request) {
+	var body struct {
+		Project string `json:"project"`
+		Profile string `json:"profile"`
+		Cycle   string `json:"cycle"`
+		TaskID  string `json:"task_id"`
+		WorkDir string `json:"work_dir"`
+	}
+	if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
+		apiError(w, http.StatusBadRequest, "invalid JSON", err)
+		return
+	}
+	if body.Project == "" {
+		body.Project = "default"
+	}
+	if body.Profile == "" {
+		http.Error(w, `{"error":"profile is required"}`, http.StatusBadRequest)
+		return
+	}
+
+	if r.PTYMgr == nil {
+		http.Error(w, `{"error":"PTY not available"}`, http.StatusServiceUnavailable)
+		return
+	}
+
+	// Build context prompt from profile+cycle — interactive mode gets full context
+	ctx, err := spawn.BuildSpawnContext(r.DB, body.Project, body.Profile, body.Cycle, body.TaskID, spawn.ModeInteractive)
+	if err != nil {
+		apiError(w, http.StatusBadRequest, "build context failed", err)
+		return
+	}
+	prompt := spawn.FormatPrompt(ctx)
+
+	sessionID, _, err := r.PTYMgr.Spawn(prompt, "", "30m", body.WorkDir)
+	if err != nil {
+		apiError(w, http.StatusConflict, "spawn failed", err)
+		return
+	}
+
+	b, _ := json.Marshal(map[string]any{
+		"session_id": sessionID,
+		"profile":    body.Profile,
+		"status":     "running",
+	})
+	w.WriteHeader(http.StatusCreated)
+	w.Write(b)
+}
+
+// apiTerminalWS handles GET /api/terminal/ws/{sessionID} — upgrades to WebSocket.
+// On connect, replays the 128KB ring buffer so the client sees full history,
+// then streams live output. Multiple reconnects are supported.
+func (r *Relay) apiTerminalWS(w http.ResponseWriter, req *http.Request, path string) {
+	sessionID := strings.TrimPrefix(path, "/terminal/ws/")
+	sessionID = strings.TrimSuffix(sessionID, "/")
+
+	if r.PTYMgr == nil {
+		http.Error(w, `{"error":"PTY not available"}`, http.StatusServiceUnavailable)
+		return
+	}
+
+	sess := r.PTYMgr.Get(sessionID)
+	if sess == nil {
+		http.Error(w, `{"error":"session not found"}`, http.StatusNotFound)
+		return
+	}
+
+	conn, err := upgrader.Upgrade(w, req, nil)
+	if err != nil {
+		log.Printf("[ws-terminal] upgrade failed: %v", err)
+		return
+	}
+	defer conn.Close()
+
+	// Subscribe to PTY output — get replay + live channel
+	replay, live, subID := sess.Subscribe()
+	defer sess.Unsubscribe(subID)
+
+	// Send replay buffer first (full history)
+	if len(replay) > 0 {
+		if err := conn.WriteMessage(websocket.BinaryMessage, replay); err != nil {
+			return
+		}
+	}
+
+	// PTY live output → WebSocket (binary frames)
+	wsDone := make(chan struct{})
+	go func() {
+		defer close(wsDone)
+		for {
+			select {
+			case chunk, ok := <-live:
+				if !ok {
+					// Channel closed — subscriber removed or session ended
+					conn.WriteMessage(websocket.TextMessage, []byte(`{"type":"exit"}`))
+					return
+				}
+				if err := conn.WriteMessage(websocket.BinaryMessage, chunk); err != nil {
+					return
+				}
+			case <-sess.Done():
+				conn.WriteMessage(websocket.TextMessage, []byte(`{"type":"exit"}`))
+				return
+			}
+		}
+	}()
+
+	// WebSocket → PTY input
+	for {
+		msgType, data, err := conn.ReadMessage()
+		if err != nil {
+			break
+		}
+
+		if msgType == websocket.TextMessage {
+			var msg wsMessage
+			if json.Unmarshal(data, &msg) == nil {
+				switch msg.Type {
+				case "resize":
+					if msg.Rows > 0 && msg.Cols > 0 {
+						sess.Resize(msg.Rows, msg.Cols)
+					}
+				case "input":
+					sess.Write([]byte(msg.Data))
+				case "ping":
+					conn.WriteMessage(websocket.TextMessage, []byte(`{"type":"pong"}`))
+				}
+			}
+		} else if msgType == websocket.BinaryMessage {
+			sess.Write(data)
+		}
+	}
+
+	<-wsDone
+}
+
+// apiTerminalKill handles POST /api/terminal/{sessionID}/kill.
+func (r *Relay) apiTerminalKill(w http.ResponseWriter, path string) {
+	sessionID := strings.TrimSuffix(strings.TrimPrefix(path, "/terminal/"), "/kill")
+
+	if r.PTYMgr == nil {
+		http.Error(w, `{"error":"PTY not available"}`, http.StatusServiceUnavailable)
+		return
+	}
+
+	if err := r.PTYMgr.Kill(sessionID); err != nil {
+		apiError(w, http.StatusNotFound, "kill failed", err)
+		return
+	}
+	writeJSON(w, map[string]any{"session_id": sessionID, "status": "killed"})
+}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -1,0 +1,92 @@
+package scheduler
+
+import (
+	"fmt"
+	"log/slog"
+	"sync"
+
+	"github.com/robfig/cron/v3"
+)
+
+// Scheduler wraps robfig/cron to manage agent cycles.
+type Scheduler struct {
+	mu      sync.Mutex
+	cron    *cron.Cron
+	jobs    map[string]cron.EntryID // scheduleID -> entry ID
+	logger  *slog.Logger
+	running bool
+}
+
+// New creates a new scheduler.
+func New(logger *slog.Logger) *Scheduler {
+	return &Scheduler{
+		cron:   cron.New(),
+		jobs:   make(map[string]cron.EntryID),
+		logger: logger,
+	}
+}
+
+// Start begins the cron scheduler.
+func (s *Scheduler) Start() {
+	s.mu.Lock()
+	s.running = true
+	s.mu.Unlock()
+	s.cron.Start()
+	s.logger.Info("scheduler started")
+}
+
+// Stop gracefully stops the scheduler.
+func (s *Scheduler) Stop() {
+	ctx := s.cron.Stop()
+	<-ctx.Done()
+	s.mu.Lock()
+	s.running = false
+	s.mu.Unlock()
+	s.logger.Info("scheduler stopped")
+}
+
+// IsRunning returns whether the scheduler is active.
+func (s *Scheduler) IsRunning() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.running
+}
+
+// AddJob schedules a function by a stable schedule ID.
+func (s *Scheduler) AddJob(scheduleID, cronExpr string, fn func()) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Remove existing job with same ID if any
+	if oldID, ok := s.jobs[scheduleID]; ok {
+		s.cron.Remove(oldID)
+	}
+
+	id, err := s.cron.AddFunc(cronExpr, fn)
+	if err != nil {
+		return fmt.Errorf("adding cron job %s (%s): %w", scheduleID, cronExpr, err)
+	}
+
+	s.jobs[scheduleID] = id
+	s.logger.Info("job scheduled", "schedule_id", scheduleID, "expr", cronExpr)
+	return nil
+}
+
+// RemoveJob removes a scheduled job by its ID.
+func (s *Scheduler) RemoveJob(scheduleID string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if id, ok := s.jobs[scheduleID]; ok {
+		s.cron.Remove(id)
+		delete(s.jobs, scheduleID)
+		s.logger.Info("job removed", "schedule_id", scheduleID)
+	}
+}
+
+// JobCount returns total number of scheduled jobs.
+func (s *Scheduler) JobCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.jobs)
+}

--- a/internal/scheduler/ttl.go
+++ b/internal/scheduler/ttl.go
@@ -1,0 +1,19 @@
+package scheduler
+
+import "time"
+
+// DefaultTTL is the default maximum duration for a cycle execution.
+const DefaultTTL = 10 * time.Minute
+
+// ParseTTL parses a TTL string like "10m", "2h", "30s".
+// Returns DefaultTTL if empty or invalid.
+func ParseTTL(s string) time.Duration {
+	if s == "" {
+		return DefaultTTL
+	}
+	d, err := time.ParseDuration(s)
+	if err != nil {
+		return DefaultTTL
+	}
+	return d
+}

--- a/internal/spawn/executor.go
+++ b/internal/spawn/executor.go
@@ -1,0 +1,298 @@
+package spawn
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// TokenUsage holds token consumption from a Claude execution.
+type TokenUsage struct {
+	InputTokens         int64 `json:"input_tokens"`
+	OutputTokens        int64 `json:"output_tokens"`
+	CacheReadTokens     int64 `json:"cache_read_tokens"`
+	CacheCreationTokens int64 `json:"cache_creation_tokens"`
+}
+
+// Total returns the sum of all token types.
+func (t TokenUsage) Total() int64 {
+	return t.InputTokens + t.OutputTokens + t.CacheReadTokens + t.CacheCreationTokens
+}
+
+// ExecResult holds the output of a claude execution.
+type ExecResult struct {
+	Stdout   string
+	Stderr   string
+	Duration time.Duration
+	ExitCode int
+	Err      error
+	Tokens   TokenUsage
+}
+
+// MCPServer describes an MCP server to pass to the spawned claude process.
+type MCPServer struct {
+	Name    string
+	Command string
+	Args    []string
+	Env     map[string]string
+}
+
+// Executor runs claude as a subprocess.
+type Executor struct {
+	ClaudeBinary string
+	Logger       *slog.Logger
+}
+
+// NewExecutor creates an executor.
+func NewExecutor(claudeBinary string, logger *slog.Logger) *Executor {
+	return &Executor{
+		ClaudeBinary: claudeBinary,
+		Logger:       logger,
+	}
+}
+
+// SpawnParams holds parameters for spawning a child agent.
+type SpawnParams struct {
+	Prompt       string
+	TTL          time.Duration
+	AllowedTools string
+	MCPServers   []MCPServer
+	Streaming    bool
+}
+
+// Run executes a claude subprocess with the given prompt and parameters.
+func (e *Executor) Run(ctx context.Context, params SpawnParams) *ExecResult {
+	args := e.buildArgs(params)
+
+	e.Logger.Info("spawning child", "binary", e.ClaudeBinary)
+
+	start := time.Now()
+	execCtx, cancel := context.WithTimeout(ctx, params.TTL)
+	defer cancel()
+
+	cmd := exec.CommandContext(execCtx, e.ClaudeBinary, args...)
+	cmd.Env = cleanEnv()
+	cmd.Stdin = strings.NewReader(params.Prompt)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	duration := time.Since(start)
+
+	result := &ExecResult{
+		Stdout:   stdout.String(),
+		Stderr:   stderr.String(),
+		Duration: duration,
+		Err:      err,
+		ExitCode: exitCode(err),
+		Tokens:   parseTokenUsage(stdout.String()),
+	}
+
+	if err != nil {
+		e.Logger.Error("child failed", "duration", duration, "error", err)
+	} else {
+		e.Logger.Info("child completed", "duration", duration,
+			"input_tokens", result.Tokens.InputTokens, "output_tokens", result.Tokens.OutputTokens)
+	}
+
+	return result
+}
+
+// RunWithLive executes with live output streaming.
+func (e *Executor) RunWithLive(ctx context.Context, params SpawnParams, live io.Writer) *ExecResult {
+	args := e.buildArgs(params)
+
+	e.Logger.Info("spawning child (live)", "binary", e.ClaudeBinary)
+
+	start := time.Now()
+	execCtx, cancel := context.WithTimeout(ctx, params.TTL)
+	defer cancel()
+
+	cmd := exec.CommandContext(execCtx, e.ClaudeBinary, args...)
+	cmd.Env = cleanEnv()
+	cmd.Stdin = strings.NewReader(params.Prompt)
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = io.MultiWriter(&stdout, live)
+	cmd.Stderr = io.MultiWriter(&stderr, live)
+
+	err := cmd.Run()
+	duration := time.Since(start)
+
+	result := &ExecResult{
+		Stdout:   stdout.String(),
+		Stderr:   stderr.String(),
+		Duration: duration,
+		Err:      err,
+		ExitCode: exitCode(err),
+		Tokens:   parseTokenUsage(stdout.String()),
+	}
+
+	if err != nil {
+		e.Logger.Error("child failed", "duration", duration, "error", err)
+	} else {
+		e.Logger.Info("child completed", "duration", duration,
+			"input_tokens", result.Tokens.InputTokens, "output_tokens", result.Tokens.OutputTokens)
+	}
+
+	return result
+}
+
+// IsClaudeAvailable checks if the claude binary is on PATH.
+func (e *Executor) IsClaudeAvailable() bool {
+	_, err := exec.LookPath(e.ClaudeBinary)
+	return err == nil
+}
+
+func (e *Executor) buildArgs(params SpawnParams) []string {
+	allowedTools := params.AllowedTools
+	if allowedTools == "" {
+		allowedTools = DefaultAllowedTools()
+	}
+
+	args := []string{"-p", "-"}
+	if params.Streaming {
+		args = append(args, "--output-format", "stream-json", "--verbose")
+	}
+	args = append(args, "--allowedTools", allowedTools)
+
+	mcpConfig := buildMCPConfig(params.MCPServers)
+	if mcpConfig != "" {
+		args = append(args, "--mcp-config", mcpConfig)
+	}
+
+	return args
+}
+
+// DefaultAllowedTools returns the default allowed tools for spawned agents.
+func DefaultAllowedTools() string {
+	return "Agent,mcp__agent-relay__*,Bash,Read,Write,Edit,Grep,Glob"
+}
+
+func exitCode(err error) int {
+	if err == nil {
+		return 0
+	}
+	if exitErr, ok := err.(*exec.ExitError); ok {
+		return exitErr.ExitCode()
+	}
+	return -1
+}
+
+func cleanEnv() []string {
+	var env []string
+	for _, e := range os.Environ() {
+		if !strings.HasPrefix(e, "CLAUDECODE=") {
+			env = append(env, e)
+		}
+	}
+	return env
+}
+
+func buildMCPConfig(servers []MCPServer) string {
+	if len(servers) == 0 {
+		return ""
+	}
+
+	mcpJSON := map[string]any{
+		"mcpServers": map[string]any{},
+	}
+	serversMap := mcpJSON["mcpServers"].(map[string]any)
+
+	for _, s := range servers {
+		entry := map[string]any{
+			"command": s.Command,
+		}
+		if len(s.Args) > 0 {
+			entry["args"] = s.Args
+		}
+		if len(s.Env) > 0 {
+			entry["env"] = s.Env
+		}
+		serversMap[s.Name] = entry
+	}
+
+	tmpFile, err := os.CreateTemp("", "relay-mcp-*.json")
+	if err != nil {
+		return ""
+	}
+	defer tmpFile.Close()
+
+	if err := json.NewEncoder(tmpFile).Encode(mcpJSON); err != nil {
+		os.Remove(tmpFile.Name())
+		return ""
+	}
+
+	return tmpFile.Name()
+}
+
+// parseTokenUsage extracts token usage from Claude stream-json or JSON output.
+func parseTokenUsage(output string) TokenUsage {
+	var usage TokenUsage
+	for _, line := range strings.Split(output, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		var obj map[string]json.RawMessage
+		if err := json.Unmarshal([]byte(line), &obj); err != nil {
+			continue
+		}
+		if raw, ok := obj["usage"]; ok {
+			var u struct {
+				InputTokens         int64 `json:"input_tokens"`
+				OutputTokens        int64 `json:"output_tokens"`
+				CacheReadTokens     int64 `json:"cache_read_input_tokens"`
+				CacheCreationTokens int64 `json:"cache_creation_input_tokens"`
+			}
+			if json.Unmarshal(raw, &u) == nil && (u.InputTokens > 0 || u.OutputTokens > 0) {
+				usage.InputTokens = u.InputTokens
+				usage.OutputTokens = u.OutputTokens
+				usage.CacheReadTokens = u.CacheReadTokens
+				usage.CacheCreationTokens = u.CacheCreationTokens
+			}
+		}
+		if rawMsg, ok := obj["message"]; ok {
+			var msg struct {
+				Usage struct {
+					InputTokens         int64 `json:"input_tokens"`
+					OutputTokens        int64 `json:"output_tokens"`
+					CacheReadTokens     int64 `json:"cache_read_input_tokens"`
+					CacheCreationTokens int64 `json:"cache_creation_input_tokens"`
+				} `json:"usage"`
+			}
+			if json.Unmarshal(rawMsg, &msg) == nil && (msg.Usage.InputTokens > 0 || msg.Usage.OutputTokens > 0) {
+				usage.InputTokens = msg.Usage.InputTokens
+				usage.OutputTokens = msg.Usage.OutputTokens
+				usage.CacheReadTokens = msg.Usage.CacheReadTokens
+				usage.CacheCreationTokens = msg.Usage.CacheCreationTokens
+			}
+		}
+	}
+	return usage
+}
+
+// LoadPromptFile reads a prompt from a file path (supports ~ expansion).
+func LoadPromptFile(path string) (string, error) {
+	expanded := path
+	if len(path) > 1 && path[:2] == "~/" {
+		home, err := os.UserHomeDir()
+		if err == nil {
+			expanded = filepath.Join(home, path[2:])
+		}
+	}
+	data, err := os.ReadFile(expanded)
+	if err != nil {
+		return "", fmt.Errorf("reading prompt file %s: %w", expanded, err)
+	}
+	return string(data), nil
+}

--- a/internal/spawn/livebuffer.go
+++ b/internal/spawn/livebuffer.go
@@ -1,0 +1,81 @@
+package spawn
+
+import (
+	"sync"
+)
+
+// LiveBuffer stores real-time output per agent during cycle execution.
+type LiveBuffer struct {
+	mu      sync.RWMutex
+	buffers map[string]*agentOutput
+}
+
+type agentOutput struct {
+	Data    []byte
+	Running bool
+	Cycle   string
+}
+
+// NewLiveBuffer creates a new live buffer.
+func NewLiveBuffer() *LiveBuffer {
+	return &LiveBuffer{
+		buffers: make(map[string]*agentOutput),
+	}
+}
+
+// Start marks an agent as running and clears previous output.
+func (lb *LiveBuffer) Start(agent, cycle string) {
+	lb.mu.Lock()
+	defer lb.mu.Unlock()
+	lb.buffers[agent] = &agentOutput{
+		Data:    nil,
+		Running: true,
+		Cycle:   cycle,
+	}
+}
+
+// Writer returns an io.Writer for the agent's live output.
+func (lb *LiveBuffer) Writer(agent string) *AgentWriter {
+	return &AgentWriter{lb: lb, agent: agent}
+}
+
+// Finish marks agent as done.
+func (lb *LiveBuffer) Finish(agent string) {
+	lb.mu.Lock()
+	defer lb.mu.Unlock()
+	if buf, ok := lb.buffers[agent]; ok {
+		buf.Running = false
+	}
+}
+
+// Get returns current output for an agent.
+func (lb *LiveBuffer) Get(agent string) (data string, running bool, cycle string) {
+	lb.mu.RLock()
+	defer lb.mu.RUnlock()
+	buf, ok := lb.buffers[agent]
+	if !ok {
+		return "", false, ""
+	}
+	return string(buf.Data), buf.Running, buf.Cycle
+}
+
+// AgentWriter is an io.Writer that appends to a specific agent's buffer.
+type AgentWriter struct {
+	lb    *LiveBuffer
+	agent string
+}
+
+func (w *AgentWriter) Write(p []byte) (n int, err error) {
+	w.lb.mu.Lock()
+	defer w.lb.mu.Unlock()
+	if buf, ok := w.lb.buffers[w.agent]; ok {
+		// Cap at 64KB to avoid memory issues
+		if len(buf.Data)+len(p) > 64*1024 {
+			// Keep last 32KB + new data
+			buf.Data = append(buf.Data[len(buf.Data)-32*1024:], p...)
+		} else {
+			buf.Data = append(buf.Data, p...)
+		}
+	}
+	return len(p), nil
+}

--- a/internal/spawn/manager.go
+++ b/internal/spawn/manager.go
@@ -1,0 +1,444 @@
+package spawn
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	"agent-relay/internal/db"
+	"agent-relay/internal/lock"
+	"agent-relay/internal/scheduler"
+
+	"github.com/google/uuid"
+)
+
+// ChildState tracks a running spawned child process.
+type ChildState struct {
+	ID        string
+	Parent    string
+	Project   string
+	Profile   string
+	Prompt    string
+	StartedAt time.Time
+	Cancel    context.CancelFunc
+}
+
+// Manager manages agent spawning, scheduling, and pool limits.
+type Manager struct {
+	mu        sync.RWMutex
+	children  map[string]*ChildState // childID -> state
+	executor  *Executor
+	db        *db.DB
+	lockMgr   *lock.Manager
+	queue     *lock.PriorityQueue
+	scheduler *scheduler.Scheduler
+	live      *LiveBuffer
+	metrics   *MetricsCollector
+	logger    *slog.Logger
+	maxPool   int // global max concurrent children
+}
+
+// NewManager creates a spawn manager.
+func NewManager(database *db.DB, executor *Executor, lockMgr *lock.Manager, queue *lock.PriorityQueue, sched *scheduler.Scheduler, maxPool int, logger *slog.Logger) *Manager {
+	return &Manager{
+		children:  make(map[string]*ChildState),
+		executor:  executor,
+		db:        database,
+		lockMgr:   lockMgr,
+		queue:     queue,
+		scheduler: sched,
+		live:      NewLiveBuffer(),
+		metrics:   NewMetricsCollector(1000),
+		logger:    logger,
+		maxPool:   maxPool,
+	}
+}
+
+// Spawn creates a child agent process. Returns the child ID.
+func (m *Manager) Spawn(parentAgent, project, profile, prompt, ttlStr, allowedTools string) (string, error) {
+	m.mu.Lock()
+
+	// Check global pool limit
+	activeCount := 0
+	for _, c := range m.children {
+		if c.Project == project {
+			activeCount++
+		}
+	}
+	if activeCount >= m.maxPool {
+		m.mu.Unlock()
+		return "", fmt.Errorf("pool full: %d/%d active children in project %s", activeCount, m.maxPool, project)
+	}
+
+	childID := uuid.New().String()
+	ctx, cancel := context.WithCancel(context.Background())
+
+	child := &ChildState{
+		ID:        childID,
+		Parent:    parentAgent,
+		Project:   project,
+		Profile:   profile,
+		Prompt:    prompt,
+		StartedAt: time.Now().UTC(),
+		Cancel:    cancel,
+	}
+	m.children[childID] = child
+	m.mu.Unlock()
+
+	// Record in DB
+	m.db.InsertSpawnChild(childID, parentAgent, project, profile, prompt)
+
+	ttl := scheduler.ParseTTL(ttlStr)
+
+	// Build the full prompt with agent context
+	fullPrompt := fmt.Sprintf(`You are a spawned child agent.
+Profile: %s
+Parent agent: %s
+Project: %s
+
+Pass as: "%s-child-%s" and project: "%s" on EVERY relay tool call.
+
+Boot sequence:
+1. Register with the relay: register_agent(name: "%s-child-%s", role: "%s", reports_to: "%s", project: "%s")
+2. Execute your task below.
+3. When done, report results to your parent via send_message.
+
+## Task
+%s
+`, profile, parentAgent, project, profile, childID[:8], project, profile, childID[:8], profile, parentAgent, project, prompt)
+
+	// Spawn in background goroutine
+	go func() {
+		m.live.Start(childID, "spawn")
+
+		params := SpawnParams{
+			Prompt:       fullPrompt,
+			TTL:          ttl,
+			AllowedTools: allowedTools,
+			Streaming:    true,
+		}
+
+		result := m.executor.RunWithLive(ctx, params, m.live.Writer(childID))
+		m.live.Finish(childID)
+
+		// Record metrics
+		metric := CycleMetric{
+			Agent:               parentAgent,
+			Project:             project,
+			Cycle:               "spawn:" + profile,
+			Duration:            result.Duration,
+			Success:             result.ExitCode == 0,
+			ExitCode:            result.ExitCode,
+			Timestamp:           time.Now(),
+			InputTokens:         result.Tokens.InputTokens,
+			OutputTokens:        result.Tokens.OutputTokens,
+			CacheReadTokens:     result.Tokens.CacheReadTokens,
+			CacheCreationTokens: result.Tokens.CacheCreationTokens,
+		}
+		if result.Err != nil {
+			metric.Error = result.Err.Error()
+		}
+		m.metrics.Record(metric)
+
+		// Update DB
+		errMsg := ""
+		if result.Err != nil {
+			errMsg = result.Err.Error()
+		}
+		m.db.UpdateSpawnChild(childID, "finished", result.ExitCode, errMsg)
+
+		// Record cycle history
+		m.db.RecordCycleHistory(parentAgent, project, "spawn:"+profile,
+			result.Duration.Milliseconds(), result.ExitCode == 0, result.ExitCode, errMsg,
+			result.Tokens.InputTokens, result.Tokens.OutputTokens,
+			result.Tokens.CacheReadTokens, result.Tokens.CacheCreationTokens)
+
+		// Cleanup in-memory state
+		m.mu.Lock()
+		delete(m.children, childID)
+		m.mu.Unlock()
+
+		m.logger.Info("child finished",
+			"child_id", childID,
+			"profile", profile,
+			"exit_code", result.ExitCode,
+			"duration", result.Duration,
+		)
+	}()
+
+	m.logger.Info("child spawned",
+		"child_id", childID,
+		"parent", parentAgent,
+		"profile", profile,
+		"project", project,
+	)
+
+	return childID, nil
+}
+
+// KillChild terminates a running child by ID.
+func (m *Manager) KillChild(childID string) error {
+	m.mu.RLock()
+	child, ok := m.children[childID]
+	m.mu.RUnlock()
+
+	if !ok {
+		return fmt.Errorf("child %s not found or already finished", childID)
+	}
+
+	child.Cancel()
+	m.db.UpdateSpawnChild(childID, "killed", -1, "killed by parent")
+
+	m.mu.Lock()
+	delete(m.children, childID)
+	m.mu.Unlock()
+
+	m.logger.Info("child killed", "child_id", childID, "profile", child.Profile)
+	return nil
+}
+
+// ListChildren returns children for a given parent agent and project.
+func (m *Manager) ListChildren(parentAgent, project, status string) []map[string]any {
+	return m.db.ListSpawnChildren(parentAgent, project, status)
+}
+
+// ActiveCount returns the number of currently running children in a project.
+func (m *Manager) ActiveCount(project string) int {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	count := 0
+	for _, c := range m.children {
+		if c.Project == project {
+			count++
+		}
+	}
+	return count
+}
+
+// GetLiveBuffer returns the live output buffer.
+func (m *Manager) GetLiveBuffer() *LiveBuffer {
+	return m.live
+}
+
+// GetMetrics returns the metrics collector.
+func (m *Manager) GetMetrics() *MetricsCollector {
+	return m.metrics
+}
+
+// GetScheduler returns the scheduler.
+func (m *Manager) GetScheduler() *scheduler.Scheduler {
+	return m.scheduler
+}
+
+// GetExecutor returns the executor.
+func (m *Manager) GetExecutor() *Executor {
+	return m.executor
+}
+
+// SpawnWithContext assembles context from DB and spawns an agent.
+// This is the Agent OS "exec" — takes profile + cycle, builds the full prompt.
+func (m *Manager) SpawnWithContext(project, profileSlug, cycleName, taskID string) (string, error) {
+	// Build the full context object
+	ctx, err := BuildSpawnContext(m.db, project, profileSlug, cycleName, taskID, ModeHeadless)
+	if err != nil {
+		return "", fmt.Errorf("build context: %w", err)
+	}
+
+	// Format as prompt
+	prompt := FormatPrompt(ctx)
+
+	// Check per-profile pool limit
+	profile, _ := m.db.GetProfile(project, profileSlug)
+	if profile != nil && profile.PoolSize > 0 {
+		m.mu.RLock()
+		profileCount := 0
+		for _, c := range m.children {
+			if c.Project == project && c.Profile == profileSlug {
+				profileCount++
+			}
+		}
+		m.mu.RUnlock()
+		if profileCount >= profile.PoolSize {
+			return "", fmt.Errorf("profile pool full: %d/%d active for %s", profileCount, profile.PoolSize, profileSlug)
+		}
+	}
+
+	// TTL from cycle DB or default
+	ttl := "10m"
+	if cycleName != "" {
+		if cycle, _ := m.db.GetCycle(project, cycleName); cycle != nil && cycle.TTL > 0 {
+			ttl = fmt.Sprintf("%dm", cycle.TTL)
+		}
+	}
+
+	return m.Spawn("relay-os", project, profileSlug, prompt, ttl, "")
+}
+
+// --- Schedule management ---
+
+// Schedule creates or updates a cron schedule and registers it with the scheduler.
+func (m *Manager) Schedule(id, agentName, project, name, cronExpr, prompt, ttl, cycle, allowedTools string) error {
+	// Store in DB
+	m.db.UpsertSchedule(id, agentName, project, name, cronExpr, prompt, ttl, cycle, allowedTools)
+
+	// Register with cron
+	return m.scheduler.AddJob(id, cronExpr, func() {
+		m.executeCycle(agentName, project, name, prompt, ttl, cycle, allowedTools)
+	})
+}
+
+// Unschedule removes a schedule.
+func (m *Manager) Unschedule(scheduleID string) {
+	m.scheduler.RemoveJob(scheduleID)
+	m.db.DeleteSchedule(scheduleID)
+}
+
+// TriggerCycle manually triggers a scheduled cycle.
+func (m *Manager) TriggerCycle(scheduleID string) error {
+	sched := m.db.GetSchedule(scheduleID)
+	if sched == nil {
+		return fmt.Errorf("schedule %s not found", scheduleID)
+	}
+
+	agentName, _ := sched["agent_name"].(string)
+	project, _ := sched["project"].(string)
+	name, _ := sched["name"].(string)
+	prompt, _ := sched["prompt"].(string)
+	ttl, _ := sched["ttl"].(string)
+	cycle, _ := sched["cycle"].(string)
+	allowedTools, _ := sched["allowed_tools"].(string)
+
+	go m.executeCycle(agentName, project, name, prompt, ttl, cycle, allowedTools)
+	return nil
+}
+
+// LoadSchedulesFromDB loads all enabled schedules from DB and registers them.
+func (m *Manager) LoadSchedulesFromDB() {
+	schedules := m.db.ListAllEnabledSchedules()
+	for _, s := range schedules {
+		id, _ := s["id"].(string)
+		agentName, _ := s["agent_name"].(string)
+		project, _ := s["project"].(string)
+		name, _ := s["name"].(string)
+		cronExpr, _ := s["cron_expr"].(string)
+		prompt, _ := s["prompt"].(string)
+		ttl, _ := s["ttl"].(string)
+		cycle, _ := s["cycle"].(string)
+		allowedTools, _ := s["allowed_tools"].(string)
+
+		err := m.scheduler.AddJob(id, cronExpr, func() {
+			m.executeCycle(agentName, project, name, prompt, ttl, cycle, allowedTools)
+		})
+		if err != nil {
+			m.logger.Error("failed to load schedule", "id", id, "error", err)
+		}
+	}
+	m.logger.Info("schedules loaded from DB", "count", len(schedules))
+}
+
+// executeCycle handles lock acquisition, execution, metrics, and queue processing.
+func (m *Manager) executeCycle(agentName, project, cycleName, prompt, ttlStr, cycle, allowedTools string) {
+	ttl := scheduler.ParseTTL(ttlStr)
+
+	lk, err := m.lockMgr.Acquire(agentName, cycleName, ttl)
+	if err != nil {
+		m.logger.Error("lock error", "agent", agentName, "cycle", cycleName, "error", err)
+		return
+	}
+	if lk == nil {
+		m.queue.Enqueue(agentName, cycleName)
+		return
+	}
+
+	var fullPrompt string
+
+	if cycle != "" {
+		// Agent OS mode: assemble context from DB
+		ctx, err := BuildSpawnContext(m.db, project, agentName, cycle, "", ModeHeadless)
+		if err != nil {
+			m.logger.Error("build context failed", "agent", agentName, "cycle", cycle, "error", err)
+			_ = lk.Release()
+			return
+		}
+		fullPrompt = FormatPrompt(ctx)
+	} else {
+		// Legacy mode: raw prompt
+		fullPrompt = prompt
+		if fullPrompt == "" {
+			fullPrompt = fmt.Sprintf(`You are %s for project %s.
+
+Boot sequence:
+1. get_session_context() — full project state
+2. get_inbox(unread_only: true, full_content: true) — pending messages
+
+Pass as: "%s" and project: "%s" on EVERY relay tool call.
+
+## Cycle: %s
+Process inbox, advance current tasks, update memory before exit.
+`, agentName, project, agentName, project, cycleName)
+		}
+	}
+
+	m.live.Start(agentName+":"+cycleName, cycleName)
+
+	params := SpawnParams{
+		Prompt:    fullPrompt,
+		TTL:       ttl,
+		Streaming: true,
+	}
+
+	result := m.executor.RunWithLive(context.Background(), params, m.live.Writer(agentName+":"+cycleName))
+	m.live.Finish(agentName + ":" + cycleName)
+
+	// Record metrics
+	metric := CycleMetric{
+		Agent:               agentName,
+		Project:             project,
+		Cycle:               cycleName,
+		Duration:            result.Duration,
+		Success:             result.ExitCode == 0,
+		ExitCode:            result.ExitCode,
+		Timestamp:           time.Now(),
+		InputTokens:         result.Tokens.InputTokens,
+		OutputTokens:        result.Tokens.OutputTokens,
+		CacheReadTokens:     result.Tokens.CacheReadTokens,
+		CacheCreationTokens: result.Tokens.CacheCreationTokens,
+	}
+	if result.Err != nil {
+		metric.Error = result.Err.Error()
+	}
+	m.metrics.Record(metric)
+
+	// Persist to DB
+	errMsg := ""
+	if result.Err != nil {
+		errMsg = result.Err.Error()
+	}
+	m.db.RecordCycleHistory(agentName, project, cycleName,
+		result.Duration.Milliseconds(), result.ExitCode == 0, result.ExitCode, errMsg,
+		result.Tokens.InputTokens, result.Tokens.OutputTokens,
+		result.Tokens.CacheReadTokens, result.Tokens.CacheCreationTokens)
+
+	_ = lk.Release()
+
+	// Process queue
+	if nextCycleName, ok := m.queue.Dequeue(agentName); ok {
+		m.logger.Info("processing queued cycle", "agent", agentName, "cycle", nextCycleName)
+		// Look up the schedule for the queued cycle to get its prompt/ttl
+		schedules := m.db.ListSchedulesByAgent(project, agentName)
+		for _, s := range schedules {
+			n, _ := s["name"].(string)
+			if n == nextCycleName {
+				p, _ := s["prompt"].(string)
+				t, _ := s["ttl"].(string)
+				c, _ := s["cycle"].(string)
+				at, _ := s["allowed_tools"].(string)
+				m.executeCycle(agentName, project, nextCycleName, p, t, c, at)
+				break
+			}
+		}
+	}
+}

--- a/internal/spawn/metrics.go
+++ b/internal/spawn/metrics.go
@@ -1,0 +1,61 @@
+package spawn
+
+import (
+	"sync"
+	"time"
+)
+
+// CycleMetric records one cycle execution.
+type CycleMetric struct {
+	Agent               string        `json:"agent"`
+	Project             string        `json:"project"`
+	Cycle               string        `json:"cycle"`
+	Duration            time.Duration `json:"duration_ms"`
+	Success             bool          `json:"success"`
+	ExitCode            int           `json:"exit_code"`
+	Timestamp           time.Time     `json:"timestamp"`
+	Error               string        `json:"error,omitempty"`
+	InputTokens         int64         `json:"input_tokens"`
+	OutputTokens        int64         `json:"output_tokens"`
+	CacheReadTokens     int64         `json:"cache_read_tokens"`
+	CacheCreationTokens int64         `json:"cache_creation_tokens"`
+}
+
+// MetricsCollector stores cycle metrics in memory (ring buffer).
+type MetricsCollector struct {
+	mu      sync.RWMutex
+	history []CycleMetric
+	maxSize int
+}
+
+// NewMetricsCollector creates a collector with a max history size.
+func NewMetricsCollector(maxSize int) *MetricsCollector {
+	return &MetricsCollector{
+		history: make([]CycleMetric, 0, maxSize),
+		maxSize: maxSize,
+	}
+}
+
+// Record adds a cycle metric.
+func (mc *MetricsCollector) Record(m CycleMetric) {
+	mc.mu.Lock()
+	defer mc.mu.Unlock()
+
+	if len(mc.history) >= mc.maxSize {
+		mc.history = mc.history[1:]
+	}
+	mc.history = append(mc.history, m)
+}
+
+// History returns the last N raw metrics.
+func (mc *MetricsCollector) History(n int) []CycleMetric {
+	mc.mu.RLock()
+	defer mc.mu.RUnlock()
+
+	if n > len(mc.history) {
+		n = len(mc.history)
+	}
+	result := make([]CycleMetric, n)
+	copy(result, mc.history[len(mc.history)-n:])
+	return result
+}

--- a/internal/spawn/prompt.go
+++ b/internal/spawn/prompt.go
@@ -1,0 +1,398 @@
+package spawn
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"agent-relay/internal/db"
+)
+
+// SpawnContext is the fully-assembled context object that a spawned agent receives.
+// The agent opens its eyes knowing everything — zero boot calls needed.
+type SpawnContext struct {
+	Identity  *ContextIdentity  `json:"identity"`
+	Task      *ContextTask      `json:"task,omitempty"`
+	Knowledge *ContextKnowledge `json:"knowledge"`
+	Team      *ContextTeam      `json:"team,omitempty"`
+	Inbox     []ContextMessage  `json:"inbox,omitempty"`
+	Rules     *ContextRules     `json:"rules"`
+}
+
+type ContextIdentity struct {
+	Profile     string `json:"profile"`
+	Project     string `json:"project"`
+	Role        string `json:"role"`
+	ContextPack string `json:"context_pack,omitempty"`
+	ReportsTo   string `json:"reports_to,omitempty"`
+}
+
+type ContextTask struct {
+	ID          string `json:"id"`
+	Title       string `json:"title"`
+	Description string `json:"description"`
+	Acceptance  string `json:"acceptance,omitempty"`
+	Priority    string `json:"priority"`
+}
+
+type ContextKnowledge struct {
+	Conventions []string `json:"conventions,omitempty"`
+	Constraints []string `json:"constraints,omitempty"`
+	Lessons     []string `json:"lessons,omitempty"`
+	LastCycle   string   `json:"last_cycle,omitempty"`
+}
+
+type ContextTeam struct {
+	Agents       []ContextAgent `json:"agents,omitempty"`
+	PendingTasks int            `json:"pending_tasks"`
+	BlockedTasks int            `json:"blocked_tasks"`
+}
+
+type ContextAgent struct {
+	Name     string `json:"name"`
+	Status   string `json:"status"`
+	LastSeen string `json:"last_seen"`
+}
+
+type ContextMessage struct {
+	From     string `json:"from"`
+	Subject  string `json:"subject"`
+	Content  string `json:"content"`
+	Priority string `json:"priority,omitempty"`
+}
+
+type ContextRules struct {
+	Cycle string `json:"cycle,omitempty"`
+}
+
+// SpawnMode controls how much context is injected into the agent prompt.
+type SpawnMode string
+
+const (
+	// ModeHeadless is for automated spawns (cron, fire, triggers).
+	// Lean context: constraints + task-relevant FTS + vault index only.
+	ModeHeadless SpawnMode = "headless"
+
+	// ModeInteractive is for manual connections (user launches Claude + connects to relay).
+	// Full context: all memories, full vault docs, all inbox.
+	ModeInteractive SpawnMode = "interactive"
+)
+
+// BuildSpawnContext assembles the full context for a spawned agent.
+// Mode controls the injection strategy: headless = lean, interactive = everything.
+func BuildSpawnContext(database *db.DB, project, profileSlug, cycleName string, taskID string, mode SpawnMode) (*SpawnContext, error) {
+	if mode == "" {
+		mode = ModeHeadless
+	}
+
+	// 1. IDENTITY — load profile
+	profile, err := database.GetProfile(project, profileSlug)
+	if err != nil {
+		return nil, fmt.Errorf("load profile: %w", err)
+	}
+	if profile == nil {
+		return nil, fmt.Errorf("profile %q not found in project %q", profileSlug, project)
+	}
+
+	ctx := &SpawnContext{
+		Identity: &ContextIdentity{
+			Profile:    profile.Slug,
+			Project:    project,
+			Role:       profile.Role,
+			ContextPack: profile.ContextPack,
+		},
+		Knowledge: &ContextKnowledge{},
+		Rules:     &ContextRules{},
+	}
+
+	// 2. TASK — load if specified
+	if taskID != "" {
+		task, err := database.GetTask(taskID, project)
+		if err == nil && task != nil {
+			ctx.Task = &ContextTask{
+				ID:          task.ID,
+				Title:       task.Title,
+				Description: task.Description,
+				Priority:    task.Priority,
+			}
+		}
+	}
+
+	// 3. KNOWLEDGE — strategy differs by mode
+
+	// 3a. Constraints — always ALL, both modes
+	constraints, err := database.GetMemoriesByLayer(project, profileSlug, "constraints")
+	if err == nil {
+		for _, m := range constraints {
+			ctx.Knowledge.Constraints = append(ctx.Knowledge.Constraints,
+				fmt.Sprintf("[%s] %s", m.Key, m.Value))
+		}
+	}
+
+	if mode == ModeInteractive {
+		// Interactive: load ALL behavior + context memories
+		for _, layer := range []string{"behavior", "context"} {
+			mems, err := database.GetMemoriesByLayer(project, profileSlug, layer)
+			if err == nil {
+				for _, m := range mems {
+					ctx.Knowledge.Lessons = append(ctx.Knowledge.Lessons,
+						fmt.Sprintf("[%s] %s", m.Key, m.Value))
+				}
+			}
+		}
+	} else {
+		// Headless: FTS search scoped to task/cycle, skip context + constraints layers
+		searchQuery := ""
+		if ctx.Task != nil {
+			searchQuery = ctx.Task.Title + " " + ctx.Task.Description
+		} else if cycleName != "" {
+			searchQuery = cycleName
+		}
+		if searchQuery != "" {
+			memories, err := database.SearchMemory(project, profileSlug, searchQuery, nil, "", 10)
+			if err == nil {
+				for _, m := range memories {
+					if m.Layer == "context" || m.Layer == "constraints" {
+						continue
+					}
+					ctx.Knowledge.Lessons = append(ctx.Knowledge.Lessons,
+						fmt.Sprintf("[%s] %s", m.Key, m.Value))
+				}
+			}
+		}
+	}
+
+	// 3b. Vault docs
+	if mode == ModeInteractive {
+		// Interactive: load full content from profile's vault_paths
+		if profile.VaultPaths != "" && profile.VaultPaths != "[]" {
+			var paths []string
+			if err := json.Unmarshal([]byte(profile.VaultPaths), &paths); err == nil {
+				resolved := make([]string, len(paths))
+				for i, p := range paths {
+					resolved[i] = strings.ReplaceAll(p, "{slug}", profileSlug)
+				}
+				docs, err := database.GetVaultDocsByPaths(project, resolved, 0)
+				if err == nil {
+					for _, d := range docs {
+						ctx.Knowledge.Conventions = append(ctx.Knowledge.Conventions,
+							fmt.Sprintf("--- %s ---\n%s", d.Path, d.Content))
+					}
+				}
+			}
+		}
+	} else {
+		// Headless: FTS search vault for task/cycle-relevant docs, return paths only
+		vaultQuery := ""
+		if ctx.Task != nil {
+			vaultQuery = ctx.Task.Title
+		} else if cycleName != "" {
+			vaultQuery = cycleName
+		} else {
+			vaultQuery = profileSlug
+		}
+		if vaultQuery != "" {
+			results, err := database.SearchVault(project, vaultQuery, nil, 5)
+			if err == nil {
+				for _, r := range results {
+					ctx.Knowledge.Conventions = append(ctx.Knowledge.Conventions,
+						fmt.Sprintf("`%s` — %s", r.Path, r.Title))
+				}
+			}
+		}
+	}
+
+	// 3c. Last cycle info from cycle_history
+	history := database.GetCycleHistory(project, profileSlug, 1)
+	if len(history) > 0 {
+		h := history[0]
+		createdAt, _ := h["created_at"].(string)
+		cycleName, _ := h["cycle_name"].(string)
+		durationMs, _ := h["duration_ms"].(int64)
+		success, _ := h["success"].(bool)
+		status := "success"
+		if !success {
+			status = "failed"
+		}
+		ctx.Knowledge.LastCycle = fmt.Sprintf("%s: %s (%dms, %s)", createdAt, cycleName, durationMs, status)
+	}
+
+	// 4. CYCLE PROMPT — from cycles table
+	if cycleName != "" {
+		cycle, _ := database.GetCycle(project, cycleName)
+		if cycle != nil {
+			ctx.Rules.Cycle = cycle.Prompt
+		}
+	}
+
+	// 5. INBOX — unread messages for this profile (pruning/TTL handled by DB)
+	inbox, err := database.GetInbox(project, profileSlug, true, 0)
+	if err == nil {
+		for _, msg := range inbox {
+			ctx.Inbox = append(ctx.Inbox, ContextMessage{
+				From:     msg.From,
+				Subject:  msg.Subject,
+				Content:  msg.Content,
+				Priority: msg.Priority,
+			})
+		}
+	}
+
+	// 6. TEAM — for managers (agents with reports_to)
+	agents, err := database.ListAgents(project)
+	if err == nil && len(agents) > 0 {
+		// Check if this profile is a manager (has anyone reporting to it)
+		isManager := false
+		for _, a := range agents {
+			if a.ReportsTo != nil && *a.ReportsTo == profileSlug {
+				isManager = true
+				break
+			}
+		}
+
+		if isManager {
+			team := &ContextTeam{}
+			for _, a := range agents {
+				team.Agents = append(team.Agents, ContextAgent{
+					Name:     a.Name,
+					Status:   a.Status,
+					LastSeen: a.LastSeen,
+				})
+			}
+
+			// Count pending + blocked tasks
+			pendingTasks, _ := database.ListTasks(project, "pending", "", "", "", "", 0, false)
+			blockedTasks, _ := database.ListTasks(project, "blocked", "", "", "", "", 0, false)
+			team.PendingTasks = len(pendingTasks)
+			team.BlockedTasks = len(blockedTasks)
+
+			ctx.Team = team
+		}
+	}
+
+	return ctx, nil
+}
+
+// FormatPrompt converts a SpawnContext into the prompt string passed to claude --headless.
+func FormatPrompt(ctx *SpawnContext) string {
+	var b strings.Builder
+
+	b.WriteString("You are an autonomous agent spawned by the relay OS.\n\n")
+
+	// --- Identity ---
+	b.WriteString("## Identity\n\n")
+	b.WriteString(fmt.Sprintf("- **Profile:** %s\n", ctx.Identity.Profile))
+	b.WriteString(fmt.Sprintf("- **Project:** %s\n", ctx.Identity.Project))
+	b.WriteString(fmt.Sprintf("- **Role:** %s\n", ctx.Identity.Role))
+	if ctx.Identity.ReportsTo != "" {
+		b.WriteString(fmt.Sprintf("- **Reports to:** %s\n", ctx.Identity.ReportsTo))
+	}
+	if ctx.Identity.ContextPack != "" {
+		b.WriteString(fmt.Sprintf("\n%s\n", ctx.Identity.ContextPack))
+	}
+	b.WriteString("\n")
+
+	// --- Boot: register first ---
+	b.WriteString("## Boot: Register First\n\n")
+	b.WriteString(fmt.Sprintf("**Step 0 — before anything else**, call:\n```\nregister_agent(name: %q, role: %q, project: %q", ctx.Identity.Profile, ctx.Identity.Role, ctx.Identity.Project))
+	if ctx.Identity.ReportsTo != "" {
+		b.WriteString(fmt.Sprintf(", reports_to: %q", ctx.Identity.ReportsTo))
+	}
+	b.WriteString(fmt.Sprintf(", profile_slug: %q)\n```\n", ctx.Identity.Profile))
+	b.WriteString("This connects your session to the relay. Without it you cannot send/receive messages, claim tasks, or ACK notifications.\n\n")
+
+	// --- Relay identity reminder ---
+	b.WriteString(fmt.Sprintf("Pass `as: %q` and `project: %q` on **every** relay tool call (except register_agent which uses `name`).\n\n", ctx.Identity.Profile, ctx.Identity.Project))
+
+	// --- Task ---
+	if ctx.Task != nil {
+		b.WriteString("## Task\n\n")
+		b.WriteString(fmt.Sprintf("**[%s] %s**\n\n", ctx.Task.Priority, ctx.Task.Title))
+		b.WriteString(ctx.Task.Description)
+		b.WriteString("\n")
+		if ctx.Task.Acceptance != "" {
+			b.WriteString(fmt.Sprintf("\n**Acceptance criteria:** %s\n", ctx.Task.Acceptance))
+		}
+		b.WriteString("\n")
+	}
+
+	// --- Cycle instructions ---
+	if ctx.Rules.Cycle != "" {
+		b.WriteString("## Cycle Instructions\n\n")
+		b.WriteString(ctx.Rules.Cycle)
+		b.WriteString("\n\n")
+	}
+
+	// --- Constraints (non-negotiable rules) ---
+	if len(ctx.Knowledge.Constraints) > 0 {
+		b.WriteString("## Constraints (non-negotiable)\n\n")
+		for _, c := range ctx.Knowledge.Constraints {
+			b.WriteString(fmt.Sprintf("- %s\n", c))
+		}
+		b.WriteString("\n")
+	}
+
+	// --- Knowledge ---
+	if len(ctx.Knowledge.Conventions) > 0 || len(ctx.Knowledge.Lessons) > 0 || ctx.Knowledge.LastCycle != "" {
+		b.WriteString("## Knowledge\n\n")
+
+		if len(ctx.Knowledge.Conventions) > 0 {
+			b.WriteString("### Conventions (use `get_vault_doc` to load)\n\n")
+			for _, c := range ctx.Knowledge.Conventions {
+				b.WriteString(fmt.Sprintf("- %s\n", c))
+			}
+			b.WriteString("\n")
+		}
+
+		if len(ctx.Knowledge.Lessons) > 0 {
+			b.WriteString("### Lessons Learned\n\n")
+			for _, l := range ctx.Knowledge.Lessons {
+				b.WriteString(fmt.Sprintf("- %s\n", l))
+			}
+			b.WriteString("\n")
+		}
+
+		if ctx.Knowledge.LastCycle != "" {
+			b.WriteString(fmt.Sprintf("### Last Cycle\n\n%s\n\n", ctx.Knowledge.LastCycle))
+		}
+	}
+
+	// --- Inbox ---
+	if len(ctx.Inbox) > 0 {
+		b.WriteString("## Inbox\n\n")
+		for _, m := range ctx.Inbox {
+			prio := ""
+			if m.Priority != "" {
+				prio = fmt.Sprintf(" (%s)", m.Priority)
+			}
+			b.WriteString(fmt.Sprintf("**From %s%s:** %s\n", m.From, prio, m.Subject))
+			if m.Content != "" {
+				b.WriteString(fmt.Sprintf("> %s\n", m.Content))
+			}
+			b.WriteString("\n")
+		}
+	}
+
+	// --- Team ---
+	if ctx.Team != nil && len(ctx.Team.Agents) > 0 {
+		b.WriteString("## Team\n\n")
+		for _, a := range ctx.Team.Agents {
+			b.WriteString(fmt.Sprintf("- **%s** — %s (last seen: %s)\n", a.Name, a.Status, a.LastSeen))
+		}
+		b.WriteString(fmt.Sprintf("\nPending tasks: %d | Blocked tasks: %d\n\n", ctx.Team.PendingTasks, ctx.Team.BlockedTasks))
+	}
+
+	b.WriteString("When done: persist what you learned via `set_memory`, then exit.\n")
+
+	return b.String()
+}
+
+func containsStr(slice []string, s string) bool {
+	for _, v := range slice {
+		if v == s {
+			return true
+		}
+	}
+	return false
+}
+

--- a/internal/spawn/prompt.go
+++ b/internal/spawn/prompt.go
@@ -96,9 +96,9 @@ func BuildSpawnContext(database *db.DB, project, profileSlug, cycleName string, 
 
 	ctx := &SpawnContext{
 		Identity: &ContextIdentity{
-			Profile:    profile.Slug,
-			Project:    project,
-			Role:       profile.Role,
+			Profile:     profile.Slug,
+			Project:     project,
+			Role:        profile.Role,
 			ContextPack: profile.ContextPack,
 		},
 		Knowledge: &ContextKnowledge{},
@@ -281,37 +281,37 @@ func FormatPrompt(ctx *SpawnContext) string {
 
 	// --- Identity ---
 	b.WriteString("## Identity\n\n")
-	b.WriteString(fmt.Sprintf("- **Profile:** %s\n", ctx.Identity.Profile))
-	b.WriteString(fmt.Sprintf("- **Project:** %s\n", ctx.Identity.Project))
-	b.WriteString(fmt.Sprintf("- **Role:** %s\n", ctx.Identity.Role))
+	fmt.Fprintf(&b, "- **Profile:** %s\n", ctx.Identity.Profile)
+	fmt.Fprintf(&b, "- **Project:** %s\n", ctx.Identity.Project)
+	fmt.Fprintf(&b, "- **Role:** %s\n", ctx.Identity.Role)
 	if ctx.Identity.ReportsTo != "" {
-		b.WriteString(fmt.Sprintf("- **Reports to:** %s\n", ctx.Identity.ReportsTo))
+		fmt.Fprintf(&b, "- **Reports to:** %s\n", ctx.Identity.ReportsTo)
 	}
 	if ctx.Identity.ContextPack != "" {
-		b.WriteString(fmt.Sprintf("\n%s\n", ctx.Identity.ContextPack))
+		fmt.Fprintf(&b, "\n%s\n", ctx.Identity.ContextPack)
 	}
 	b.WriteString("\n")
 
 	// --- Boot: register first ---
 	b.WriteString("## Boot: Register First\n\n")
-	b.WriteString(fmt.Sprintf("**Step 0 — before anything else**, call:\n```\nregister_agent(name: %q, role: %q, project: %q", ctx.Identity.Profile, ctx.Identity.Role, ctx.Identity.Project))
+	fmt.Fprintf(&b, "**Step 0 — before anything else**, call:\n```\nregister_agent(name: %q, role: %q, project: %q", ctx.Identity.Profile, ctx.Identity.Role, ctx.Identity.Project)
 	if ctx.Identity.ReportsTo != "" {
-		b.WriteString(fmt.Sprintf(", reports_to: %q", ctx.Identity.ReportsTo))
+		fmt.Fprintf(&b, ", reports_to: %q", ctx.Identity.ReportsTo)
 	}
-	b.WriteString(fmt.Sprintf(", profile_slug: %q)\n```\n", ctx.Identity.Profile))
+	fmt.Fprintf(&b, ", profile_slug: %q)\n```\n", ctx.Identity.Profile)
 	b.WriteString("This connects your session to the relay. Without it you cannot send/receive messages, claim tasks, or ACK notifications.\n\n")
 
 	// --- Relay identity reminder ---
-	b.WriteString(fmt.Sprintf("Pass `as: %q` and `project: %q` on **every** relay tool call (except register_agent which uses `name`).\n\n", ctx.Identity.Profile, ctx.Identity.Project))
+	fmt.Fprintf(&b, "Pass `as: %q` and `project: %q` on **every** relay tool call (except register_agent which uses `name`).\n\n", ctx.Identity.Profile, ctx.Identity.Project)
 
 	// --- Task ---
 	if ctx.Task != nil {
 		b.WriteString("## Task\n\n")
-		b.WriteString(fmt.Sprintf("**[%s] %s**\n\n", ctx.Task.Priority, ctx.Task.Title))
+		fmt.Fprintf(&b, "**[%s] %s**\n\n", ctx.Task.Priority, ctx.Task.Title)
 		b.WriteString(ctx.Task.Description)
 		b.WriteString("\n")
 		if ctx.Task.Acceptance != "" {
-			b.WriteString(fmt.Sprintf("\n**Acceptance criteria:** %s\n", ctx.Task.Acceptance))
+			fmt.Fprintf(&b, "\n**Acceptance criteria:** %s\n", ctx.Task.Acceptance)
 		}
 		b.WriteString("\n")
 	}
@@ -327,7 +327,7 @@ func FormatPrompt(ctx *SpawnContext) string {
 	if len(ctx.Knowledge.Constraints) > 0 {
 		b.WriteString("## Constraints (non-negotiable)\n\n")
 		for _, c := range ctx.Knowledge.Constraints {
-			b.WriteString(fmt.Sprintf("- %s\n", c))
+			fmt.Fprintf(&b, "- %s\n", c)
 		}
 		b.WriteString("\n")
 	}
@@ -339,7 +339,7 @@ func FormatPrompt(ctx *SpawnContext) string {
 		if len(ctx.Knowledge.Conventions) > 0 {
 			b.WriteString("### Conventions (use `get_vault_doc` to load)\n\n")
 			for _, c := range ctx.Knowledge.Conventions {
-				b.WriteString(fmt.Sprintf("- %s\n", c))
+				fmt.Fprintf(&b, "- %s\n", c)
 			}
 			b.WriteString("\n")
 		}
@@ -347,13 +347,13 @@ func FormatPrompt(ctx *SpawnContext) string {
 		if len(ctx.Knowledge.Lessons) > 0 {
 			b.WriteString("### Lessons Learned\n\n")
 			for _, l := range ctx.Knowledge.Lessons {
-				b.WriteString(fmt.Sprintf("- %s\n", l))
+				fmt.Fprintf(&b, "- %s\n", l)
 			}
 			b.WriteString("\n")
 		}
 
 		if ctx.Knowledge.LastCycle != "" {
-			b.WriteString(fmt.Sprintf("### Last Cycle\n\n%s\n\n", ctx.Knowledge.LastCycle))
+			fmt.Fprintf(&b, "### Last Cycle\n\n%s\n\n", ctx.Knowledge.LastCycle)
 		}
 	}
 
@@ -365,9 +365,9 @@ func FormatPrompt(ctx *SpawnContext) string {
 			if m.Priority != "" {
 				prio = fmt.Sprintf(" (%s)", m.Priority)
 			}
-			b.WriteString(fmt.Sprintf("**From %s%s:** %s\n", m.From, prio, m.Subject))
+			fmt.Fprintf(&b, "**From %s%s:** %s\n", m.From, prio, m.Subject)
 			if m.Content != "" {
-				b.WriteString(fmt.Sprintf("> %s\n", m.Content))
+				fmt.Fprintf(&b, "> %s\n", m.Content)
 			}
 			b.WriteString("\n")
 		}
@@ -377,22 +377,12 @@ func FormatPrompt(ctx *SpawnContext) string {
 	if ctx.Team != nil && len(ctx.Team.Agents) > 0 {
 		b.WriteString("## Team\n\n")
 		for _, a := range ctx.Team.Agents {
-			b.WriteString(fmt.Sprintf("- **%s** — %s (last seen: %s)\n", a.Name, a.Status, a.LastSeen))
+			fmt.Fprintf(&b, "- **%s** — %s (last seen: %s)\n", a.Name, a.Status, a.LastSeen)
 		}
-		b.WriteString(fmt.Sprintf("\nPending tasks: %d | Blocked tasks: %d\n\n", ctx.Team.PendingTasks, ctx.Team.BlockedTasks))
+		fmt.Fprintf(&b, "\nPending tasks: %d | Blocked tasks: %d\n\n", ctx.Team.PendingTasks, ctx.Team.BlockedTasks)
 	}
 
 	b.WriteString("When done: persist what you learned via `set_memory`, then exit.\n")
 
 	return b.String()
 }
-
-func containsStr(slice []string, s string) bool {
-	for _, v := range slice {
-		if v == s {
-			return true
-		}
-	}
-	return false
-}
-

--- a/internal/spawn/pty.go
+++ b/internal/spawn/pty.go
@@ -1,0 +1,220 @@
+package spawn
+
+import (
+	"context"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+
+	"github.com/creack/pty"
+)
+
+const replayBufSize = 128 * 1024 // 128KB rolling buffer
+
+// PTYSession holds a running process with a PTY attached.
+// A persistent reader goroutine pumps PTY output into a ring buffer
+// and broadcasts to subscribed WebSocket connections.
+type PTYSession struct {
+	ID     string
+	PTY    *os.File
+	Cmd    *exec.Cmd
+	Cancel context.CancelFunc
+
+	mu     sync.Mutex
+	closed bool
+
+	// Ring buffer for replay on reconnect
+	ring    []byte
+	ringPos int  // next write position in ring
+	ringLen int  // bytes written (capped at replayBufSize)
+
+	// Subscriber channels — each WS connection gets one
+	subs   map[uint64]chan []byte
+	subSeq uint64
+	subMu  sync.Mutex
+
+	// Signals that the PTY reader has stopped
+	done chan struct{}
+}
+
+// Write sends input to the PTY (from browser → process stdin).
+func (s *PTYSession) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return 0, io.ErrClosedPipe
+	}
+	return s.PTY.Write(p)
+}
+
+// Close terminates the PTY session.
+func (s *PTYSession) Close() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return
+	}
+	s.closed = true
+	s.Cancel()
+	s.PTY.Close()
+}
+
+// Resize changes the PTY window size.
+func (s *PTYSession) Resize(rows, cols uint16) error {
+	return pty.Setsize(s.PTY, &pty.Winsize{Rows: rows, Cols: cols})
+}
+
+// Subscribe returns the replay buffer contents and a channel for live output.
+// Call Unsubscribe when the WS disconnects.
+func (s *PTYSession) Subscribe() (replay []byte, ch <-chan []byte, id uint64) {
+	s.subMu.Lock()
+	defer s.subMu.Unlock()
+
+	// Snapshot the ring buffer
+	s.mu.Lock()
+	if s.ringLen > 0 {
+		replay = make([]byte, s.ringLen)
+		if s.ringLen < replayBufSize {
+			copy(replay, s.ring[:s.ringLen])
+		} else {
+			// Ring wrapped — read from ringPos to end, then start to ringPos
+			n := copy(replay, s.ring[s.ringPos:])
+			copy(replay[n:], s.ring[:s.ringPos])
+		}
+	}
+	s.mu.Unlock()
+
+	c := make(chan []byte, 64)
+	s.subSeq++
+	id = s.subSeq
+	s.subs[id] = c
+	return replay, c, id
+}
+
+// Unsubscribe removes a subscriber.
+func (s *PTYSession) Unsubscribe(id uint64) {
+	s.subMu.Lock()
+	defer s.subMu.Unlock()
+	if ch, ok := s.subs[id]; ok {
+		close(ch)
+		delete(s.subs, id)
+	}
+}
+
+// Done returns a channel that closes when the PTY reader stops (process exit).
+func (s *PTYSession) Done() <-chan struct{} {
+	return s.done
+}
+
+// startReader pumps PTY output into the ring buffer and broadcasts to subscribers.
+// Must be called once after PTY is started.
+func (s *PTYSession) startReader() {
+	s.done = make(chan struct{})
+	s.subs = make(map[uint64]chan []byte)
+	s.ring = make([]byte, replayBufSize)
+
+	go func() {
+		defer close(s.done)
+		buf := make([]byte, 4096)
+		for {
+			n, err := s.PTY.Read(buf)
+			if n > 0 {
+				chunk := make([]byte, n)
+				copy(chunk, buf[:n])
+
+				// Write to ring buffer
+				s.mu.Lock()
+				for i := 0; i < n; i++ {
+					s.ring[s.ringPos] = chunk[i]
+					s.ringPos = (s.ringPos + 1) % replayBufSize
+					if s.ringLen < replayBufSize {
+						s.ringLen++
+					}
+				}
+				s.mu.Unlock()
+
+				// Broadcast to subscribers (non-blocking)
+				s.subMu.Lock()
+				for _, ch := range s.subs {
+					select {
+					case ch <- chunk:
+					default:
+						// subscriber too slow, drop
+					}
+				}
+				s.subMu.Unlock()
+			}
+			if err != nil {
+				return
+			}
+		}
+	}()
+}
+
+// StartPTY spawns claude in INTERACTIVE mode with a pseudo-terminal.
+// The context prompt is passed via --append-system-prompt so the agent
+// boots with full identity/context. workDir sets the process cwd.
+func (e *Executor) StartPTY(ctx context.Context, params SpawnParams, workDir string) (*PTYSession, error) {
+	args := []string{}
+
+	allowedTools := params.AllowedTools
+	if allowedTools == "" {
+		allowedTools = DefaultAllowedTools()
+	}
+	args = append(args, "--allowedTools", allowedTools)
+
+	mcpConfig := buildMCPConfig(params.MCPServers)
+	if mcpConfig != "" {
+		args = append(args, "--mcp-config", mcpConfig)
+	}
+
+	if params.Prompt != "" {
+		args = append(args, "--append-system-prompt", params.Prompt)
+	}
+
+	execCtx, cancel := context.WithTimeout(ctx, params.TTL)
+	cmd := exec.CommandContext(execCtx, e.ClaudeBinary, args...)
+	cmd.Env = ptyEnv()
+	if workDir != "" {
+		cmd.Dir = workDir
+	}
+
+	ptmx, err := pty.Start(cmd)
+	if err != nil {
+		cancel()
+		return nil, err
+	}
+
+	_ = pty.Setsize(ptmx, &pty.Winsize{Rows: 24, Cols: 120})
+
+	e.Logger.Info("spawned interactive PTY", "binary", e.ClaudeBinary, "pid", cmd.Process.Pid, "prompt_len", len(params.Prompt), "work_dir", workDir)
+
+	sess := &PTYSession{
+		PTY:    ptmx,
+		Cmd:    cmd,
+		Cancel: cancel,
+	}
+	sess.startReader()
+
+	return sess, nil
+}
+
+// ptyEnv returns a clean environment with TERM set for TUI rendering.
+func ptyEnv() []string {
+	env := cleanEnv()
+	hasTerm := false
+	for i, e := range env {
+		if strings.HasPrefix(e, "TERM=") {
+			env[i] = "TERM=xterm-256color"
+			hasTerm = true
+			break
+		}
+	}
+	if !hasTerm {
+		env = append(env, "TERM=xterm-256color")
+	}
+	env = append(env, "FORCE_COLOR=1", "COLORTERM=truecolor")
+	return env
+}

--- a/internal/spawn/pty.go
+++ b/internal/spawn/pty.go
@@ -27,8 +27,8 @@ type PTYSession struct {
 
 	// Ring buffer for replay on reconnect
 	ring    []byte
-	ringPos int  // next write position in ring
-	ringLen int  // bytes written (capped at replayBufSize)
+	ringPos int // next write position in ring
+	ringLen int // bytes written (capped at replayBufSize)
 
 	// Subscriber channels — each WS connection gets one
 	subs   map[uint64]chan []byte

--- a/internal/spawn/pty_manager.go
+++ b/internal/spawn/pty_manager.go
@@ -1,0 +1,105 @@
+package spawn
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+func parseTTLDuration(s string) time.Duration {
+	if s == "" {
+		return 10 * time.Minute
+	}
+	d, err := time.ParseDuration(s)
+	if err != nil {
+		return 10 * time.Minute
+	}
+	return d
+}
+
+// PTYManager tracks interactive PTY sessions (separate from headless children).
+type PTYManager struct {
+	mu       sync.RWMutex
+	sessions map[string]*PTYSession // sessionID -> PTYSession
+	executor *Executor
+}
+
+// NewPTYManager creates a PTY session manager.
+func NewPTYManager(executor *Executor) *PTYManager {
+	return &PTYManager{
+		sessions: make(map[string]*PTYSession),
+		executor: executor,
+	}
+}
+
+// Spawn creates a new interactive PTY session.
+func (pm *PTYManager) Spawn(prompt, allowedTools, ttl, workDir string) (string, *PTYSession, error) {
+	pm.mu.Lock()
+	defer pm.mu.Unlock()
+
+	if len(pm.sessions) >= 5 {
+		return "", nil, fmt.Errorf("max 5 concurrent PTY sessions")
+	}
+
+	params := SpawnParams{
+		Prompt:       prompt,
+		TTL:          parseTTLDuration(ttl),
+		AllowedTools: allowedTools,
+		Streaming:    true,
+	}
+
+	sess, err := pm.executor.StartPTY(context.Background(), params, workDir)
+	if err != nil {
+		return "", nil, fmt.Errorf("start PTY: %w", err)
+	}
+
+	id := uuid.New().String()
+	sess.ID = id
+	pm.sessions[id] = sess
+
+	// Auto-cleanup when process exits
+	go func() {
+		_ = sess.Cmd.Wait()
+		pm.mu.Lock()
+		delete(pm.sessions, id)
+		pm.mu.Unlock()
+	}()
+
+	return id, sess, nil
+}
+
+// Get returns a PTY session by ID.
+func (pm *PTYManager) Get(id string) *PTYSession {
+	pm.mu.RLock()
+	defer pm.mu.RUnlock()
+	return pm.sessions[id]
+}
+
+// Kill terminates a PTY session.
+func (pm *PTYManager) Kill(id string) error {
+	pm.mu.Lock()
+	sess, ok := pm.sessions[id]
+	if !ok {
+		pm.mu.Unlock()
+		return fmt.Errorf("session %s not found", id)
+	}
+	delete(pm.sessions, id)
+	pm.mu.Unlock()
+
+	sess.Close()
+	return nil
+}
+
+// List returns all active session IDs.
+func (pm *PTYManager) List() []string {
+	pm.mu.RLock()
+	defer pm.mu.RUnlock()
+	ids := make([]string, 0, len(pm.sessions))
+	for id := range pm.sessions {
+		ids = append(ids, id)
+	}
+	return ids
+}

--- a/internal/spawn/reaper.go
+++ b/internal/spawn/reaper.go
@@ -1,0 +1,66 @@
+package spawn
+
+import (
+	"log/slog"
+	"time"
+
+	"agent-relay/internal/db"
+)
+
+// StartReaper runs a background goroutine that detects ghost spawns
+// (DB says "running" but process is gone) and marks them as dead.
+func StartReaper(database *db.DB, mgr *Manager, done <-chan struct{}, logger *slog.Logger) {
+	go func() {
+		ticker := time.NewTicker(30 * time.Second)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-done:
+				return
+			case <-ticker.C:
+				reapGhosts(database, mgr, logger)
+			}
+		}
+	}()
+}
+
+func reapGhosts(database *db.DB, mgr *Manager, logger *slog.Logger) {
+	// Find all children marked as "running" in DB
+	children := database.ListRunningChildren()
+	if len(children) == 0 {
+		return
+	}
+
+	// Get the set of children tracked in-memory (= truly alive)
+	mgr.mu.RLock()
+	activeIDs := make(map[string]bool, len(mgr.children))
+	for id := range mgr.children {
+		activeIDs[id] = true
+	}
+	mgr.mu.RUnlock()
+
+	for _, c := range children {
+		id, _ := c["id"].(string)
+		if id == "" {
+			continue
+		}
+
+		// If the child is in the manager's map, it's still alive
+		if activeIDs[id] {
+			continue
+		}
+
+		// Ghost detected — DB says running but manager doesn't know about it.
+		// This happens when relay restarts while children were running,
+		// or when a process disappears (OOM, SIGKILL, machine reboot).
+		startedAt, _ := c["started_at"].(string)
+		profile, _ := c["profile"].(string)
+		logger.Warn("ghost spawn detected — marking dead",
+			"child_id", id,
+			"profile", profile,
+			"started_at", startedAt,
+		)
+		database.UpdateSpawnChild(id, "dead", -1, "ghost: process not tracked (relay restart or crash)")
+	}
+}

--- a/internal/web/static/index.html
+++ b/internal/web/static/index.html
@@ -7,9 +7,12 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easymde/dist/easymde.min.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@xterm/xterm@5/css/xterm.css">
   <link rel="stylesheet" href="/style.css">
   <script src="https://cdn.jsdelivr.net/npm/easymde/dist/easymde.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/marked/lib/marked.umd.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@xterm/xterm@5/lib/xterm.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@xterm/addon-fit@0/lib/addon-fit.js"></script>
 </head>
 <body>
   <header id="header">
@@ -50,6 +53,9 @@
         <button class="mode-btn" data-mode="vault" title="Docs [3]">
           <span class="mode-icon">&#9776;</span>
         </button>
+        <button class="mode-btn" data-mode="ops" title="Ops [4]">
+          <span class="mode-icon">&#9881;</span>
+        </button>
       </div>
     </div>
     <div class="header-right">
@@ -68,21 +74,25 @@
   </header>
 
   <main id="main" class="mode-canvas">
-    <div id="canvas-container">
-      <canvas id="relay-canvas"></canvas>
-      <div id="asset-picker" class="hidden">
-        <div id="asset-picker-title">SELECT</div>
-        <div id="asset-picker-grid"></div>
-      </div>
-      <!-- Quest Tracker HUD -->
-      <div id="quest-tracker" class="quest-tracker collapsed">
-        <div id="quest-tracker-header">
-          <span class="qt-icon">&#9670;</span>
-          <span class="qt-title">OBJECTIVES</span>
-          <span id="qt-toggle" class="qt-toggle">&#9660;</span>
+    <div id="left-column">
+      <div id="canvas-container">
+        <canvas id="relay-canvas"></canvas>
+        <div id="asset-picker" class="hidden">
+          <div id="asset-picker-title">SELECT</div>
+          <div id="asset-picker-grid"></div>
         </div>
-        <div id="quest-tracker-body"></div>
+        <!-- Quest Tracker HUD -->
+        <div id="quest-tracker" class="quest-tracker collapsed">
+          <div id="quest-tracker-header">
+            <span class="qt-icon">&#9670;</span>
+            <span class="qt-title">OBJECTIVES</span>
+            <span id="qt-toggle" class="qt-toggle">&#9660;</span>
+          </div>
+          <div id="quest-tracker-body"></div>
+        </div>
       </div>
+      <div id="cmd-resize-handle" class="colony-only"></div>
+      <div id="command-panel" class="colony-only"></div>
     </div>
 
     <!-- Kanban panel (hidden by default, shown in kanban mode) -->
@@ -90,6 +100,9 @@
 
     <!-- Vault panel (hidden by default, shown in vault mode) -->
     <div id="vault-panel" class="hidden"></div>
+
+    <!-- Ops panel (hidden by default, shown in ops mode) -->
+    <div id="ops-panel" class="hidden"></div>
 
     <div id="messages-panel">
       <div id="messages-header">
@@ -227,6 +240,30 @@
       </div>
     </div>
 
+    <!-- Skills -->
+    <div class="dp-section">
+      <div class="dp-section-header" data-toggle="dp-skills-body">SKILLS</div>
+      <div id="dp-skills-body" class="dp-section-body">
+        <div id="detail-skills" class="detail-value"></div>
+      </div>
+    </div>
+
+    <!-- Quotas -->
+    <div class="dp-section">
+      <div class="dp-section-header" data-toggle="dp-quotas-body">QUOTAS</div>
+      <div id="dp-quotas-body" class="dp-section-body">
+        <div id="detail-quotas" class="detail-value"></div>
+      </div>
+    </div>
+
+    <!-- Elevation -->
+    <div class="dp-section">
+      <div class="dp-section-header" data-toggle="dp-elevation-body">ELEVATION</div>
+      <div id="dp-elevation-body" class="dp-section-body">
+        <div id="detail-elevation" class="detail-value"></div>
+      </div>
+    </div>
+
     <!-- Nav arrows -->
     <div class="dp-nav">
       <button id="dp-nav-prev" class="dp-nav-btn" title="Previous agent [←]">
@@ -269,6 +306,7 @@
           <li><b>Canvas</b> <kbd>1</kbd> — agents on planet surface, message orb animations</li>
           <li><b>Kanban</b> <kbd>2</kbd> — task boards with drag &amp; drop, sprint columns</li>
           <li><b>Vault</b> <kbd>3</kbd> — project docs, file tree, inline markdown editor</li>
+          <li><b>Ops</b> <kbd>4</kbd> — OS primitives: triggers, polls, skills, quotas</li>
         </ul>
       </div>
 
@@ -352,6 +390,17 @@
       </div>
 
       <div class="help-section">
+        <h3>Ops Console</h3>
+        <ul>
+          <li><b>Triggers</b> — event-driven automation rules (fire on event match)</li>
+          <li><b>Polls</b> — URL polling triggers (check external endpoints on interval)</li>
+          <li><b>Skills</b> — skill registry with proficiency levels, service discovery</li>
+          <li><b>Quotas</b> — per-agent rate limits (tokens, messages, tasks, spawns)</li>
+          <li>Agent detail panel shows Skills, Quotas, and Elevation status</li>
+        </ul>
+      </div>
+
+      <div class="help-section">
         <h3>User Notifications</h3>
         <ul>
           <li>Agents send <code>to: "user"</code> — cards appear bottom-left</li>
@@ -369,6 +418,7 @@
           <tr><td><kbd>1</kbd></td><td>Canvas view</td></tr>
           <tr><td><kbd>2</kbd></td><td>Kanban view</td></tr>
           <tr><td><kbd>3</kbd></td><td>Vault (Docs) view</td></tr>
+          <tr><td><kbd>4</kbd></td><td>Ops view (triggers, polls, skills, quotas)</td></tr>
           <tr><td><kbd>M</kbd></td><td>Messages tab</td></tr>
           <tr><td><kbd>Y</kbd></td><td>Memories tab</td></tr>
           <tr><td><kbd>T</kbd></td><td>Tasks tab</td></tr>

--- a/internal/web/static/js/api-client.js
+++ b/internal/web/static/js/api-client.js
@@ -510,6 +510,261 @@ export class APIClient {
     }
   }
 
+  // --- Triggers API ---
+
+  async fetchTriggers(project) {
+    try {
+      const qs = project ? `?project=${encodeURIComponent(project)}` : '';
+      const res = await fetch(`/api/triggers${qs}`);
+      if (!res.ok) return [];
+      return await res.json();
+    } catch { return []; }
+  }
+
+  async fetchTriggerHistory(project) {
+    try {
+      const qs = project ? `?project=${encodeURIComponent(project)}` : '';
+      const res = await fetch(`/api/trigger-history${qs}`);
+      if (!res.ok) return [];
+      return await res.json();
+    } catch { return []; }
+  }
+
+  async createTrigger(data) {
+    try {
+      const res = await fetch('/api/triggers', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data),
+      });
+      return res.ok ? await res.json() : null;
+    } catch { return null; }
+  }
+
+  async deleteTrigger(id) {
+    try {
+      const res = await fetch(`/api/triggers/${id}`, { method: 'DELETE' });
+      return res.ok;
+    } catch { return false; }
+  }
+
+  // --- Poll Triggers API ---
+
+  async fetchPollTriggers(project) {
+    try {
+      const qs = project ? `?project=${encodeURIComponent(project)}` : '';
+      const res = await fetch(`/api/poll-triggers${qs}`);
+      if (!res.ok) return [];
+      return await res.json();
+    } catch { return []; }
+  }
+
+  async createPollTrigger(data) {
+    try {
+      const res = await fetch('/api/poll-triggers', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data),
+      });
+      return res.ok ? await res.json() : null;
+    } catch { return null; }
+  }
+
+  async deletePollTrigger(id) {
+    try {
+      const res = await fetch(`/api/poll-triggers/${id}`, { method: 'DELETE' });
+      return res.ok;
+    } catch { return false; }
+  }
+
+  async testPollTrigger(id) {
+    try {
+      const res = await fetch(`/api/poll-triggers/${id}/test`, { method: 'POST' });
+      if (!res.ok) return null;
+      return await res.json();
+    } catch { return null; }
+  }
+
+  // --- Skills API ---
+
+  async fetchSkills(project, agent) {
+    try {
+      let qs = project ? `?project=${encodeURIComponent(project)}` : '';
+      if (agent) qs += `&agent=${encodeURIComponent(agent)}`;
+      const res = await fetch(`/api/skills${qs}`);
+      if (!res.ok) return [];
+      return await res.json();
+    } catch { return []; }
+  }
+
+  async createSkill(data) {
+    try {
+      const res = await fetch('/api/skills', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data),
+      });
+      return res.ok ? await res.json() : null;
+    } catch { return null; }
+  }
+
+  async fetchSkillProfiles(name, project) {
+    try {
+      const qs = project ? `?project=${encodeURIComponent(project)}` : '';
+      const res = await fetch(`/api/skills/${encodeURIComponent(name)}/profiles${qs}`);
+      if (!res.ok) return [];
+      return await res.json();
+    } catch { return []; }
+  }
+
+  // --- Quotas API ---
+
+  async fetchQuotas(project) {
+    try {
+      const qs = project ? `?project=${encodeURIComponent(project)}` : '';
+      const res = await fetch(`/api/quotas${qs}`);
+      if (!res.ok) return [];
+      return await res.json();
+    } catch { return []; }
+  }
+
+  async fetchAgentQuota(agent, project) {
+    try {
+      const qs = project ? `?project=${encodeURIComponent(project)}` : '';
+      const res = await fetch(`/api/quotas/${encodeURIComponent(agent)}${qs}`);
+      if (!res.ok) return null;
+      return await res.json();
+    } catch { return null; }
+  }
+
+  async updateAgentQuota(agent, data) {
+    try {
+      const res = await fetch(`/api/quotas/${encodeURIComponent(agent)}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data),
+      });
+      return res.ok ? await res.json() : null;
+    } catch { return null; }
+  }
+
+  // --- Profiles API ---
+
+  async fetchProfiles(project) {
+    try {
+      const qs = project ? `?project=${encodeURIComponent(project)}` : '';
+      const res = await fetch(`/api/profiles${qs}`);
+      if (!res.ok) return [];
+      return await res.json();
+    } catch { return []; }
+  }
+
+  async fetchProfile(slug, project) {
+    try {
+      const qs = project ? `?project=${encodeURIComponent(project)}` : '';
+      const res = await fetch(`/api/profiles/${encodeURIComponent(slug)}${qs}`);
+      if (!res.ok) return null;
+      return await res.json();
+    } catch { return null; }
+  }
+
+  async createProfile(data) {
+    try {
+      const res = await fetch('/api/profiles', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data),
+      });
+      return res.ok ? await res.json() : null;
+    } catch { return null; }
+  }
+
+  async updateProfile(slug, data) {
+    try {
+      const qs = data.project ? `?project=${encodeURIComponent(data.project)}` : '';
+      const res = await fetch(`/api/profiles/${encodeURIComponent(slug)}${qs}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data),
+      });
+      return res.ok ? await res.json() : null;
+    } catch { return null; }
+  }
+
+  async deleteProfile(slug, project) {
+    try {
+      const qs = project ? `?project=${encodeURIComponent(project)}` : '';
+      const res = await fetch(`/api/profiles/${encodeURIComponent(slug)}${qs}`, { method: 'DELETE' });
+      return res.ok;
+    } catch { return false; }
+  }
+
+  async deactivateAgent(name, project) {
+    try {
+      const qs = project ? `?project=${encodeURIComponent(project)}` : '';
+      const res = await fetch(`/api/agents/${encodeURIComponent(name)}${qs}`, { method: 'DELETE' });
+      return res.ok;
+    } catch { return false; }
+  }
+
+  async deleteSkill(name, project) {
+    try {
+      const qs = project ? `?project=${encodeURIComponent(project)}` : '';
+      const res = await fetch(`/api/skills/${encodeURIComponent(name)}${qs}`, { method: 'DELETE' });
+      return res.ok;
+    } catch { return false; }
+  }
+
+  async deleteQuota(agent, project) {
+    try {
+      const qs = project ? `?project=${encodeURIComponent(project)}` : '';
+      const res = await fetch(`/api/quotas/${encodeURIComponent(agent)}${qs}`, { method: 'DELETE' });
+      return res.ok;
+    } catch { return false; }
+  }
+
+  // --- Service Discovery API ---
+
+  async discoverBySkill(project, skill) {
+    try {
+      const qs = new URLSearchParams();
+      if (project) qs.set('project', project);
+      if (skill) qs.set('skill', skill);
+      const res = await fetch(`/api/discover?${qs}`);
+      if (!res.ok) return null;
+      return await res.json();
+    } catch { return null; }
+  }
+
+  // --- Elevations API ---
+
+  async fetchElevations(project) {
+    try {
+      const qs = project ? `?project=${encodeURIComponent(project)}` : '';
+      const res = await fetch(`/api/elevations${qs}`);
+      if (!res.ok) return [];
+      return await res.json();
+    } catch { return []; }
+  }
+
+  async grantElevation(data) {
+    try {
+      const res = await fetch('/api/elevations', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data),
+      });
+      return res.ok ? await res.json() : null;
+    } catch { return null; }
+  }
+
+  async revokeElevation(id) {
+    try {
+      const res = await fetch(`/api/elevations/${id}`, { method: 'DELETE' });
+      return res.ok;
+    } catch { return false; }
+  }
+
   // --- Projects API ---
 
   async fetchProjects() {
@@ -618,5 +873,245 @@ export class APIClient {
       if (!res.ok) return [];
       return await res.json();
     } catch { return []; }
+  }
+
+  // --- Cycles API ---
+
+  async fetchCycles(project) {
+    try {
+      const qs = project ? `?project=${encodeURIComponent(project)}` : '';
+      const res = await fetch(`/api/cycles${qs}`);
+      if (!res.ok) return [];
+      return await res.json();
+    } catch { return []; }
+  }
+
+  async createCycle(data) {
+    try {
+      const res = await fetch('/api/cycles', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data),
+      });
+      return res.ok ? await res.json() : null;
+    } catch { return null; }
+  }
+
+  async updateCycle(name, data) {
+    try {
+      const res = await fetch(`/api/cycles/${encodeURIComponent(name)}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data),
+      });
+      return res.ok ? await res.json() : null;
+    } catch { return null; }
+  }
+
+  async deleteCycle(name, project) {
+    try {
+      const qs = project ? `?project=${encodeURIComponent(project)}` : '';
+      const res = await fetch(`/api/cycles/${encodeURIComponent(name)}${qs}`, { method: 'DELETE' });
+      return res.ok;
+    } catch { return false; }
+  }
+
+  // --- Workflows API ---
+
+  async fetchWorkflows(project) {
+    try {
+      const qs = project ? `?project=${encodeURIComponent(project)}` : '';
+      const res = await fetch(`/api/workflows${qs}`);
+      if (!res.ok) return [];
+      return await res.json();
+    } catch { return []; }
+  }
+
+  async fetchWorkflow(id) {
+    try {
+      const res = await fetch(`/api/workflows/${encodeURIComponent(id)}`);
+      if (!res.ok) return null;
+      return await res.json();
+    } catch { return null; }
+  }
+
+  async createWorkflow(data) {
+    try {
+      const res = await fetch('/api/workflows', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data),
+      });
+      return res.ok ? await res.json() : null;
+    } catch { return null; }
+  }
+
+  async updateWorkflow(id, data) {
+    try {
+      const res = await fetch(`/api/workflows/${encodeURIComponent(id)}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data),
+      });
+      return res.ok ? await res.json() : null;
+    } catch { return null; }
+  }
+
+  async deleteWorkflow(id) {
+    try {
+      const res = await fetch(`/api/workflows/${encodeURIComponent(id)}`, { method: 'DELETE' });
+      return res.ok;
+    } catch { return false; }
+  }
+
+  async executeWorkflow(id, meta = {}) {
+    try {
+      const res = await fetch(`/api/workflows/${encodeURIComponent(id)}/execute`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ meta }),
+      });
+      return res.ok ? await res.json() : null;
+    } catch { return null; }
+  }
+
+  async fetchWorkflowRuns(workflowId, limit = 20) {
+    try {
+      const res = await fetch(`/api/workflows/${encodeURIComponent(workflowId)}/runs?limit=${limit}`);
+      if (!res.ok) return [];
+      return await res.json();
+    } catch { return []; }
+  }
+
+  async fetchWorkflowRunDetail(runId) {
+    try {
+      const res = await fetch(`/api/workflow-runs/${encodeURIComponent(runId)}`);
+      if (!res.ok) return null;
+      return await res.json();
+    } catch { return null; }
+  }
+
+  // --- Schedules API ---
+
+  async fetchSchedules(project) {
+    try {
+      const qs = project ? `?project=${encodeURIComponent(project)}` : '';
+      const res = await fetch(`/api/schedules${qs}`);
+      if (!res.ok) return [];
+      return await res.json();
+    } catch { return []; }
+  }
+
+  async fetchAgentSchedules(project, agent) {
+    try {
+      const qs = new URLSearchParams();
+      if (project) qs.set('project', project);
+      if (agent) qs.set('agent', agent);
+      const res = await fetch(`/api/schedules?${qs}`);
+      if (!res.ok) return [];
+      return await res.json();
+    } catch { return []; }
+  }
+
+  async createSchedule(data) {
+    try {
+      const res = await fetch('/api/schedules', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data),
+      });
+      return res.ok ? await res.json() : null;
+    } catch { return null; }
+  }
+
+  async updateSchedule(id, data) {
+    try {
+      const res = await fetch(`/api/schedules/${encodeURIComponent(id)}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data),
+      });
+      return res.ok ? await res.json() : null;
+    } catch { return null; }
+  }
+
+  async deleteSchedule(id) {
+    try {
+      const res = await fetch(`/api/schedules/${encodeURIComponent(id)}`, { method: 'DELETE' });
+      return res.ok;
+    } catch { return false; }
+  }
+
+  async triggerSchedule(id) {
+    try {
+      const res = await fetch(`/api/schedules/${encodeURIComponent(id)}/trigger`, { method: 'POST' });
+      return res.ok ? await res.json() : null;
+    } catch { return null; }
+  }
+
+  // --- Spawn API ---
+
+  async fetchCycleHistory(project, agent) {
+    try {
+      const qs = new URLSearchParams();
+      if (project) qs.set('project', project);
+      if (agent) qs.set('agent', agent);
+      const res = await fetch(`/api/cycle-history?${qs}`);
+      if (!res.ok) return [];
+      return await res.json();
+    } catch { return []; }
+  }
+
+  async fetchSpawnChildren(project, agent, status) {
+    try {
+      const qs = new URLSearchParams();
+      if (project) qs.set('project', project);
+      if (agent) qs.set('agent', agent);
+      if (status) qs.set('status', status);
+      const res = await fetch(`/api/spawn/children?${qs}`);
+      if (!res.ok) return [];
+      return await res.json();
+    } catch { return []; }
+  }
+
+  async killSpawnChild(id) {
+    try {
+      const res = await fetch(`/api/spawn/children/${encodeURIComponent(id)}/kill`, { method: 'POST' });
+      return res.ok;
+    } catch { return false; }
+  }
+
+  async spawnWithContext(data) {
+    try {
+      const res = await fetch('/api/spawn/context', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data),
+      });
+      return res.ok ? await res.json() : null;
+    } catch { return null; }
+  }
+
+  async terminalSpawn(data) {
+    try {
+      const res = await fetch('/api/terminal/spawn', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data),
+      });
+      return res.ok ? await res.json() : null;
+    } catch { return null; }
+  }
+
+  async terminalKill(sessionId) {
+    try {
+      const res = await fetch(`/api/terminal/${encodeURIComponent(sessionId)}/kill`, { method: 'POST' });
+      return res.ok;
+    } catch { return false; }
+  }
+
+  terminalWsUrl(sessionId) {
+    const proto = location.protocol === 'https:' ? 'wss:' : 'ws:';
+    return `${proto}//${location.host}/api/terminal/ws/${sessionId}`;
   }
 }

--- a/internal/web/static/js/command-panel.js
+++ b/internal/web/static/js/command-panel.js
@@ -1,0 +1,1508 @@
+// command-panel.js — Colony Command Panel: agent HUD + management dock
+// Replaces the side detail drawer — all agent info lives here now.
+// HUD / Retro-futurism aesthetic: scanlines, neon glow, monospace
+
+function esc(str) {
+  if (!str) return '';
+  const d = document.createElement('div');
+  d.textContent = str;
+  return d.innerHTML;
+}
+
+function timeAgo(dateStr) {
+  if (!dateStr) return '';
+  const diff = Date.now() - new Date(dateStr).getTime();
+  const s = Math.floor(diff / 1000);
+  if (s < 60) return `${s}s`;
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h`;
+  return `${Math.floor(h / 24)}d`;
+}
+
+const CMD_STYLES = `
+/* ══════════════════════════════════════════════════════════
+   COMMAND PANEL — HUD / Retro-Futurism Console
+   ══════════════════════════════════════════════════════════ */
+
+@keyframes cmdFadeIn {
+  from { opacity: 0; transform: translateY(6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+@keyframes cmdPulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.5; }
+}
+@keyframes scanline {
+  0% { background-position: 0 0; }
+  100% { background-position: 0 4px; }
+}
+
+.cmd-root {
+  font-family: 'JetBrains Mono', monospace;
+  color: #c8ccd4;
+  width: 100%; height: 100%;
+  display: flex; flex-direction: column;
+  overflow: hidden;
+  position: relative;
+}
+/* Subtle scanline overlay */
+.cmd-root::before {
+  content: '';
+  position: absolute; inset: 0;
+  background: repeating-linear-gradient(
+    0deg,
+    transparent,
+    transparent 2px,
+    rgba(108, 92, 231, 0.02) 2px,
+    rgba(108, 92, 231, 0.02) 4px
+  );
+  pointer-events: none;
+  z-index: 1;
+}
+
+/* ── CREATION BAR (no agent) ── */
+.cmd-creation-bar {
+  display: flex; gap: 12px;
+  padding: 16px 24px;
+  align-items: center;
+  flex-shrink: 0;
+}
+.cmd-creation-bar::before {
+  content: 'COMMAND';
+  color: rgba(108, 92, 231, 0.5);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 2px;
+  margin-right: 8px;
+}
+.cmd-create-btn {
+  padding: 10px 20px;
+  font-size: 10px; font-weight: 700;
+  letter-spacing: 1.5px;
+  border: 1px solid rgba(108, 92, 231, 0.4);
+  background: rgba(108, 92, 231, 0.08);
+  color: #a29bfe;
+  cursor: pointer;
+  border-radius: 3px;
+  transition: all 0.2s ease;
+  font-family: inherit;
+  text-transform: uppercase;
+}
+.cmd-create-btn:hover {
+  background: rgba(108, 92, 231, 0.15);
+  border-color: rgba(108, 92, 231, 0.6);
+  color: #a29bfe;
+  box-shadow: 0 0 12px rgba(108, 92, 231, 0.15);
+}
+.cmd-create-btn.active {
+  background: rgba(108, 92, 231, 0.2);
+  border-color: #a29bfe;
+  color: #d4cfff;
+  box-shadow: 0 0 16px rgba(108, 92, 231, 0.25), inset 0 0 8px rgba(108, 92, 231, 0.1);
+}
+
+.cmd-form-area {
+  flex: 1; overflow-y: auto;
+  padding: 12px 20px;
+  animation: cmdFadeIn 0.2s ease;
+}
+
+/* ── AGENT HUD — horizontal layout ── */
+.cmd-agent-layout {
+  display: flex;
+  flex: 1;
+  overflow: hidden;
+  min-height: 0;
+}
+
+/* Left: Identity + live data */
+.cmd-hud-left {
+  width: 280px;
+  min-width: 240px;
+  flex-shrink: 0;
+  border-right: 1px solid rgba(108, 92, 231, 0.15);
+  display: flex;
+  flex-direction: column;
+  overflow-y: auto;
+  padding: 12px 16px;
+}
+
+/* Right: Tabbed management */
+.cmd-hud-right {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  min-width: 0;
+}
+
+/* ── HUD Identity Block ── */
+.cmd-hero {
+  margin-bottom: 10px;
+}
+.cmd-hero-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 4px;
+}
+.cmd-hero-name {
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 1px;
+  color: #e0e0e8;
+  text-shadow: 0 0 8px rgba(162, 155, 254, 0.3);
+}
+.cmd-hero-status {
+  font-size: 8px;
+  font-weight: 700;
+  letter-spacing: 1px;
+  padding: 2px 8px;
+  border-radius: 2px;
+  margin-left: auto;
+}
+.cmd-hero-status.online {
+  color: #00e676;
+  background: rgba(0, 230, 118, 0.08);
+  border: 1px solid rgba(0, 230, 118, 0.25);
+  box-shadow: 0 0 6px rgba(0, 230, 118, 0.15);
+}
+.cmd-hero-status.offline {
+  color: #636e72;
+  background: rgba(99, 110, 114, 0.06);
+  border: 1px solid rgba(99, 110, 114, 0.2);
+}
+.cmd-hero-status.sleeping {
+  color: #9b59b6;
+  background: rgba(155, 89, 182, 0.06);
+  border: 1px solid rgba(155, 89, 182, 0.2);
+}
+.cmd-hero-role {
+  font-size: 9px;
+  color: #7f8694;
+  letter-spacing: 0.5px;
+  margin-bottom: 2px;
+}
+.cmd-hero-activity {
+  font-size: 9px;
+  color: #a29bfe;
+  animation: cmdPulse 2s ease infinite;
+}
+
+/* ── HUD Stats Grid ── */
+.cmd-stats {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 4px;
+  margin: 8px 0;
+}
+.cmd-stat {
+  padding: 5px 8px;
+  background: rgba(15, 15, 30, 0.5);
+  border: 1px solid rgba(108, 92, 231, 0.08);
+  border-radius: 2px;
+}
+.cmd-stat-value {
+  font-size: 11px;
+  font-weight: 700;
+  color: #a29bfe;
+  display: block;
+}
+.cmd-stat-label {
+  font-size: 7px;
+  color: #5a5e78;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+}
+
+/* ── Current Task ── */
+.cmd-current-task {
+  padding: 8px 10px;
+  background: rgba(0, 230, 118, 0.03);
+  border-left: 2px solid rgba(0, 230, 118, 0.4);
+  border-radius: 0 2px 2px 0;
+  margin: 6px 0;
+}
+.cmd-current-task-label {
+  font-size: 7px;
+  color: #5a5e78;
+  letter-spacing: 1.5px;
+  text-transform: uppercase;
+  margin-bottom: 3px;
+}
+.cmd-current-task-title {
+  font-size: 10px;
+  color: #dfe6e9;
+}
+.cmd-current-task-status {
+  font-size: 8px;
+  margin-top: 2px;
+}
+
+/* ── Hierarchy / Teams compact ── */
+.cmd-hud-section {
+  margin-top: 8px;
+  padding-top: 6px;
+  border-top: 1px solid rgba(108, 92, 231, 0.08);
+}
+.cmd-hud-section-label {
+  font-size: 7px;
+  color: #5a5e78;
+  letter-spacing: 1.5px;
+  text-transform: uppercase;
+  margin-bottom: 4px;
+}
+.cmd-tag {
+  display: inline-block;
+  padding: 2px 7px;
+  font-size: 8px;
+  font-weight: 600;
+  background: rgba(108, 92, 231, 0.08);
+  border: 1px solid rgba(108, 92, 231, 0.15);
+  border-radius: 2px;
+  color: #a29bfe;
+  margin: 0 3px 3px 0;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+.cmd-tag:hover {
+  background: rgba(108, 92, 231, 0.2);
+  border-color: rgba(108, 92, 231, 0.4);
+}
+.cmd-tag.gold {
+  color: #f6c243;
+  border-color: rgba(246, 194, 67, 0.25);
+  background: rgba(246, 194, 67, 0.06);
+}
+.cmd-tag.dim {
+  color: #636e72;
+  cursor: default;
+}
+.cmd-tag.dim:hover { background: rgba(108, 92, 231, 0.08); }
+
+/* ── Recent Comms compact ── */
+.cmd-msg-item {
+  display: flex;
+  align-items: baseline;
+  gap: 5px;
+  padding: 3px 0;
+  font-size: 9px;
+  color: #7f8694;
+  border-bottom: 1px solid rgba(108, 92, 231, 0.04);
+}
+.cmd-msg-item:last-child { border-bottom: none; }
+.cmd-msg-dir { font-weight: 700; font-size: 10px; flex-shrink: 0; }
+.cmd-msg-peer { color: #a29bfe; flex-shrink: 0; }
+.cmd-msg-preview {
+  flex: 1; min-width: 0;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+  color: #636e72;
+}
+.cmd-msg-time { flex-shrink: 0; color: #3d4150; font-size: 8px; }
+
+/* ── Nav arrows ── */
+.cmd-nav {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: auto;
+  padding-top: 8px;
+  border-top: 1px solid rgba(108, 92, 231, 0.08);
+}
+.cmd-nav-btn {
+  background: none; border: 1px solid rgba(108, 92, 231, 0.2);
+  color: #7c6fe0; cursor: pointer;
+  width: 24px; height: 24px;
+  display: flex; align-items: center; justify-content: center;
+  border-radius: 2px; font-size: 12px;
+  font-family: inherit;
+  transition: all 0.15s;
+}
+.cmd-nav-btn:hover {
+  background: rgba(108, 92, 231, 0.15);
+  border-color: rgba(108, 92, 231, 0.5);
+}
+.cmd-nav-label {
+  font-size: 8px; color: #5a5e78;
+  letter-spacing: 1px; flex: 1; text-align: center;
+}
+
+/* ── TAB BAR ── */
+.cmd-tabs {
+  display: flex; gap: 0;
+  border-bottom: 1px solid rgba(108, 92, 231, 0.15);
+  flex-shrink: 0;
+  padding: 0 16px;
+  background: rgba(10, 10, 26, 0.5);
+}
+.cmd-tab {
+  padding: 8px 14px;
+  font-size: 8px; font-weight: 700;
+  letter-spacing: 1.5px;
+  color: #4a4e64;
+  cursor: pointer; border: none; background: none;
+  position: relative;
+  transition: color 0.15s;
+  font-family: inherit;
+  text-transform: uppercase;
+}
+.cmd-tab:hover { color: #7c6fe0; }
+.cmd-tab.active { color: #a29bfe; }
+.cmd-tab.active::after {
+  content: '';
+  position: absolute;
+  bottom: -1px; left: 8px; right: 8px;
+  height: 2px;
+  background: linear-gradient(90deg, transparent, #a29bfe, transparent);
+  box-shadow: 0 0 6px rgba(162, 155, 254, 0.4);
+}
+
+/* ── TAB CONTENT ── */
+.cmd-tab-content {
+  flex: 1; overflow-y: auto;
+  padding: 12px 16px;
+  animation: cmdFadeIn 0.15s ease;
+}
+
+/* ── ACTIONS BAR ── */
+.cmd-actions {
+  display: flex; gap: 6px;
+  padding: 8px 16px;
+  border-top: 1px solid rgba(108, 92, 231, 0.12);
+  flex-shrink: 0;
+  align-items: center;
+  background: rgba(10, 10, 26, 0.4);
+}
+
+/* ── Shared: forms, buttons, lists ── */
+.cmd-form { display: flex; flex-direction: column; gap: 8px; }
+.cmd-form-row { display: flex; gap: 8px; align-items: center; }
+.cmd-form-row.wide { flex-direction: column; align-items: stretch; }
+.cmd-label {
+  font-size: 8px; font-weight: 700;
+  letter-spacing: 1.5px; color: #4a4e64;
+  min-width: 80px; flex-shrink: 0;
+  text-transform: uppercase;
+}
+.cmd-input, .cmd-select, .cmd-textarea {
+  font-family: inherit;
+  font-size: 10px; padding: 5px 8px;
+  background: rgba(10, 10, 26, 0.7);
+  border: 1px solid rgba(108, 92, 231, 0.18);
+  color: #c8ccd4;
+  border-radius: 2px; flex: 1; min-width: 0;
+  transition: border-color 0.15s, box-shadow 0.15s;
+}
+.cmd-input:focus, .cmd-select:focus, .cmd-textarea:focus {
+  outline: none;
+  border-color: rgba(108, 92, 231, 0.5);
+  box-shadow: 0 0 8px rgba(108, 92, 231, 0.15);
+}
+.cmd-textarea { resize: vertical; min-height: 40px; }
+.cmd-input[readonly] { opacity: 0.4; cursor: not-allowed; }
+
+.cmd-btn {
+  padding: 5px 12px;
+  font-size: 8px; font-weight: 700;
+  letter-spacing: 1px;
+  border: 1px solid rgba(108, 92, 231, 0.3);
+  background: rgba(108, 92, 231, 0.06);
+  color: #7c6fe0;
+  cursor: pointer; border-radius: 2px;
+  transition: all 0.2s ease;
+  font-family: inherit;
+  text-transform: uppercase;
+}
+.cmd-btn:hover {
+  background: rgba(108, 92, 231, 0.18);
+  border-color: #a29bfe;
+  box-shadow: 0 0 8px rgba(108, 92, 231, 0.15);
+}
+.cmd-btn:active { transform: scale(0.97); }
+.cmd-btn.primary {
+  background: rgba(108, 92, 231, 0.2);
+  border-color: #a29bfe;
+  color: #d4cfff;
+}
+.cmd-btn.primary:hover {
+  background: rgba(108, 92, 231, 0.35);
+  box-shadow: 0 0 12px rgba(108, 92, 231, 0.25);
+}
+.cmd-btn.danger {
+  border-color: rgba(255, 107, 107, 0.3);
+  color: #e74c3c;
+  background: rgba(255, 107, 107, 0.04);
+}
+.cmd-btn.danger:hover {
+  background: rgba(255, 107, 107, 0.15);
+  border-color: #ff6b6b;
+  box-shadow: 0 0 8px rgba(255, 107, 107, 0.15);
+}
+.cmd-btn.success {
+  border-color: rgba(0, 230, 118, 0.3);
+  color: #00c853;
+  background: rgba(0, 230, 118, 0.04);
+}
+.cmd-btn.success:hover {
+  background: rgba(0, 230, 118, 0.15);
+  border-color: #00e676;
+  box-shadow: 0 0 8px rgba(0, 230, 118, 0.15);
+}
+
+/* ── List items ── */
+.cmd-list-item {
+  display: flex; align-items: center;
+  gap: 10px; padding: 5px 0;
+  border-bottom: 1px solid rgba(108, 92, 231, 0.06);
+  font-size: 10px;
+}
+.cmd-list-item:last-child { border-bottom: none; }
+.cmd-list-name { flex: 1; color: #c8ccd4; }
+.cmd-list-meta { color: #4a4e64; font-size: 9px; }
+.cmd-list-actions { display: flex; gap: 4px; }
+
+/* ── Skill entries (expandable .md cards) ── */
+.cmd-skill-entry {
+  border-bottom: 1px solid rgba(108, 92, 231, 0.08);
+  font-size: 10px;
+}
+.cmd-skill-entry:last-of-type { border-bottom: none; }
+.cmd-skill-header {
+  display: flex; align-items: center; gap: 6px;
+  padding: 5px 4px; cursor: pointer;
+  transition: background 0.15s;
+}
+.cmd-skill-header:hover { background: rgba(108, 92, 231, 0.06); }
+.cmd-skill-chevron {
+  color: #4a4e64; font-size: 7px; width: 10px; text-align: center;
+  flex-shrink: 0;
+}
+.cmd-skill-name {
+  font-weight: 600; color: #a29bfe;
+  font-family: 'JetBrains Mono', monospace;
+  flex-shrink: 0;
+}
+.cmd-skill-preview {
+  color: #4a4e64; font-size: 9px;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+  flex: 1; min-width: 0;
+}
+.cmd-skill-body {
+  padding: 0 4px 6px 20px;
+}
+.cmd-skill-md {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 9px; line-height: 1.5;
+  color: #8a8ea0; white-space: pre-wrap; word-break: break-word;
+  margin: 0; padding: 6px 8px;
+  background: rgba(0,0,0,0.25);
+  border: 1px solid rgba(108, 92, 231, 0.1);
+  border-radius: 3px;
+  max-height: 200px; overflow-y: auto;
+}
+.cmd-skill-textarea {
+  min-height: 120px; font-size: 10px;
+  font-family: 'JetBrains Mono', monospace;
+  white-space: pre;
+}
+
+/* ── Quota bars ── */
+.cmd-quota-row { display: flex; align-items: center; gap: 8px; padding: 4px 0; }
+.cmd-quota-label {
+  font-size: 8px; color: #4a4e64;
+  min-width: 90px; letter-spacing: 1px;
+  text-transform: uppercase;
+}
+.cmd-quota-bar-bg {
+  flex: 1; height: 6px;
+  background: rgba(108, 92, 231, 0.06);
+  border-radius: 3px; overflow: hidden;
+}
+.cmd-quota-bar-fill {
+  height: 100%; border-radius: 3px;
+  transition: width 0.3s ease;
+  box-shadow: 0 0 4px currentColor;
+}
+.cmd-quota-value {
+  font-size: 9px; color: #7c6fe0;
+  min-width: 55px; text-align: right;
+}
+
+.cmd-inline-form {
+  padding: 10px;
+  background: rgba(10, 10, 26, 0.6);
+  border: 1px solid rgba(108, 92, 231, 0.12);
+  border-radius: 2px; margin-top: 8px;
+  animation: cmdFadeIn 0.15s ease;
+}
+
+.cmd-empty {
+  text-align: center; color: #3d4150;
+  font-size: 9px; padding: 16px;
+  letter-spacing: 1px;
+}
+
+/* Terminal tab */
+#cmd-xterm { flex: 1; min-height: 0; }
+#cmd-xterm .xterm { height: 100%; }
+#cmd-xterm .xterm-viewport { overflow-y: auto !important; }
+.cmd-tab-content:has(#cmd-xterm) { padding: 0; }
+
+/* ── Send message form ── */
+.cmd-send-form {
+  display: flex; flex-direction: column; gap: 6px;
+  padding: 8px 16px;
+  border-top: 1px solid rgba(108, 92, 231, 0.1);
+  background: rgba(10, 10, 26, 0.4);
+  flex-shrink: 0;
+  animation: cmdFadeIn 0.15s ease;
+}
+.cmd-send-row { display: flex; gap: 6px; align-items: center; }
+`;
+
+export class CommandPanel {
+  constructor(container, resizeHandle) {
+    this._container = container;
+    this._resizeHandle = resizeHandle;
+    this._project = null;
+    this._agent = null;
+    this._activeTab = 'profile';
+    this._client = null;
+    this._profiles = [];
+    this._cycles = [];
+    this._activeCreateForm = null;
+    this._msgFormOpen = false;
+    this._onNavigate = null; // callback(agentKey) for prev/next
+    this._terminal = null;     // xterm.js Terminal instance
+    this._termWs = null;       // WebSocket connection
+    this._termSessionId = null; // PTY session ID
+    this._termBox = null;      // persistent DOM container for xterm (survives tab switches)
+    this._termFit = null;      // FitAddon instance
+    this._termByAgent = {};    // slug → sessionId (survives agent switches)
+
+    if (!document.getElementById('cmd-panel-styles')) {
+      const style = document.createElement('style');
+      style.id = 'cmd-panel-styles';
+      style.textContent = CMD_STYLES;
+      document.head.appendChild(style);
+    }
+    this._initResize();
+  }
+
+  setClient(client) { this._client = client; }
+
+  /** @param {Function} fn - called with direction: -1 or +1 */
+  set onNavigate(fn) { this._onNavigate = fn; }
+
+  show(project) {
+    this._project = project;
+    this._loadCacheLists();
+    if (!this._agent) this._renderCreationBar();
+  }
+
+  hide() {
+    // Visibility is controlled by body.view-galaxy .colony-only { display: none !important }
+    // No need to set inline styles
+    this._resizeHandle.style.display = 'none';
+  }
+
+  setAgent(agentData) {
+    const prevSlug = this._agent?.slug || this._agent?.name;
+    const newSlug = agentData?.slug || agentData?.name;
+    // Switching to a different agent — save session ID, teardown UI only
+    if (prevSlug && newSlug && prevSlug !== newSlug) {
+      if (this._termSessionId) {
+        this._termByAgent[prevSlug] = this._termSessionId;
+      }
+      this._teardownTerminalUI();
+      // Restore session ID if this agent had one running
+      this._termSessionId = this._termByAgent[newSlug] || null;
+    }
+    this._agent = agentData;
+    if (!this._agent._tabVisited) this._activeTab = 'profile';
+    this._agent._tabVisited = true;
+    this._msgFormOpen = false;
+    this._renderAgentPanel();
+  }
+
+  clearAgent() {
+    // Save session before clearing
+    const slug = this._agent?.slug || this._agent?.name;
+    if (slug && this._termSessionId) {
+      this._termByAgent[slug] = this._termSessionId;
+    }
+    this._agent = null;
+    this._activeCreateForm = null;
+    this._msgFormOpen = false;
+    this._teardownTerminalUI();
+    this._termSessionId = null;
+    this._renderCreationBar();
+  }
+
+  // Teardown xterm UI only (WS + DOM). PTY session stays alive on server.
+  _teardownTerminalUI() {
+    if (this._termWs) { this._termWs.close(); this._termWs = null; }
+    if (this._terminal) { this._terminal.dispose(); this._terminal = null; }
+    if (this._termBox) { this._termBox.remove(); this._termBox = null; }
+    this._termFit = null;
+  }
+
+  // Full destroy: teardown UI + forget session ID
+  _destroyTerminal() {
+    const slug = this._agent?.slug || this._agent?.name;
+    if (slug) delete this._termByAgent[slug];
+    this._teardownTerminalUI();
+    this._termSessionId = null;
+  }
+
+  // ── Internals ──
+
+  async _loadCacheLists() {
+    if (!this._client || !this._project) return;
+    try {
+      [this._profiles, this._cycles] = await Promise.all([
+        this._client.fetchProfiles(this._project),
+        this._client.fetchCycles(this._project),
+      ]);
+    } catch { /* ignore */ }
+  }
+
+  // ════════════════════════════════════════════
+  //  CREATION BAR (no agent selected)
+  // ════════════════════════════════════════════
+
+  _renderCreationBar() {
+    this._container.innerHTML = '';
+    const root = document.createElement('div');
+    root.className = 'cmd-root';
+
+    const bar = document.createElement('div');
+    bar.className = 'cmd-creation-bar';
+    const btns = [
+      { label: '+ Agent', form: 'agent' },
+      { label: '+ Cycle', form: 'cycle' },
+      { label: '+ Schedule', form: 'schedule' },
+    ];
+    for (const b of btns) {
+      const btn = document.createElement('button');
+      btn.className = 'cmd-create-btn' + (this._activeCreateForm === b.form ? ' active' : '');
+      btn.textContent = b.label;
+      btn.addEventListener('click', () => {
+        this._activeCreateForm = this._activeCreateForm === b.form ? null : b.form;
+        this._renderCreationBar();
+      });
+      bar.appendChild(btn);
+    }
+    root.appendChild(bar);
+
+    if (this._activeCreateForm) {
+      const area = document.createElement('div');
+      area.className = 'cmd-form-area';
+      if (this._activeCreateForm === 'agent') this._buildAgentCreateForm(area);
+      else if (this._activeCreateForm === 'cycle') this._buildCycleCreateForm(area);
+      else if (this._activeCreateForm === 'schedule') this._buildScheduleCreateForm(area);
+      root.appendChild(area);
+    }
+
+    this._container.appendChild(root);
+  }
+
+  _buildAgentCreateForm(area) {
+    const form = document.createElement('div');
+    form.className = 'cmd-form';
+    form.innerHTML = `
+      <div class="cmd-form-row">
+        <span class="cmd-label">SLUG</span>
+        <input class="cmd-input" data-field="slug" placeholder="agent-slug" />
+      </div>
+      <div class="cmd-form-row">
+        <span class="cmd-label">NAME</span>
+        <input class="cmd-input" data-field="name" placeholder="Agent Name" />
+      </div>
+      <div class="cmd-form-row">
+        <span class="cmd-label">ROLE</span>
+        <input class="cmd-input" data-field="role" placeholder="Role description" />
+      </div>
+      <div class="cmd-form-row wide">
+        <span class="cmd-label">CONTEXT PACK</span>
+        <textarea class="cmd-textarea" data-field="context_pack" rows="2" placeholder="Context pack..."></textarea>
+      </div>
+      <div class="cmd-form-row">
+        <span class="cmd-label">PROJECT</span>
+        <input class="cmd-input" data-field="project" value="${esc(this._project)}" readonly />
+        <button class="cmd-btn primary" id="cmd-create-agent-btn">CREATE</button>
+      </div>
+    `;
+    area.appendChild(form);
+    area.querySelector('#cmd-create-agent-btn').addEventListener('click', () => this._doCreateAgent(form));
+  }
+
+  async _doCreateAgent(form) {
+    const get = (f) => form.querySelector(`[data-field="${f}"]`)?.value?.trim() || '';
+    const data = { slug: get('slug'), name: get('name'), role: get('role'), context_pack: get('context_pack'), project: this._project };
+    if (!data.slug) return;
+    const result = await this._client.createProfile(data);
+    if (result) { this._activeCreateForm = null; await this._loadCacheLists(); this._renderCreationBar(); }
+  }
+
+  _buildCycleCreateForm(area) {
+    const form = document.createElement('div');
+    form.className = 'cmd-form';
+    form.innerHTML = `
+      <div class="cmd-form-row">
+        <span class="cmd-label">NAME</span>
+        <input class="cmd-input" data-field="name" placeholder="cycle-name" />
+      </div>
+      <div class="cmd-form-row wide">
+        <span class="cmd-label">PROMPT</span>
+        <textarea class="cmd-textarea" data-field="prompt" rows="2" placeholder="Cycle prompt..."></textarea>
+      </div>
+      <div class="cmd-form-row">
+        <span class="cmd-label">TTL</span>
+        <input class="cmd-input" data-field="ttl" placeholder="30m" />
+        <button class="cmd-btn primary" id="cmd-create-cycle-btn">CREATE</button>
+      </div>
+    `;
+    area.appendChild(form);
+    area.querySelector('#cmd-create-cycle-btn').addEventListener('click', () => this._doCreateCycle(form));
+  }
+
+  async _doCreateCycle(form) {
+    const get = (f) => form.querySelector(`[data-field="${f}"]`)?.value?.trim() || '';
+    const data = { name: get('name'), prompt: get('prompt'), ttl: get('ttl'), project: this._project };
+    if (!data.name) return;
+    const result = await this._client.createCycle(data);
+    if (result) { this._activeCreateForm = null; await this._loadCacheLists(); this._renderCreationBar(); }
+  }
+
+  _buildScheduleCreateForm(area) {
+    const form = document.createElement('div');
+    form.className = 'cmd-form';
+    const agentOpts = this._profiles.map(p => `<option value="${esc(p.slug)}">${esc(p.slug)}</option>`).join('');
+    const cycleOpts = this._cycles.map(c => `<option value="${esc(c.name)}">${esc(c.name)}</option>`).join('');
+    form.innerHTML = `
+      <div class="cmd-form-row">
+        <span class="cmd-label">AGENT</span>
+        <select class="cmd-select" data-field="agent"><option value="">--</option>${agentOpts}</select>
+      </div>
+      <div class="cmd-form-row">
+        <span class="cmd-label">CYCLE</span>
+        <select class="cmd-select" data-field="cycle"><option value="">--</option>${cycleOpts}</select>
+      </div>
+      <div class="cmd-form-row">
+        <span class="cmd-label">NAME</span>
+        <input class="cmd-input" data-field="name" placeholder="schedule-name" />
+      </div>
+      <div class="cmd-form-row">
+        <span class="cmd-label">CRON</span>
+        <input class="cmd-input" data-field="cron_expr" placeholder="*/30 * * * *" />
+        <button class="cmd-btn primary" id="cmd-create-schedule-btn">CREATE</button>
+      </div>
+    `;
+    area.appendChild(form);
+    area.querySelector('#cmd-create-schedule-btn').addEventListener('click', () => this._doCreateSchedule(form));
+  }
+
+  async _doCreateSchedule(form) {
+    const get = (f) => form.querySelector(`[data-field="${f}"]`)?.value?.trim() || '';
+    const data = { agent: get('agent'), project: this._project, name: get('name'), cron_expr: get('cron_expr'), ttl: '', cycle: get('cycle') };
+    if (!data.agent || !data.cron_expr) return;
+    const result = await this._client.createSchedule(data);
+    if (result) { this._activeCreateForm = null; this._renderCreationBar(); }
+  }
+
+  // ════════════════════════════════════════════
+  //  AGENT HUD PANEL
+  // ════════════════════════════════════════════
+
+  _renderAgentPanel() {
+    const a = this._agent;
+    if (!a) return;
+    // Detach the persistent terminal box before clearing (so it isn't destroyed)
+    if (this._termBox && this._termBox.parentNode) {
+      this._termBox.remove();
+    }
+    this._container.innerHTML = '';
+    const root = document.createElement('div');
+    root.className = 'cmd-root';
+
+    const layout = document.createElement('div');
+    layout.className = 'cmd-agent-layout';
+
+    // ── LEFT: Identity HUD ──
+    const left = document.createElement('div');
+    left.className = 'cmd-hud-left';
+    this._renderHudLeft(left, a);
+    layout.appendChild(left);
+
+    // ── RIGHT: Tabbed management ──
+    const right = document.createElement('div');
+    right.className = 'cmd-hud-right';
+
+    // Tab bar
+    const tabs = document.createElement('div');
+    tabs.className = 'cmd-tabs';
+    const tabDefs = ['profile', 'skills', 'quotas', 'schedules', 'comms', 'tasks', 'terminal'];
+    for (const t of tabDefs) {
+      const btn = document.createElement('button');
+      btn.className = 'cmd-tab' + (this._activeTab === t ? ' active' : '');
+      btn.textContent = t.charAt(0).toUpperCase() + t.slice(1);
+      btn.addEventListener('click', () => { this._activeTab = t; this._renderAgentPanel(); });
+      tabs.appendChild(btn);
+    }
+    right.appendChild(tabs);
+
+    // Tab content
+    const content = document.createElement('div');
+    content.className = 'cmd-tab-content';
+    if (this._activeTab === 'profile') this._renderProfileTab(content);
+    else if (this._activeTab === 'skills') this._renderSkillsTab(content);
+    else if (this._activeTab === 'quotas') this._renderQuotasTab(content);
+    else if (this._activeTab === 'schedules') this._renderSchedulesTab(content);
+    else if (this._activeTab === 'comms') this._renderCommsTab(content);
+    else if (this._activeTab === 'tasks') this._renderTasksTab(content);
+    else if (this._activeTab === 'terminal') this._renderTerminalTab(content);
+    right.appendChild(content);
+
+    // Actions bar
+    const actions = document.createElement('div');
+    actions.className = 'cmd-actions';
+
+    // Terminal spawn button
+    const spawnBtn = document.createElement('button');
+    if (this._termSessionId) {
+      // Terminal is running — show kill button
+      spawnBtn.className = 'cmd-btn danger';
+      spawnBtn.textContent = 'Kill Terminal';
+      spawnBtn.addEventListener('click', async () => {
+        spawnBtn.textContent = 'Killing...';
+        spawnBtn.disabled = true;
+        await this._client.terminalKill(this._termSessionId);
+        this._destroyTerminal();
+        this._renderAgentPanel();
+      });
+    } else {
+      spawnBtn.className = 'cmd-btn success';
+      spawnBtn.textContent = 'Spawn Terminal';
+      spawnBtn.addEventListener('click', async () => {
+        spawnBtn.textContent = 'Spawning...';
+        spawnBtn.disabled = true;
+        const slug = this._agent.slug || this._agent.name;
+        const result = await this._client.terminalSpawn({
+          project: this._project,
+          profile: slug,
+        });
+        if (result && result.session_id) {
+          this._termSessionId = result.session_id;
+          this._activeTab = 'terminal';
+          this._renderAgentPanel();
+        } else {
+          spawnBtn.textContent = 'Failed';
+          spawnBtn.style.color = '#ff6b6b';
+          setTimeout(() => { spawnBtn.textContent = 'Spawn Terminal'; spawnBtn.disabled = false; spawnBtn.style.color = ''; }, 2000);
+        }
+      });
+    }
+    actions.appendChild(spawnBtn);
+
+    const msgBtn = document.createElement('button');
+    msgBtn.className = 'cmd-btn';
+    msgBtn.textContent = 'Message';
+    msgBtn.addEventListener('click', () => { this._msgFormOpen = !this._msgFormOpen; this._renderAgentPanel(); });
+    actions.appendChild(msgBtn);
+
+    const delBtn = document.createElement('button');
+    delBtn.className = 'cmd-btn danger';
+    delBtn.textContent = 'Delete';
+    delBtn.addEventListener('click', () => this._doDeleteAgent());
+    actions.appendChild(delBtn);
+
+    right.appendChild(actions);
+
+    // Message form (inline, below actions)
+    if (this._msgFormOpen) {
+      const mf = document.createElement('div');
+      mf.className = 'cmd-send-form';
+      mf.innerHTML = `
+        <div class="cmd-send-row">
+          <span class="cmd-label">TO</span>
+          <input class="cmd-input" data-field="to" value="${esc(a.slug || a.name)}" />
+          <span class="cmd-label" style="min-width:auto">PRI</span>
+          <select class="cmd-select" data-field="priority" style="width:70px;flex:none">
+            <option value="normal">normal</option><option value="high">high</option><option value="low">low</option>
+          </select>
+        </div>
+        <div class="cmd-send-row">
+          <textarea class="cmd-textarea" data-field="content" rows="2" placeholder="Message..." style="flex:1"></textarea>
+          <button class="cmd-btn primary" id="cmd-send-msg-btn" style="align-self:flex-end">Send</button>
+        </div>
+      `;
+      right.appendChild(mf);
+      mf.querySelector('#cmd-send-msg-btn').addEventListener('click', () => this._doSendMessage(mf));
+    }
+
+    layout.appendChild(right);
+    root.appendChild(layout);
+    this._container.appendChild(root);
+  }
+
+  _renderHudLeft(left, a) {
+    // Hero identity
+    const hero = document.createElement('div');
+    hero.className = 'cmd-hero';
+
+    const statusClass = a.sleeping ? 'sleeping' : a.online ? 'online' : 'offline';
+    const statusText = a.sleeping ? 'ZZZ' : a.online ? 'ONLINE' : 'OFFLINE';
+
+    hero.innerHTML = `
+      <div class="cmd-hero-row">
+        <span class="cmd-hero-name" style="color:${a.color || '#a29bfe'}">${esc(a.name || a.slug)}</span>
+        <span class="cmd-hero-status ${statusClass}">${statusText}</span>
+      </div>
+      <div class="cmd-hero-role">${esc(a.role || '')}</div>
+      ${a.activity && a.activity !== 'idle' ? `<div class="cmd-hero-activity">${esc(a.activityTool || a.activity)}</div>` : ''}
+    `;
+    left.appendChild(hero);
+
+    // Stats grid
+    const stats = document.createElement('div');
+    stats.className = 'cmd-stats';
+    const lastSeen = a._lastSeenRaw ? timeAgo(a._lastSeenRaw) : '--';
+    const poolSize = a.pool_size || 1;
+    const skillCount = (a._skills || []).length;
+    const taskCount = (a._tasks || []).length;
+    stats.innerHTML = `
+      <div class="cmd-stat"><span class="cmd-stat-value">${lastSeen}</span><span class="cmd-stat-label">Last seen</span></div>
+      <div class="cmd-stat"><span class="cmd-stat-value">${poolSize}</span><span class="cmd-stat-label">Pool size</span></div>
+      <div class="cmd-stat"><span class="cmd-stat-value">${skillCount}</span><span class="cmd-stat-label">Skills</span></div>
+      <div class="cmd-stat"><span class="cmd-stat-value">${taskCount}</span><span class="cmd-stat-label">Tasks</span></div>
+    `;
+    left.appendChild(stats);
+
+    // Current task
+    const tasks = a._tasks || [];
+    const current = tasks.find(t => t.status === 'in-progress') || tasks[0];
+    if (current) {
+      const statusColors = { pending: '#ffd93d', accepted: '#74b9ff', 'in-progress': '#00e676', blocked: '#ff6b6b' };
+      const c = statusColors[current.status] || '#636e72';
+      const ct = document.createElement('div');
+      ct.className = 'cmd-current-task';
+      ct.innerHTML = `
+        <div class="cmd-current-task-label">Current Task</div>
+        <div class="cmd-current-task-title">${esc(current.title)}</div>
+        <div class="cmd-current-task-status" style="color:${c}">${current.status} &middot; ${current.priority}</div>
+      `;
+      left.appendChild(ct);
+    }
+
+    // Hierarchy
+    if (a._reportsTo || (a._directReports && a._directReports.length)) {
+      const sec = document.createElement('div');
+      sec.className = 'cmd-hud-section';
+      sec.innerHTML = '<div class="cmd-hud-section-label">Hierarchy</div>';
+      if (a._reportsTo) {
+        const tag = document.createElement('span');
+        tag.className = 'cmd-tag';
+        tag.textContent = '\u25B2 ' + a._reportsTo;
+        tag.addEventListener('click', () => { if (this._onNavigate) this._onNavigate(a._reportsTo); });
+        sec.appendChild(tag);
+      }
+      for (const r of (a._directReports || [])) {
+        const tag = document.createElement('span');
+        tag.className = 'cmd-tag';
+        tag.textContent = '\u25BC ' + r;
+        tag.addEventListener('click', () => { if (this._onNavigate) this._onNavigate(r); });
+        sec.appendChild(tag);
+      }
+      left.appendChild(sec);
+    }
+
+    // Teams
+    if (a._teams && a._teams.length) {
+      const sec = document.createElement('div');
+      sec.className = 'cmd-hud-section';
+      sec.innerHTML = '<div class="cmd-hud-section-label">Teams</div>';
+      for (const t of a._teams) {
+        const tag = document.createElement('span');
+        tag.className = 'cmd-tag' + (t.type === 'admin' ? ' gold' : '');
+        tag.textContent = (t.type === 'admin' ? '\u2605 ' : '') + t.name;
+        tag.title = `Role: ${t.role || '-'} | Type: ${t.type}`;
+        sec.appendChild(tag);
+      }
+      left.appendChild(sec);
+    }
+
+    // Nav arrows
+    const nav = document.createElement('div');
+    nav.className = 'cmd-nav';
+    const prevBtn = document.createElement('button');
+    prevBtn.className = 'cmd-nav-btn';
+    prevBtn.textContent = '\u25C0';
+    prevBtn.title = 'Previous agent';
+    prevBtn.addEventListener('click', () => { if (this._onNavigate) this._onNavigate(-1); });
+    const nextBtn = document.createElement('button');
+    nextBtn.className = 'cmd-nav-btn';
+    nextBtn.textContent = '\u25B6';
+    nextBtn.title = 'Next agent';
+    nextBtn.addEventListener('click', () => { if (this._onNavigate) this._onNavigate(+1); });
+    const navLabel = document.createElement('span');
+    navLabel.className = 'cmd-nav-label';
+    navLabel.textContent = a._navLabel || '';
+    nav.appendChild(prevBtn);
+    nav.appendChild(navLabel);
+    nav.appendChild(nextBtn);
+    left.appendChild(nav);
+  }
+
+  // ── Tab renderers ──
+
+  _renderProfileTab(content) {
+    const a = this._agent;
+    const form = document.createElement('div');
+    form.className = 'cmd-form';
+    form.innerHTML = `
+      <div class="cmd-form-row">
+        <span class="cmd-label">SLUG</span>
+        <input class="cmd-input" data-field="slug" value="${esc(a.slug || '')}" readonly />
+        <span class="cmd-label" style="min-width:auto">POOL</span>
+        <input class="cmd-input" data-field="pool_size" type="number" value="${a.pool_size || 1}" style="width:50px;flex:none" />
+      </div>
+      <div class="cmd-form-row">
+        <span class="cmd-label">NAME</span>
+        <input class="cmd-input" data-field="name" value="${esc(a.name || '')}" />
+      </div>
+      <div class="cmd-form-row">
+        <span class="cmd-label">ROLE</span>
+        <input class="cmd-input" data-field="role" value="${esc(a.role || '')}" />
+      </div>
+      <div class="cmd-form-row wide">
+        <span class="cmd-label">CONTEXT PACK</span>
+        <textarea class="cmd-textarea" data-field="context_pack" rows="2">${esc(a.context_pack || '')}</textarea>
+      </div>
+      <div class="cmd-form-row wide">
+        <span class="cmd-label">VAULT PATHS</span>
+        <textarea class="cmd-textarea" data-field="vault_paths" rows="1">${esc(a.vault_paths || '')}</textarea>
+      </div>
+      <div class="cmd-form-row wide">
+        <span class="cmd-label">ALLOWED TOOLS</span>
+        <textarea class="cmd-textarea" data-field="allowed_tools" rows="1">${esc(a.allowed_tools || '')}</textarea>
+      </div>
+      <div class="cmd-form-row"><button class="cmd-btn primary" id="cmd-save-profile-btn">Save Profile</button></div>
+    `;
+    content.appendChild(form);
+    content.querySelector('#cmd-save-profile-btn').addEventListener('click', () => this._doSaveProfile(form));
+  }
+
+  async _doSaveProfile(form) {
+    const get = (f) => form.querySelector(`[data-field="${f}"]`)?.value?.trim() || '';
+    const slug = this._agent.slug || this._agent.name;
+    await this._client.updateProfile(slug, {
+      name: get('name'), role: get('role'), context_pack: get('context_pack'),
+      vault_paths: get('vault_paths'), allowed_tools: get('allowed_tools'),
+      pool_size: parseInt(get('pool_size')) || 1, project: this._project,
+    });
+  }
+
+  _renderSkillsTab(content) {
+    const skills = this._agent._skills || [];
+    if (skills.length === 0) {
+      content.innerHTML = '<div class="cmd-empty">No skills registered</div>';
+    } else {
+      for (const sk of skills) {
+        const item = document.createElement('div');
+        item.className = 'cmd-skill-entry';
+        const hasDesc = sk.description && sk.description.trim();
+        const preview = hasDesc ? (sk.description.length > 80 ? sk.description.slice(0, 78) + '...' : sk.description.split('\n')[0]) : '';
+        item.innerHTML = `
+          <div class="cmd-skill-header" data-toggle-skill="${esc(sk.name)}">
+            <span class="cmd-skill-chevron">${hasDesc ? '\u25B6' : '\u2022'}</span>
+            <span class="cmd-skill-name">${esc(sk.name)}</span>
+            ${preview ? `<span class="cmd-skill-preview">${esc(preview)}</span>` : ''}
+            <button class="cmd-btn danger" data-del-skill="${esc(sk.name)}" style="padding:1px 6px;font-size:8px">x</button>
+          </div>
+          <div class="cmd-skill-body" data-skill-body="${esc(sk.name)}" style="display:none">
+            <pre class="cmd-skill-md">${esc(sk.description || '')}</pre>
+          </div>
+        `;
+        content.appendChild(item);
+      }
+      // Toggle expand/collapse
+      content.querySelectorAll('[data-toggle-skill]').forEach(header => {
+        header.addEventListener('click', (e) => {
+          if (e.target.dataset.delSkill) return; // don't toggle on delete click
+          const name = header.dataset.toggleSkill;
+          const body = content.querySelector(`[data-skill-body="${name}"]`);
+          const chevron = header.querySelector('.cmd-skill-chevron');
+          if (body.style.display === 'none') {
+            body.style.display = 'block';
+            chevron.textContent = '\u25BC';
+          } else {
+            body.style.display = 'none';
+            chevron.textContent = '\u25B6';
+          }
+        });
+      });
+      content.querySelectorAll('[data-del-skill]').forEach(btn => {
+        btn.addEventListener('click', async (e) => {
+          e.stopPropagation();
+          await this._client.deleteSkill(btn.dataset.delSkill, this._project);
+          this._renderAgentPanel();
+        });
+      });
+    }
+    // Add skill form
+    const addBtn = document.createElement('button');
+    addBtn.className = 'cmd-btn';
+    addBtn.textContent = '+ Skill';
+    addBtn.style.marginTop = '8px';
+    addBtn.addEventListener('click', () => {
+      if (content.querySelector('.cmd-inline-form')) return;
+      const f = document.createElement('div');
+      f.className = 'cmd-inline-form';
+      f.innerHTML = `<div class="cmd-form">
+        <div class="cmd-form-row">
+          <span class="cmd-label">NAME</span>
+          <input class="cmd-input" data-field="skill-name" placeholder="e.g. deploy-pipeline" />
+        </div>
+        <div class="cmd-form-row wide">
+          <span class="cmd-label">CONTENT</span>
+          <textarea class="cmd-textarea cmd-skill-textarea" data-field="skill-desc" rows="10" placeholder="Paste full .md skill definition here..."></textarea>
+        </div>
+        <div class="cmd-form-row">
+          <button class="cmd-btn primary" id="cmd-add-skill-btn">Add Skill</button>
+        </div></div>`;
+      content.appendChild(f);
+      f.querySelector('#cmd-add-skill-btn').addEventListener('click', async () => {
+        const name = f.querySelector('[data-field="skill-name"]').value.trim();
+        const desc = f.querySelector('[data-field="skill-desc"]').value;
+        if (!name) return;
+        const slug = this._agent.slug || this._agent.name;
+        await this._client.createSkill({ name, description: desc, proficiency: 3, agent: slug, project: this._project });
+        const skills = await this._client.fetchSkills(this._project, slug);
+        this._agent._skills = skills;
+        this._renderAgentPanel();
+      });
+    });
+    content.appendChild(addBtn);
+  }
+
+  _renderQuotasTab(content) {
+    const q = this._agent._quota || {};
+    const fields = [
+      { key: 'max_tokens_per_day', label: 'Tokens/Day', used: q.tokens_today || 0 },
+      { key: 'max_messages_per_hour', label: 'Msgs/Hour', used: q.messages_this_hour || 0 },
+      { key: 'max_tasks_per_hour', label: 'Tasks/Hour', used: q.tasks_this_hour || 0 },
+      { key: 'max_spawns_per_hour', label: 'Spawns/Hour', used: q.spawns_this_hour || 0 },
+    ];
+    const form = document.createElement('div');
+    form.className = 'cmd-form';
+    for (const f of fields) {
+      const limit = q[f.key] || 0;
+      const pct = limit > 0 ? Math.min(100, (f.used / limit) * 100) : 0;
+      const color = pct > 80 ? '#ff6b6b' : pct > 50 ? '#ffd93d' : '#00e676';
+      const row = document.createElement('div');
+      row.className = 'cmd-quota-row';
+      row.innerHTML = `
+        <span class="cmd-quota-label">${f.label}</span>
+        <div class="cmd-quota-bar-bg"><div class="cmd-quota-bar-fill" style="width:${pct}%;background:${color}"></div></div>
+        <input class="cmd-input" data-field="${f.key}" type="number" value="${limit}" style="width:65px;flex:none;text-align:right" />
+      `;
+      form.appendChild(row);
+    }
+    const saveRow = document.createElement('div');
+    saveRow.className = 'cmd-form-row';
+    saveRow.innerHTML = '<button class="cmd-btn primary" id="cmd-save-quotas-btn">Save Quotas</button>';
+    form.appendChild(saveRow);
+    content.appendChild(form);
+    content.querySelector('#cmd-save-quotas-btn').addEventListener('click', async () => {
+      const get = (f) => parseInt(form.querySelector(`[data-field="${f}"]`)?.value) || 0;
+      const slug = this._agent.slug || this._agent.name;
+      await this._client.updateAgentQuota(slug, {
+        project: this._project,
+        max_tokens_per_day: get('max_tokens_per_day'), max_messages_per_hour: get('max_messages_per_hour'),
+        max_tasks_per_hour: get('max_tasks_per_hour'), max_spawns_per_hour: get('max_spawns_per_hour'),
+      });
+    });
+  }
+
+  async _renderSchedulesTab(content) {
+    const slug = this._agent.slug || this._agent.name;
+    const schedules = await this._client.fetchAgentSchedules(this._project, slug);
+    if (!schedules || schedules.length === 0) {
+      content.innerHTML = '<div class="cmd-empty">No schedules</div>';
+    } else {
+      for (const s of schedules) {
+        const item = document.createElement('div');
+        item.className = 'cmd-list-item';
+        item.innerHTML = `
+          <span class="cmd-list-name">${esc(s.name || s.id)}</span>
+          <span class="cmd-list-meta">${esc(s.cron_expr)} &middot; ${esc(s.cycle || '-')}</span>
+          <div class="cmd-list-actions">
+            <button class="cmd-btn success" data-trigger="${s.id}">Run</button>
+            <button class="cmd-btn danger" data-del="${s.id}">Del</button>
+          </div>
+        `;
+        content.appendChild(item);
+      }
+      content.querySelectorAll('[data-trigger]').forEach(b => b.addEventListener('click', () => this._client.triggerSchedule(b.dataset.trigger)));
+      content.querySelectorAll('[data-del]').forEach(b => b.addEventListener('click', async () => { await this._client.deleteSchedule(b.dataset.del); this._renderAgentPanel(); }));
+    }
+    const addBtn = document.createElement('button');
+    addBtn.className = 'cmd-btn';
+    addBtn.textContent = '+ Schedule';
+    addBtn.style.marginTop = '8px';
+    addBtn.addEventListener('click', () => {
+      if (content.querySelector('.cmd-inline-form')) return;
+      const cycleOpts = this._cycles.map(c => `<option value="${esc(c.name)}">${esc(c.name)}</option>`).join('');
+      const f = document.createElement('div');
+      f.className = 'cmd-inline-form';
+      f.innerHTML = `<div class="cmd-form">
+        <div class="cmd-form-row">
+          <span class="cmd-label">CRON</span><input class="cmd-input" data-field="sched-cron" placeholder="*/30 * * * *" />
+          <span class="cmd-label" style="min-width:auto">CYCLE</span>
+          <select class="cmd-select" data-field="sched-cycle" style="width:90px;flex:none"><option value="">--</option>${cycleOpts}</select>
+          <button class="cmd-btn primary" id="cmd-add-sched-btn">Create</button>
+        </div></div>`;
+      content.appendChild(f);
+      f.querySelector('#cmd-add-sched-btn').addEventListener('click', async () => {
+        const cron_expr = f.querySelector('[data-field="sched-cron"]').value.trim();
+        const cycle = f.querySelector('[data-field="sched-cycle"]').value;
+        if (!cron_expr) return;
+        await this._client.createSchedule({ agent: slug, project: this._project, name: '', cron_expr, cycle, ttl: '' });
+        this._renderAgentPanel();
+      });
+    });
+    content.appendChild(addBtn);
+  }
+
+  _renderCommsTab(content) {
+    const msgs = this._agent._recentMsgs || [];
+    if (msgs.length === 0) {
+      content.innerHTML = '<div class="cmd-empty">No recent messages</div>';
+      return;
+    }
+    for (const m of msgs) {
+      const isSent = m.from === (this._agent.slug || this._agent.name);
+      const peer = isSent ? (m.to || 'broadcast') : m.from;
+      const dir = isSent ? '\u2192' : '\u2190';
+      const dirColor = isSent ? '#a29bfe' : '#74b9ff';
+      const preview = m.content.length > 80 ? m.content.slice(0, 78) + '...' : m.content;
+      const item = document.createElement('div');
+      item.className = 'cmd-msg-item';
+      item.innerHTML = `
+        <span class="cmd-msg-dir" style="color:${dirColor}">${dir}</span>
+        <span class="cmd-msg-peer">${esc(peer)}</span>
+        <span class="cmd-msg-preview">${esc(preview)}</span>
+        <span class="cmd-msg-time">${timeAgo(m.created_at)}</span>
+      `;
+      content.appendChild(item);
+    }
+  }
+
+  _renderTasksTab(content) {
+    const tasks = this._agent._tasks || [];
+    if (tasks.length === 0) {
+      content.innerHTML = '<div class="cmd-empty">No active tasks</div>';
+      return;
+    }
+    const statusColors = { pending: '#ffd93d', accepted: '#74b9ff', 'in-progress': '#00e676', blocked: '#ff6b6b' };
+    for (const t of tasks) {
+      const c = statusColors[t.status] || '#636e72';
+      const item = document.createElement('div');
+      item.className = 'cmd-list-item';
+      item.innerHTML = `
+        <span style="color:${c};font-size:9px;font-weight:700;min-width:70px">${t.status}</span>
+        <span class="cmd-list-name">${esc(t.title.length > 50 ? t.title.slice(0, 48) + '...' : t.title)}</span>
+        <span class="cmd-list-meta">${t.priority}</span>
+      `;
+      content.appendChild(item);
+    }
+  }
+
+  _renderTerminalTab(content) {
+    if (!this._termSessionId) {
+      content.innerHTML = `<div class="cmd-empty">
+        No terminal session.<br>
+        <span style="color:#5a5e78;font-size:8px">Click "Spawn Terminal" to start an interactive agent.</span>
+      </div>`;
+      return;
+    }
+
+    // Make content a flex column so the terminal fills it
+    content.style.cssText += 'display:flex;flex-direction:column;padding:4px;';
+
+    // If we already have a persistent terminal box, just re-attach it
+    if (this._termBox) {
+      content.appendChild(this._termBox);
+      this._termBox.style.display = 'flex';
+      // Re-fit after re-attach
+      requestAnimationFrame(() => { if (this._termFit) this._termFit.fit(); });
+      return;
+    }
+
+    // First time: create the persistent terminal box + xterm instance
+    const termBox = document.createElement('div');
+    termBox.id = 'cmd-xterm';
+    termBox.style.cssText = 'flex:1;min-height:0;width:100%;display:flex;';
+    this._termBox = termBox;
+    content.appendChild(termBox);
+
+    requestAnimationFrame(() => {
+      const Terminal = window.Terminal;
+      const FitAddon = window.FitAddon?.FitAddon;
+      if (!Terminal) {
+        termBox.innerHTML = '<div class="cmd-empty" style="color:#ff6b6b">xterm.js not loaded</div>';
+        return;
+      }
+
+      const term = new Terminal({
+        fontFamily: "'JetBrains Mono', monospace",
+        fontSize: 12,
+        theme: {
+          background: '#0a0a1a',
+          foreground: '#c8ccd4',
+          cursor: '#a29bfe',
+          cursorAccent: '#0a0a1a',
+          selectionBackground: 'rgba(162, 155, 254, 0.3)',
+          black: '#0a0a12',
+          red: '#ff6b6b',
+          green: '#00e676',
+          yellow: '#ffd93d',
+          blue: '#74b9ff',
+          magenta: '#a29bfe',
+          cyan: '#00cec9',
+          white: '#c8ccd4',
+          brightBlack: '#636e72',
+          brightRed: '#ff6b6b',
+          brightGreen: '#00e676',
+          brightYellow: '#ffd93d',
+          brightBlue: '#74b9ff',
+          brightMagenta: '#d4cfff',
+          brightCyan: '#00cec9',
+          brightWhite: '#e0e0e8',
+        },
+        cursorBlink: true,
+        scrollback: 5000,
+        convertEol: true,
+      });
+
+      term.open(termBox);
+
+      if (FitAddon) {
+        const fit = new FitAddon();
+        term.loadAddon(fit);
+        fit.fit();
+        this._termFit = fit;
+        // Re-fit whenever the box resizes (panel drag, window resize)
+        const ro = new ResizeObserver(() => fit.fit());
+        ro.observe(termBox);
+      }
+
+      this._terminal = term;
+
+      // Connect WebSocket
+      const wsUrl = this._client.terminalWsUrl(this._termSessionId);
+      const ws = new WebSocket(wsUrl);
+      ws.binaryType = 'arraybuffer';
+      this._termWs = ws;
+
+      ws.onopen = () => {
+        term.writeln('\x1b[38;5;141m// Connected to agent terminal\x1b[0m');
+        ws.send(JSON.stringify({ type: 'resize', rows: term.rows, cols: term.cols }));
+      };
+
+      ws.onmessage = (ev) => {
+        if (ev.data instanceof ArrayBuffer) {
+          term.write(new Uint8Array(ev.data));
+        } else {
+          try {
+            const msg = JSON.parse(ev.data);
+            if (msg.type === 'exit') {
+              term.writeln('\r\n\x1b[38;5;203m// Process exited\x1b[0m');
+              this._termSessionId = null;
+            }
+          } catch {
+            term.write(ev.data);
+          }
+        }
+      };
+
+      ws.onclose = () => {
+        term.writeln('\r\n\x1b[38;5;243m// Connection closed\x1b[0m');
+      };
+
+      ws.onerror = () => {
+        term.writeln('\r\n\x1b[38;5;203m// WebSocket error\x1b[0m');
+      };
+
+      term.onData((data) => {
+        if (ws.readyState === WebSocket.OPEN) {
+          ws.send(JSON.stringify({ type: 'input', data }));
+        }
+      });
+
+      term.onResize(({ rows, cols }) => {
+        if (ws.readyState === WebSocket.OPEN) {
+          ws.send(JSON.stringify({ type: 'resize', rows, cols }));
+        }
+      });
+    });
+  }
+
+  // ── Actions ──
+
+  async _doSpawn() {
+    const slug = this._agent.slug || this._agent.name;
+    return await this._client.spawnWithContext({ project: this._project, profile: slug });
+  }
+
+  async _doDeleteAgent() {
+    const slug = this._agent.slug || this._agent.name;
+    if (!confirm(`Delete agent "${slug}"?`)) return;
+    await this._client.deleteProfile(slug, this._project);
+    this.clearAgent();
+  }
+
+  async _doSendMessage(form) {
+    const get = (f) => form.querySelector(`[data-field="${f}"]`)?.value?.trim() || '';
+    const to = get('to');
+    const content = get('content');
+    if (!to || !content) return;
+    await this._client.sendUserResponse(this._project, to, content, null);
+    this._msgFormOpen = false;
+    this._renderAgentPanel();
+  }
+
+  // ── Resize ──
+
+  _initResize() {
+    let startY = 0, startH = 0, active = false;
+    const onMove = (e) => {
+      if (!active) return;
+      const dy = startY - e.clientY;
+      const newH = Math.max(120, Math.min(window.innerHeight * 0.6, startH + dy));
+      this._container.style.height = newH + 'px';
+      window.dispatchEvent(new Event('resize'));
+    };
+    const onUp = () => {
+      if (!active) return;
+      active = false;
+      document.body.style.userSelect = '';
+      document.body.style.cursor = '';
+      document.removeEventListener('mousemove', onMove);
+      document.removeEventListener('mouseup', onUp);
+    };
+    this._resizeHandle.addEventListener('mousedown', (e) => {
+      e.preventDefault();
+      active = true;
+      startY = e.clientY;
+      startH = this._container.offsetHeight;
+      document.body.style.userSelect = 'none';
+      document.body.style.cursor = 'ns-resize';
+      document.addEventListener('mousemove', onMove);
+      document.addEventListener('mouseup', onUp);
+    });
+  }
+}

--- a/internal/web/static/js/flow-editor.js
+++ b/internal/web/static/js/flow-editor.js
@@ -1,0 +1,1820 @@
+// flow-editor.js — Visual Workflow Builder (n8n-style DAG editor)
+// DOM-based nodes + SVG edges, purple neon pixel art aesthetic
+
+function esc(str) {
+  if (!str) return '';
+  const d = document.createElement('div');
+  d.textContent = str;
+  return d.innerHTML;
+}
+
+const NODE_TYPES = {
+  'trigger:event':     { label: 'Event Trigger',  color: '#6c5ce7', icon: '\u26A1', category: 'trigger',   inputs: 0, outputs: 1 },
+  'trigger:cron':      { label: 'Cron Schedule',   color: '#6c5ce7', icon: '\uD83D\uDD50', category: 'trigger',   inputs: 0, outputs: 1 },
+  'trigger:webhook':   { label: 'Webhook',         color: '#6c5ce7', icon: '\uD83D\uDD17', category: 'trigger',   inputs: 0, outputs: 1 },
+  'condition:match':   { label: 'Match',            color: '#0984e3', icon: '\u2753', category: 'condition', inputs: 1, outputs: 2 },
+  'condition:switch':  { label: 'Switch',           color: '#0984e3', icon: '\uD83D\uDD00', category: 'condition', inputs: 1, outputs: 4 },
+  'action:spawn':      { label: 'Spawn Agent',      color: '#00b894', icon: '\uD83E\uDD16', category: 'action',   inputs: 1, outputs: 1 },
+  'action:message':    { label: 'Send Message',     color: '#00b894', icon: '\uD83D\uDCAC', category: 'action',   inputs: 1, outputs: 1 },
+  'action:task':       { label: 'Dispatch Task',    color: '#00b894', icon: '\uD83D\uDCCB', category: 'action',   inputs: 1, outputs: 1 },
+  'action:team_notify':{ label: 'Team Notify',      color: '#00b894', icon: '\uD83D\uDCE2', category: 'action',   inputs: 1, outputs: 1 },
+  'action:broadcast':  { label: 'Broadcast',        color: '#00b894', icon: '\uD83D\uDCE1', category: 'action',   inputs: 1, outputs: 1 },
+  'action:webhook_out':{ label: 'HTTP Request',     color: '#00b894', icon: '\uD83C\uDF10', category: 'action',   inputs: 1, outputs: 1 },
+  'action:elevate':    { label: 'Elevate',          color: '#00b894', icon: '\u2B06\uFE0F', category: 'action',   inputs: 1, outputs: 1 },
+  'action:schedule':   { label: 'Schedule',         color: '#00b894', icon: '\uD83D\uDCC5', category: 'action',   inputs: 1, outputs: 1 },
+};
+
+const CATEGORY_LABELS = {
+  trigger:   'TRIGGERS',
+  condition: 'CONDITIONS',
+  action:    'ACTIONS',
+};
+
+const CATEGORY_ORDER = ['trigger', 'condition', 'action'];
+
+// ── Embedded styles ──
+
+const FLOW_STYLES = `
+@import url('https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;600;700&display=swap');
+
+@keyframes flowSlideIn {
+  from { opacity: 0; transform: translateY(8px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+@keyframes edgeFlow {
+  from { stroke-dashoffset: 20; }
+  to   { stroke-dashoffset: 0; }
+}
+
+/* ── Root layout ── */
+.flow-root {
+  font-family: 'JetBrains Mono', monospace;
+  background: #0a0a12;
+  color: #dfe6e9;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  position: relative;
+}
+
+/* ── Toolbar ── */
+.flow-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 12px;
+  background: rgba(15, 15, 26, 0.95);
+  border-bottom: 1px solid rgba(108, 92, 231, 0.2);
+  flex-shrink: 0;
+  z-index: 10;
+}
+.flow-toolbar select,
+.flow-toolbar input {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 10px;
+  background: #1a1a2e;
+  color: #dfe6e9;
+  border: 1px solid rgba(108, 92, 231, 0.3);
+  border-radius: 3px;
+  padding: 4px 8px;
+  outline: none;
+}
+.flow-toolbar select:focus,
+.flow-toolbar input:focus {
+  border-color: #6c5ce7;
+  box-shadow: 0 0 6px rgba(108, 92, 231, 0.3);
+}
+.flow-toolbar input.flow-wf-name {
+  width: 180px;
+}
+.flow-toolbar-spacer {
+  flex: 1;
+}
+.flow-btn {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 9px;
+  font-weight: 600;
+  letter-spacing: 0.5px;
+  padding: 4px 12px;
+  border: 1px solid rgba(108, 92, 231, 0.4);
+  border-radius: 3px;
+  background: rgba(108, 92, 231, 0.1);
+  color: #a29bfe;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+.flow-btn:hover {
+  background: rgba(108, 92, 231, 0.25);
+  color: #dfe6e9;
+  box-shadow: 0 0 8px rgba(108, 92, 231, 0.3);
+}
+.flow-btn.danger {
+  border-color: rgba(214, 48, 49, 0.4);
+  background: rgba(214, 48, 49, 0.1);
+  color: #ff7675;
+}
+.flow-btn.danger:hover {
+  background: rgba(214, 48, 49, 0.25);
+  color: #fab1a0;
+}
+.flow-btn.primary {
+  border-color: rgba(0, 184, 148, 0.5);
+  background: rgba(0, 184, 148, 0.15);
+  color: #55efc4;
+}
+.flow-btn.primary:hover {
+  background: rgba(0, 184, 148, 0.3);
+  color: #fff;
+}
+
+/* ── Body: palette + canvas + config ── */
+.flow-body {
+  display: flex;
+  flex: 1;
+  overflow: hidden;
+}
+
+/* ── Left palette ── */
+.flow-palette {
+  width: 180px;
+  flex-shrink: 0;
+  background: #0f0f1a;
+  border-right: 1px solid rgba(108, 92, 231, 0.15);
+  overflow-y: auto;
+  padding: 8px 0;
+}
+.flow-palette-group {
+  padding: 8px 12px 4px;
+  font-size: 8px;
+  font-weight: 700;
+  letter-spacing: 1.5px;
+  color: #636e72;
+}
+.flow-palette-item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  font-size: 9px;
+  color: #b2bec3;
+  cursor: pointer;
+  transition: all 0.12s;
+  border-left: 2px solid transparent;
+}
+.flow-palette-item:hover {
+  background: rgba(108, 92, 231, 0.08);
+  color: #dfe6e9;
+  border-left-color: var(--node-color);
+}
+.flow-palette-item .pi-icon {
+  font-size: 12px;
+  width: 18px;
+  text-align: center;
+}
+.flow-palette-item .pi-label {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* ── Canvas wrapper ── */
+.flow-canvas-wrap {
+  flex: 1;
+  position: relative;
+  overflow: hidden;
+  background: #0a0a12;
+  cursor: grab;
+}
+.flow-canvas-wrap.grabbing {
+  cursor: grabbing;
+}
+.flow-canvas-wrap.connecting {
+  cursor: crosshair;
+}
+
+/* Grid background */
+.flow-canvas-wrap::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background-image:
+    radial-gradient(circle, rgba(108, 92, 231, 0.06) 1px, transparent 1px);
+  background-size: 20px 20px;
+  pointer-events: none;
+  z-index: 0;
+}
+
+/* ── SVG edge layer ── */
+.flow-svg {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  z-index: 1;
+  overflow: visible;
+}
+.flow-svg .flow-edge {
+  fill: none;
+  stroke: #6c5ce7;
+  stroke-width: 2;
+  pointer-events: stroke;
+  cursor: pointer;
+  transition: stroke 0.15s, stroke-width 0.15s;
+}
+.flow-svg .flow-edge:hover {
+  stroke: #a29bfe;
+  stroke-width: 3;
+  filter: url(#neon-glow);
+}
+.flow-svg .flow-edge.selected {
+  stroke: #a29bfe;
+  stroke-width: 2.5;
+  stroke-dasharray: 8 4;
+  animation: edgeFlow 0.6s linear infinite;
+  filter: url(#neon-glow);
+}
+.flow-svg .flow-edge-temp {
+  fill: none;
+  stroke: rgba(108, 92, 231, 0.5);
+  stroke-width: 2;
+  stroke-dasharray: 6 4;
+  pointer-events: none;
+}
+
+/* ── Nodes layer ── */
+.flow-nodes {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 0;
+  height: 0;
+  transform-origin: 0 0;
+  z-index: 2;
+}
+
+/* ── Node ── */
+.flow-node {
+  position: absolute;
+  width: 180px;
+  background: #1a1a2e;
+  border: 1px solid rgba(108, 92, 231, 0.2);
+  border-radius: 6px;
+  overflow: visible;
+  cursor: default;
+  transition: box-shadow 0.15s, border-color 0.15s;
+  animation: flowSlideIn 0.2s ease-out;
+  user-select: none;
+}
+.flow-node:hover {
+  border-color: var(--node-color, rgba(108, 92, 231, 0.5));
+  box-shadow: 0 0 12px color-mix(in srgb, var(--node-color, #6c5ce7) 30%, transparent);
+}
+.flow-node.selected {
+  border-color: var(--node-color, #6c5ce7);
+  box-shadow: 0 0 18px color-mix(in srgb, var(--node-color, #6c5ce7) 40%, transparent),
+              0 0 4px color-mix(in srgb, var(--node-color, #6c5ce7) 20%, transparent);
+}
+
+.flow-node-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  background: var(--node-color, #6c5ce7);
+  border-radius: 5px 5px 0 0;
+  cursor: grab;
+  font-size: 9px;
+  font-weight: 600;
+  color: #fff;
+  letter-spacing: 0.3px;
+}
+.flow-node-header .nh-icon {
+  font-size: 12px;
+}
+.flow-node-header .nh-label {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.flow-node-body {
+  padding: 8px 10px;
+  font-size: 8px;
+  color: #636e72;
+  min-height: 20px;
+  line-height: 1.4;
+}
+
+/* ── Ports ── */
+.flow-port {
+  position: absolute;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: #2d3436;
+  border: 2px solid var(--node-color, #6c5ce7);
+  cursor: crosshair;
+  z-index: 5;
+  transition: all 0.12s;
+}
+.flow-port.port-input {
+  left: -5px;
+}
+.flow-port.port-output {
+  right: -5px;
+}
+.flow-port:hover {
+  background: var(--node-color, #6c5ce7);
+  box-shadow: 0 0 8px var(--node-color, #6c5ce7);
+  transform: scale(1.3);
+}
+
+/* ── Right config panel ── */
+.flow-config {
+  width: 260px;
+  flex-shrink: 0;
+  background: #0f0f1a;
+  border-left: 1px solid rgba(108, 92, 231, 0.15);
+  overflow-y: auto;
+  padding: 0;
+  display: none;
+}
+.flow-config.open {
+  display: block;
+}
+.flow-config-header {
+  padding: 10px 14px;
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 1px;
+  color: #6c5ce7;
+  border-bottom: 1px solid rgba(108, 92, 231, 0.15);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+.flow-config-close {
+  font-size: 14px;
+  cursor: pointer;
+  color: #636e72;
+  background: none;
+  border: none;
+  font-family: inherit;
+  line-height: 1;
+  padding: 2px 4px;
+}
+.flow-config-close:hover {
+  color: #dfe6e9;
+}
+.flow-config-body {
+  padding: 12px 14px;
+}
+.flow-config-field {
+  margin-bottom: 10px;
+}
+.flow-config-field label {
+  display: block;
+  font-size: 8px;
+  font-weight: 600;
+  letter-spacing: 0.8px;
+  color: #636e72;
+  margin-bottom: 4px;
+  text-transform: uppercase;
+}
+.flow-config-field input,
+.flow-config-field select,
+.flow-config-field textarea {
+  width: 100%;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 10px;
+  background: #1a1a2e;
+  color: #dfe6e9;
+  border: 1px solid rgba(108, 92, 231, 0.2);
+  border-radius: 3px;
+  padding: 5px 8px;
+  outline: none;
+  transition: border-color 0.15s;
+}
+.flow-config-field input:focus,
+.flow-config-field select:focus,
+.flow-config-field textarea:focus {
+  border-color: #6c5ce7;
+  box-shadow: 0 0 6px rgba(108, 92, 231, 0.2);
+}
+.flow-config-field textarea {
+  resize: vertical;
+  min-height: 60px;
+}
+
+/* ── Meta preview & webhook URL ── */
+.flow-meta-preview {
+  background: rgba(108, 92, 231, 0.06);
+  border: 1px solid rgba(108, 92, 231, 0.15);
+  border-radius: 4px;
+  padding: 8px 10px;
+  margin-top: 6px;
+}
+.flow-meta-title {
+  font-size: 8px;
+  font-weight: 600;
+  color: #636e72;
+  letter-spacing: 0.5px;
+  margin-bottom: 6px;
+}
+.flow-meta-tag {
+  display: inline-block;
+  font-size: 9px;
+  font-family: 'JetBrains Mono', monospace;
+  background: rgba(108, 92, 231, 0.12);
+  color: #a29bfe;
+  border: 1px solid rgba(108, 92, 231, 0.2);
+  border-radius: 3px;
+  padding: 2px 6px;
+  margin: 2px 3px 2px 0;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+.flow-meta-tag:hover {
+  background: rgba(108, 92, 231, 0.25);
+}
+.flow-webhook-url {
+  margin-top: 6px;
+}
+.flow-webhook-code {
+  display: block;
+  font-size: 10px;
+  font-family: 'JetBrains Mono', monospace;
+  background: rgba(0, 184, 148, 0.08);
+  color: #00b894;
+  border: 1px solid rgba(0, 184, 148, 0.2);
+  border-radius: 3px;
+  padding: 6px 10px;
+  margin-top: 4px;
+  word-break: break-all;
+  user-select: all;
+}
+.flow-config-field select optgroup {
+  font-size: 10px;
+  color: #636e72;
+}
+.flow-config-field select option {
+  font-size: 10px;
+  color: #dfe6e9;
+  background: #1a1a2e;
+  padding: 4px;
+}
+
+/* ── Context menu ── */
+.flow-context-menu {
+  position: fixed;
+  background: #1a1a2e;
+  border: 1px solid rgba(108, 92, 231, 0.3);
+  border-radius: 4px;
+  padding: 4px 0;
+  z-index: 100;
+  min-width: 140px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.5);
+}
+.flow-context-item {
+  padding: 6px 14px;
+  font-size: 9px;
+  color: #b2bec3;
+  cursor: pointer;
+  transition: all 0.1s;
+}
+.flow-context-item:hover {
+  background: rgba(108, 92, 231, 0.15);
+  color: #dfe6e9;
+}
+.flow-context-item.danger {
+  color: #ff7675;
+}
+.flow-context-item.danger:hover {
+  background: rgba(214, 48, 49, 0.15);
+}
+
+/* ── Scrollbar ── */
+.flow-palette::-webkit-scrollbar,
+.flow-config::-webkit-scrollbar {
+  width: 4px;
+}
+.flow-palette::-webkit-scrollbar-track,
+.flow-config::-webkit-scrollbar-track {
+  background: transparent;
+}
+.flow-palette::-webkit-scrollbar-thumb,
+.flow-config::-webkit-scrollbar-thumb {
+  background: rgba(108, 92, 231, 0.2);
+  border-radius: 2px;
+}
+
+/* ── Empty state ── */
+.flow-empty {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  text-align: center;
+  color: #636e72;
+  font-size: 10px;
+  pointer-events: none;
+  z-index: 0;
+}
+.flow-empty .fe-icon {
+  font-size: 32px;
+  margin-bottom: 8px;
+  opacity: 0.4;
+}
+.flow-empty .fe-text {
+  letter-spacing: 0.5px;
+}
+`;
+
+// ── Config field definitions per node type ──
+
+// ── Known system events with their meta fields ──
+const KNOWN_EVENTS = {
+  'message_received':  { label: 'Message Received',  icon: '\uD83D\uDCE8', meta: ['from_agent', 'to_agent', 'subject', 'type', 'priority', 'conversation_id'] },
+  'signal:interrupt':  { label: 'P0 Interrupt',      icon: '\uD83D\uDEA8', meta: ['from_agent', 'to_agent', 'subject', 'type', 'priority'] },
+  'task_pending':      { label: 'Task Dispatched',   icon: '\uD83D\uDCCB', meta: ['task_id', 'profile', 'priority', 'dispatched_by', 'title'] },
+  'task_completed':    { label: 'Task Completed',    icon: '\u2705',       meta: ['task_id', 'profile', 'completed_by', 'title'] },
+  'task_blocked':      { label: 'Task Blocked',      icon: '\uD83D\uDED1', meta: ['task_id', 'profile', 'blocked_by', 'title', 'reason'] },
+  'signal:alert':      { label: 'Alert Signal',      icon: '\u26A0\uFE0F', meta: ['task_id', 'profile', 'blocked_by', 'title', 'reason'] },
+  '*':                 { label: 'Any Event',          icon: '\uD83C\uDF10', meta: [] },
+};
+
+// ── Cron presets ──
+const CRON_PRESETS = [
+  { label: 'Every minute',      value: '* * * * *' },
+  { label: 'Every 5 minutes',   value: '*/5 * * * *' },
+  { label: 'Every 15 minutes',  value: '*/15 * * * *' },
+  { label: 'Every hour',        value: '0 * * * *' },
+  { label: 'Every 6 hours',     value: '0 */6 * * *' },
+  { label: 'Daily at midnight', value: '0 0 * * *' },
+  { label: 'Daily at 9am',      value: '0 9 * * *' },
+  { label: 'Weekly (Monday)',   value: '0 9 * * 1' },
+  { label: 'Custom...',         value: '__custom__' },
+];
+
+const NODE_CONFIG_FIELDS = {
+  'trigger:event':     [{ key: 'event',   label: 'Event Name',   type: 'event_select' }],
+  'trigger:cron':      [{ key: 'cron',    label: 'Schedule', type: 'cron_select' }],
+  'trigger:webhook':   [{ key: 'event',   label: 'Webhook Event', type: 'webhook_config' }],
+  'condition:match':   [
+    { key: 'field', label: 'Field',    type: 'text',   placeholder: 'e.g. payload.status' },
+    { key: 'op',    label: 'Operator', type: 'select', options: ['eq', 'neq', 'contains', 'gt', 'lt'] },
+    { key: 'value', label: 'Value',    type: 'text',   placeholder: 'match value' },
+  ],
+  'condition:switch':  [
+    { key: 'field', label: 'Field', type: 'text', placeholder: 'e.g. payload.type' },
+    { key: 'cases', label: 'Cases (one per line)', type: 'textarea', placeholder: 'value1\nvalue2\nvalue3\nvalue4' },
+  ],
+  'action:spawn':      [
+    { key: 'profile', label: 'Profile',  type: 'text', placeholder: 'agent profile name' },
+    { key: 'cycle',   label: 'Cycle',    type: 'text', placeholder: 'cycle name' },
+    { key: 'task_id', label: 'Task ID',  type: 'text', placeholder: '(optional)' },
+  ],
+  'action:message':    [
+    { key: 'to',      label: 'To',       type: 'text',     placeholder: 'recipient agent' },
+    { key: 'subject', label: 'Subject',  type: 'text',     placeholder: 'message subject' },
+    { key: 'content', label: 'Content',  type: 'textarea', placeholder: 'message body' },
+    { key: 'type',    label: 'Type',     type: 'select',   options: ['text', 'json', 'directive'] },
+  ],
+  'action:task':       [
+    { key: 'profile',     label: 'Assignee',    type: 'text',     placeholder: 'agent profile' },
+    { key: 'title',       label: 'Title',       type: 'text',     placeholder: 'task title' },
+    { key: 'description', label: 'Description', type: 'textarea', placeholder: 'task description' },
+  ],
+  'action:team_notify':  [{ key: 'channel', label: 'Channel', type: 'text', placeholder: 'notification channel' }],
+  'action:broadcast':    [{ key: 'event',   label: 'Event',   type: 'text', placeholder: 'broadcast event' }],
+  'action:webhook_out':  [
+    { key: 'url',    label: 'URL',    type: 'text',   placeholder: 'https://...' },
+    { key: 'method', label: 'Method', type: 'select', options: ['GET', 'POST', 'PUT', 'DELETE'] },
+  ],
+  'action:elevate':      [
+    { key: 'role',     label: 'Role',     type: 'text', placeholder: 'target role' },
+    { key: 'duration', label: 'Duration', type: 'text', placeholder: 'e.g. 30m' },
+  ],
+  'action:schedule':     [
+    { key: 'cron',   label: 'Cron Expression', type: 'text', placeholder: '*/10 * * * *' },
+    { key: 'action', label: 'Action',          type: 'text', placeholder: 'action to schedule' },
+  ],
+};
+
+
+// ── Utility: unique ID ──
+
+let _flowUid = 0;
+function flowUid() { return `fn_${++_flowUid}_${Date.now().toString(36)}`; }
+let _edgeUid = 0;
+function edgeUid() { return `fe_${++_edgeUid}_${Date.now().toString(36)}`; }
+
+
+// ── FlowEditor class ──
+
+export class FlowEditor {
+  constructor(container, apiClient) {
+    this.container = container;
+    this.api = apiClient;
+    this.project = null;
+
+    // State
+    this.workflows = [];
+    this.currentWorkflow = null;
+    this.nodes = new Map();   // nodeId -> { el, data, portEls }
+    this.edges = [];          // { id, source, target, sourcePort, targetPort, pathEl }
+
+    // Interaction state
+    this.dragState = null;    // { type: 'node'|'edge'|'pan', ... }
+    this.selectedNode = null;
+    this.selectedEdge = null;
+    this.panOffset = { x: 0, y: 0 };
+    this.zoom = 1;
+
+    // DOM refs (created in _build)
+    this.root = null;
+    this.palette = null;
+    this.canvas = null;
+    this.svgLayer = null;
+    this.nodesLayer = null;
+    this.configPanel = null;
+    this.toolbar = null;
+    this.workflowSelect = null;
+    this.nameInput = null;
+
+    this._nextNodeId = 1;
+    this._boundHandlers = {};
+    this._contextMenu = null;
+    this._styleEl = null;
+    this._tempEdgePath = null;
+  }
+
+  // ── Public API ──
+
+  show(project) {
+    this.project = project;
+    this._build();
+    this._loadWorkflows();
+  }
+
+  hide() {
+    this._removeContextMenu();
+    // Remove event listeners
+    if (this._boundHandlers.keydown) {
+      document.removeEventListener('keydown', this._boundHandlers.keydown);
+    }
+    if (this._styleEl && this._styleEl.parentNode) {
+      this._styleEl.parentNode.removeChild(this._styleEl);
+    }
+    this.container.innerHTML = '';
+    this.nodes.clear();
+    this.edges = [];
+    this.currentWorkflow = null;
+  }
+
+  // ── Build DOM ──
+
+  _build() {
+    this.container.innerHTML = '';
+
+    // Inject styles
+    this._styleEl = document.createElement('style');
+    this._styleEl.textContent = FLOW_STYLES;
+    document.head.appendChild(this._styleEl);
+
+    // Root
+    this.root = document.createElement('div');
+    this.root.className = 'flow-root';
+    this.container.appendChild(this.root);
+
+    // Toolbar
+    this.toolbar = document.createElement('div');
+    this.toolbar.className = 'flow-toolbar';
+    this.toolbar.innerHTML = `
+      <select class="flow-wf-select"></select>
+      <input class="flow-wf-name" type="text" placeholder="Workflow name..." />
+      <span class="flow-toolbar-spacer"></span>
+      <button class="flow-btn primary flow-btn-save">SAVE</button>
+      <button class="flow-btn flow-btn-run">RUN</button>
+      <button class="flow-btn danger flow-btn-delete">DELETE</button>
+    `;
+    this.root.appendChild(this.toolbar);
+
+    this.workflowSelect = this.toolbar.querySelector('.flow-wf-select');
+    this.nameInput = this.toolbar.querySelector('.flow-wf-name');
+
+    this.workflowSelect.addEventListener('change', () => this._onWorkflowSelect());
+    this.toolbar.querySelector('.flow-btn-save').addEventListener('click', () => this._saveWorkflow());
+    this.toolbar.querySelector('.flow-btn-run').addEventListener('click', () => this._runWorkflow());
+    this.toolbar.querySelector('.flow-btn-delete').addEventListener('click', () => this._deleteWorkflow());
+
+    // Body: palette + canvas + config
+    const body = document.createElement('div');
+    body.className = 'flow-body';
+    this.root.appendChild(body);
+
+    // Palette
+    this.palette = document.createElement('div');
+    this.palette.className = 'flow-palette';
+    this._buildPalette();
+    body.appendChild(this.palette);
+
+    // Canvas wrapper
+    this.canvas = document.createElement('div');
+    this.canvas.className = 'flow-canvas-wrap';
+    body.appendChild(this.canvas);
+
+    // SVG layer
+    this.svgLayer = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    this.svgLayer.classList.add('flow-svg');
+    // Neon glow filter
+    this.svgLayer.innerHTML = `
+      <defs>
+        <filter id="neon-glow" x="-50%" y="-50%" width="200%" height="200%">
+          <feGaussianBlur in="SourceGraphic" stdDeviation="3" result="blur" />
+          <feComposite in="SourceGraphic" in2="blur" operator="over" />
+        </filter>
+      </defs>
+    `;
+    this.canvas.appendChild(this.svgLayer);
+
+    // Nodes layer
+    this.nodesLayer = document.createElement('div');
+    this.nodesLayer.className = 'flow-nodes';
+    this.canvas.appendChild(this.nodesLayer);
+
+    // Empty state
+    this._emptyEl = document.createElement('div');
+    this._emptyEl.className = 'flow-empty';
+    this._emptyEl.innerHTML = `
+      <div class="fe-icon">\u2B21</div>
+      <div class="fe-text">Select or create a workflow</div>
+    `;
+    this.canvas.appendChild(this._emptyEl);
+
+    // Config panel
+    this.configPanel = document.createElement('div');
+    this.configPanel.className = 'flow-config';
+    body.appendChild(this.configPanel);
+
+    // Event bindings
+    this._boundHandlers.mousedown = (e) => this._onCanvasMouseDown(e);
+    this._boundHandlers.mousemove = (e) => this._onMouseMove(e);
+    this._boundHandlers.mouseup = (e) => this._onMouseUp(e);
+    this._boundHandlers.wheel = (e) => this._onWheel(e);
+    this._boundHandlers.contextmenu = (e) => this._onContextMenu(e);
+    this._boundHandlers.keydown = (e) => this._onKeyDown(e);
+
+    this.canvas.addEventListener('mousedown', this._boundHandlers.mousedown);
+    window.addEventListener('mousemove', this._boundHandlers.mousemove);
+    window.addEventListener('mouseup', this._boundHandlers.mouseup);
+    this.canvas.addEventListener('wheel', this._boundHandlers.wheel, { passive: false });
+    this.canvas.addEventListener('contextmenu', this._boundHandlers.contextmenu);
+    document.addEventListener('keydown', this._boundHandlers.keydown);
+  }
+
+  _buildPalette() {
+    this.palette.innerHTML = '';
+    for (const cat of CATEGORY_ORDER) {
+      const group = document.createElement('div');
+      group.className = 'flow-palette-group';
+      group.textContent = CATEGORY_LABELS[cat];
+      this.palette.appendChild(group);
+
+      for (const [typeKey, def] of Object.entries(NODE_TYPES)) {
+        if (def.category !== cat) continue;
+        const item = document.createElement('div');
+        item.className = 'flow-palette-item';
+        item.style.setProperty('--node-color', def.color);
+        item.innerHTML = `<span class="pi-icon">${def.icon}</span><span class="pi-label">${esc(def.label)}</span>`;
+        item.addEventListener('click', () => this._addNodeAtCenter(typeKey));
+        this.palette.appendChild(item);
+      }
+    }
+  }
+
+  // ── Workflow CRUD ──
+
+  async _loadWorkflows() {
+    try {
+      this.workflows = await this.api.fetchWorkflows(this.project) || [];
+    } catch {
+      this.workflows = [];
+    }
+    this._renderWorkflowList();
+  }
+
+  _renderWorkflowList() {
+    this.workflowSelect.innerHTML = '';
+
+    const opt0 = document.createElement('option');
+    opt0.value = '__new';
+    opt0.textContent = '+ New Workflow';
+    this.workflowSelect.appendChild(opt0);
+
+    for (const wf of this.workflows) {
+      const opt = document.createElement('option');
+      opt.value = wf.id;
+      opt.textContent = wf.name || `Workflow #${wf.id}`;
+      if (this.currentWorkflow && this.currentWorkflow.id === wf.id) {
+        opt.selected = true;
+      }
+      this.workflowSelect.appendChild(opt);
+    }
+  }
+
+  async _onWorkflowSelect() {
+    const val = this.workflowSelect.value;
+    if (val === '__new') {
+      this._newWorkflow();
+    } else {
+      await this._loadWorkflow(val);
+    }
+  }
+
+  async _loadWorkflow(id) {
+    try {
+      this.currentWorkflow = await this.api.fetchWorkflow(id);
+    } catch {
+      this.currentWorkflow = null;
+    }
+    if (this.currentWorkflow) {
+      this.nameInput.value = this.currentWorkflow.name || '';
+      this._renderWorkflow();
+    }
+  }
+
+  async _saveWorkflow() {
+    const name = this.nameInput.value.trim() || 'Untitled';
+    const definition = this._serializeWorkflow();
+
+    if (this.currentWorkflow && this.currentWorkflow.id) {
+      try {
+        this.currentWorkflow = await this.api.updateWorkflow(this.currentWorkflow.id, {
+          name,
+          definition,
+        });
+      } catch (err) {
+        console.error('Save workflow failed:', err);
+      }
+    } else {
+      try {
+        this.currentWorkflow = await this.api.createWorkflow({
+          project: this.project,
+          name,
+          definition,
+        });
+      } catch (err) {
+        console.error('Create workflow failed:', err);
+      }
+    }
+    await this._loadWorkflows();
+  }
+
+  _newWorkflow() {
+    this.currentWorkflow = { id: null, name: '', definition: { nodes: [], edges: [] } };
+    this.nameInput.value = '';
+    this._renderWorkflow();
+  }
+
+  async _deleteWorkflow() {
+    if (!this.currentWorkflow || !this.currentWorkflow.id) return;
+    if (!confirm('Delete this workflow?')) return;
+    try {
+      await this.api.deleteWorkflow(this.currentWorkflow.id);
+    } catch (err) {
+      console.error('Delete workflow failed:', err);
+    }
+    this.currentWorkflow = null;
+    this.nameInput.value = '';
+    this._clearCanvas();
+    await this._loadWorkflows();
+  }
+
+  async _runWorkflow() {
+    if (!this.currentWorkflow || !this.currentWorkflow.id) return;
+    try {
+      await this.api.executeWorkflow(this.currentWorkflow.id, {});
+    } catch (err) {
+      console.error('Run workflow failed:', err);
+    }
+  }
+
+  // ── Serialization ──
+
+  _serializeWorkflow() {
+    const nodes = [];
+    for (const [id, entry] of this.nodes) {
+      nodes.push({
+        id,
+        type: entry.data.type,
+        x: entry.data.x,
+        y: entry.data.y,
+        config: { ...entry.data.config },
+      });
+    }
+    const edges = this.edges.map(e => ({
+      id: e.id,
+      source: e.source,
+      target: e.target,
+      sourcePort: e.sourcePort,
+      targetPort: e.targetPort,
+    }));
+    return { nodes, edges };
+  }
+
+  // ── Render workflow ──
+
+  _renderWorkflow() {
+    this._clearCanvas();
+
+    if (!this.currentWorkflow) {
+      this._emptyEl.style.display = '';
+      return;
+    }
+    this._emptyEl.style.display = 'none';
+
+    const def = this.currentWorkflow.definition || { nodes: [], edges: [] };
+
+    // Render nodes
+    for (const nd of def.nodes || []) {
+      this._addNode(nd.type, nd.x, nd.y, nd.id, nd.config);
+    }
+
+    // Render edges
+    for (const ed of def.edges || []) {
+      this._addEdge(ed.source, ed.target, ed.sourcePort, ed.targetPort, ed.id);
+    }
+
+    this._updateTransform();
+  }
+
+  _clearCanvas() {
+    this.nodesLayer.innerHTML = '';
+    // Clear SVG edges (keep <defs>)
+    const defs = this.svgLayer.querySelector('defs');
+    this.svgLayer.innerHTML = '';
+    if (defs) this.svgLayer.appendChild(defs);
+
+    this.nodes.clear();
+    this.edges = [];
+    this.selectedNode = null;
+    this.selectedEdge = null;
+    this._hideConfig();
+    this._emptyEl.style.display = '';
+  }
+
+  // ── Node operations ──
+
+  _addNodeAtCenter(type) {
+    if (!this.currentWorkflow) {
+      this._newWorkflow();
+      this._emptyEl.style.display = 'none';
+    }
+    const rect = this.canvas.getBoundingClientRect();
+    const cx = (rect.width / 2 - this.panOffset.x) / this.zoom - 90;
+    const cy = (rect.height / 2 - this.panOffset.y) / this.zoom - 30;
+    this._addNode(type, Math.round(cx), Math.round(cy));
+  }
+
+  _addNode(type, x, y, id, config) {
+    const nodeId = id || flowUid();
+    const typeDef = NODE_TYPES[type];
+    if (!typeDef) return null;
+
+    const data = {
+      id: nodeId,
+      type,
+      x,
+      y,
+      config: config || {},
+    };
+
+    const el = this._renderNodeElement(data, typeDef);
+    this.nodesLayer.appendChild(el);
+
+    const portEls = {
+      inputs: Array.from(el.querySelectorAll('.port-input')),
+      outputs: Array.from(el.querySelectorAll('.port-output')),
+    };
+
+    this.nodes.set(nodeId, { el, data, portEls });
+    return nodeId;
+  }
+
+  _renderNodeElement(data, typeDef) {
+    const el = document.createElement('div');
+    el.className = 'flow-node';
+    el.dataset.nodeId = data.id;
+    el.style.left = `${data.x}px`;
+    el.style.top = `${data.y}px`;
+    el.style.setProperty('--node-color', typeDef.color);
+
+    // Header
+    const header = document.createElement('div');
+    header.className = 'flow-node-header';
+    header.innerHTML = `<span class="nh-icon">${typeDef.icon}</span><span class="nh-label">${esc(typeDef.label)}</span>`;
+    header.addEventListener('mousedown', (e) => this._onNodeMouseDown(e, data.id));
+    el.appendChild(header);
+
+    // Body
+    const body = document.createElement('div');
+    body.className = 'flow-node-body';
+    body.textContent = this._getNodeSummary(data);
+    el.appendChild(body);
+
+    // Input ports
+    for (let i = 0; i < typeDef.inputs; i++) {
+      const port = document.createElement('div');
+      port.className = 'flow-port port-input';
+      const totalPorts = typeDef.inputs;
+      const spacing = 60 / (totalPorts + 1);
+      port.style.top = `${20 + spacing * (i + 1)}px`;
+      port.dataset.portType = 'input';
+      port.dataset.portIndex = i;
+      port.addEventListener('mousedown', (e) => {
+        e.stopPropagation();
+        this._onPortMouseDown(e, data.id, 'input', i);
+      });
+      el.appendChild(port);
+    }
+
+    // Output ports
+    for (let i = 0; i < typeDef.outputs; i++) {
+      const port = document.createElement('div');
+      port.className = 'flow-port port-output';
+      const totalPorts = typeDef.outputs;
+      const spacing = 60 / (totalPorts + 1);
+      port.style.top = `${20 + spacing * (i + 1)}px`;
+      port.dataset.portType = 'output';
+      port.dataset.portIndex = i;
+      port.addEventListener('mousedown', (e) => {
+        e.stopPropagation();
+        this._onPortMouseDown(e, data.id, 'output', i);
+      });
+      el.appendChild(port);
+    }
+
+    // Click to select
+    el.addEventListener('mousedown', (e) => {
+      if (e.target.classList.contains('flow-port')) return;
+      this._selectNode(data.id);
+    });
+
+    return el;
+  }
+
+  _getNodeSummary(data) {
+    const cfg = data.config || {};
+    switch (data.type) {
+      case 'trigger:event':    return cfg.event ? `event: ${cfg.event}` : 'no event set';
+      case 'trigger:cron':     return cfg.cron || 'no schedule';
+      case 'trigger:webhook':  return cfg.event ? `hook: ${cfg.event}` : 'no event set';
+      case 'condition:match':  return cfg.field ? `${cfg.field} ${cfg.op || '=='} ${cfg.value || '?'}` : 'not configured';
+      case 'condition:switch': return cfg.field ? `switch: ${cfg.field}` : 'not configured';
+      case 'action:spawn':     return cfg.profile || 'no profile';
+      case 'action:message':   return cfg.to ? `to: ${cfg.to}` : 'no recipient';
+      case 'action:task':      return cfg.title || cfg.profile || 'no task';
+      default:                 return Object.keys(cfg).length ? JSON.stringify(cfg).slice(0, 30) : 'configure...';
+    }
+  }
+
+  _removeNode(nodeId) {
+    const entry = this.nodes.get(nodeId);
+    if (!entry) return;
+
+    // Remove connected edges
+    this.edges = this.edges.filter(e => {
+      if (e.source === nodeId || e.target === nodeId) {
+        if (e.pathEl && e.pathEl.parentNode) e.pathEl.parentNode.removeChild(e.pathEl);
+        return false;
+      }
+      return true;
+    });
+
+    if (entry.el.parentNode) entry.el.parentNode.removeChild(entry.el);
+    this.nodes.delete(nodeId);
+
+    if (this.selectedNode === nodeId) {
+      this.selectedNode = null;
+      this._hideConfig();
+    }
+  }
+
+  _updateNodePosition(nodeId, x, y) {
+    const entry = this.nodes.get(nodeId);
+    if (!entry) return;
+    entry.data.x = x;
+    entry.data.y = y;
+    entry.el.style.left = `${x}px`;
+    entry.el.style.top = `${y}px`;
+    this._updateEdges();
+  }
+
+  _selectNode(nodeId) {
+    // Deselect previous
+    if (this.selectedNode) {
+      const prev = this.nodes.get(this.selectedNode);
+      if (prev) prev.el.classList.remove('selected');
+    }
+    // Deselect edge
+    this._deselectEdge();
+
+    this.selectedNode = nodeId;
+    const entry = this.nodes.get(nodeId);
+    if (entry) {
+      entry.el.classList.add('selected');
+      this._showConfig(nodeId);
+    }
+  }
+
+  _deselectAll() {
+    if (this.selectedNode) {
+      const prev = this.nodes.get(this.selectedNode);
+      if (prev) prev.el.classList.remove('selected');
+      this.selectedNode = null;
+    }
+    this._deselectEdge();
+    this._hideConfig();
+  }
+
+  // ── Edge operations ──
+
+  _addEdge(source, target, sourcePort, targetPort, id) {
+    // Prevent duplicate edges
+    const exists = this.edges.find(e =>
+      e.source === source && e.target === target &&
+      e.sourcePort === sourcePort && e.targetPort === targetPort
+    );
+    if (exists) return;
+
+    // Prevent self-loops
+    if (source === target) return;
+
+    const edgeId = id || edgeUid();
+    const pathEl = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+    pathEl.classList.add('flow-edge');
+    pathEl.dataset.edgeId = edgeId;
+
+    pathEl.addEventListener('click', (e) => {
+      e.stopPropagation();
+      this._selectEdge(edgeId);
+    });
+
+    this.svgLayer.appendChild(pathEl);
+
+    const edge = { id: edgeId, source, target, sourcePort, targetPort, pathEl };
+    this.edges.push(edge);
+    this._renderEdgePath(edge);
+    return edgeId;
+  }
+
+  _removeEdge(edgeId) {
+    const idx = this.edges.findIndex(e => e.id === edgeId);
+    if (idx === -1) return;
+    const edge = this.edges[idx];
+    if (edge.pathEl && edge.pathEl.parentNode) edge.pathEl.parentNode.removeChild(edge.pathEl);
+    this.edges.splice(idx, 1);
+    if (this.selectedEdge === edgeId) {
+      this.selectedEdge = null;
+    }
+  }
+
+  _renderEdgePath(edge) {
+    const p1 = this._getPortPosition(edge.source, 'output', edge.sourcePort);
+    const p2 = this._getPortPosition(edge.target, 'input', edge.targetPort);
+    if (!p1 || !p2) return;
+
+    const dx = Math.abs(p2.x - p1.x) * 0.5;
+    const offset = Math.max(80, dx);
+    const d = `M ${p1.x},${p1.y} C ${p1.x + offset},${p1.y} ${p2.x - offset},${p2.y} ${p2.x},${p2.y}`;
+    edge.pathEl.setAttribute('d', d);
+  }
+
+  _updateEdges() {
+    for (const edge of this.edges) {
+      this._renderEdgePath(edge);
+    }
+  }
+
+  _selectEdge(edgeId) {
+    this._deselectEdge();
+    // Deselect node
+    if (this.selectedNode) {
+      const prev = this.nodes.get(this.selectedNode);
+      if (prev) prev.el.classList.remove('selected');
+      this.selectedNode = null;
+      this._hideConfig();
+    }
+
+    this.selectedEdge = edgeId;
+    const edge = this.edges.find(e => e.id === edgeId);
+    if (edge && edge.pathEl) {
+      edge.pathEl.classList.add('selected');
+    }
+  }
+
+  _deselectEdge() {
+    if (this.selectedEdge) {
+      const edge = this.edges.find(e => e.id === this.selectedEdge);
+      if (edge && edge.pathEl) edge.pathEl.classList.remove('selected');
+      this.selectedEdge = null;
+    }
+  }
+
+  // ── Port positions ──
+
+  _getPortPosition(nodeId, portType, portIndex) {
+    const entry = this.nodes.get(nodeId);
+    if (!entry) return null;
+
+    const typeDef = NODE_TYPES[entry.data.type];
+    if (!typeDef) return null;
+
+    const totalPorts = portType === 'input' ? typeDef.inputs : typeDef.outputs;
+    const spacing = 60 / (totalPorts + 1);
+    const portY = 20 + spacing * (portIndex + 1);
+
+    const x = portType === 'output' ? entry.data.x + 180 : entry.data.x;
+    const y = entry.data.y + portY;
+
+    return { x, y };
+  }
+
+  // ── Config panel ──
+
+  _showConfig(nodeId) {
+    const entry = this.nodes.get(nodeId);
+    if (!entry) return;
+
+    const typeDef = NODE_TYPES[entry.data.type];
+    const fields = NODE_CONFIG_FIELDS[entry.data.type] || [];
+
+    this.configPanel.classList.add('open');
+    this.configPanel.innerHTML = '';
+
+    // Header
+    const hdr = document.createElement('div');
+    hdr.className = 'flow-config-header';
+    hdr.innerHTML = `<span>${typeDef ? esc(typeDef.label) : 'Node'}</span>`;
+    const closeBtn = document.createElement('button');
+    closeBtn.className = 'flow-config-close';
+    closeBtn.textContent = '\u2715';
+    closeBtn.addEventListener('click', () => this._hideConfig());
+    hdr.appendChild(closeBtn);
+    this.configPanel.appendChild(hdr);
+
+    // Body
+    const body = document.createElement('div');
+    body.className = 'flow-config-body';
+
+    for (const field of fields) {
+      const wrap = document.createElement('div');
+      wrap.className = 'flow-config-field';
+
+      const label = document.createElement('label');
+      label.textContent = field.label;
+      wrap.appendChild(label);
+
+      // ── Smart field renderers ──
+
+      if (field.type === 'event_select') {
+        // Dropdown of known events + custom
+        this._renderEventSelect(wrap, entry, field.key);
+      } else if (field.type === 'cron_select') {
+        // Cron presets + custom input
+        this._renderCronSelect(wrap, entry, field.key);
+      } else if (field.type === 'webhook_config') {
+        // Webhook event + auto URL display
+        this._renderWebhookConfig(wrap, entry, field.key);
+      } else {
+        // Standard field types
+        let input;
+        if (field.type === 'select') {
+          input = document.createElement('select');
+          for (const opt of field.options) {
+            const o = document.createElement('option');
+            o.value = opt;
+            o.textContent = opt;
+            if (entry.data.config[field.key] === opt) o.selected = true;
+            input.appendChild(o);
+          }
+        } else if (field.type === 'textarea') {
+          input = document.createElement('textarea');
+          input.value = entry.data.config[field.key] || '';
+          input.placeholder = field.placeholder || '';
+        } else {
+          input = document.createElement('input');
+          input.type = 'text';
+          input.value = entry.data.config[field.key] || '';
+          input.placeholder = field.placeholder || '';
+        }
+
+        const fieldKey = field.key;
+        const updateFn = () => {
+          entry.data.config[fieldKey] = input.value;
+          const bodyEl = entry.el.querySelector('.flow-node-body');
+          if (bodyEl) bodyEl.textContent = this._getNodeSummary(entry.data);
+        };
+        input.addEventListener('input', updateFn);
+        input.addEventListener('change', updateFn);
+        wrap.appendChild(input);
+      }
+
+      body.appendChild(wrap);
+    }
+
+    // If no config fields, show generic key-value editor
+    if (fields.length === 0) {
+      const note = document.createElement('div');
+      note.style.cssText = 'font-size: 9px; color: #636e72; padding: 8px 0;';
+      note.textContent = 'No specific configuration for this node type.';
+      body.appendChild(note);
+    }
+
+    this.configPanel.appendChild(body);
+  }
+
+  // ── Smart trigger config renderers ──
+
+  _renderEventSelect(wrap, entry, key) {
+    const currentVal = entry.data.config[key] || '';
+    const isCustom = currentVal && !KNOWN_EVENTS[currentVal];
+
+    // Select dropdown
+    const select = document.createElement('select');
+    select.style.cssText = 'width:100%;margin-bottom:6px;';
+
+    // "Choose an event..." placeholder
+    const placeholder = document.createElement('option');
+    placeholder.value = '';
+    placeholder.textContent = '-- Choose an event --';
+    placeholder.disabled = true;
+    if (!currentVal) placeholder.selected = true;
+    select.appendChild(placeholder);
+
+    // Known events
+    const knownGroup = document.createElement('optgroup');
+    knownGroup.label = 'System Events';
+    for (const [eventName, def] of Object.entries(KNOWN_EVENTS)) {
+      const o = document.createElement('option');
+      o.value = eventName;
+      o.textContent = `${def.icon}  ${def.label}  (${eventName})`;
+      if (currentVal === eventName) o.selected = true;
+      knownGroup.appendChild(o);
+    }
+    select.appendChild(knownGroup);
+
+    // Custom option
+    const customGroup = document.createElement('optgroup');
+    customGroup.label = 'Custom';
+    const customOpt = document.createElement('option');
+    customOpt.value = '__custom__';
+    customOpt.textContent = '\u270F\uFE0F  Custom event name...';
+    if (isCustom) customOpt.selected = true;
+    customGroup.appendChild(customOpt);
+    select.appendChild(customGroup);
+
+    wrap.appendChild(select);
+
+    // Custom input (hidden unless "custom" selected)
+    const customInput = document.createElement('input');
+    customInput.type = 'text';
+    customInput.placeholder = 'my_custom_event';
+    customInput.value = isCustom ? currentVal : '';
+    customInput.style.cssText = `display:${isCustom ? 'block' : 'none'};margin-bottom:6px;`;
+    wrap.appendChild(customInput);
+
+    // Meta fields preview
+    const metaBox = document.createElement('div');
+    metaBox.className = 'flow-meta-preview';
+    wrap.appendChild(metaBox);
+
+    const updateMeta = (eventName) => {
+      const def = KNOWN_EVENTS[eventName];
+      if (def && def.meta.length > 0) {
+        metaBox.innerHTML = `<div class="flow-meta-title">Available fields:</div>` +
+          def.meta.map(m => `<span class="flow-meta-tag">{{.meta.${m}}}</span>`).join('');
+        metaBox.style.display = 'block';
+      } else if (eventName === '__custom__' || (eventName && !def)) {
+        metaBox.innerHTML = `<div class="flow-meta-title">Custom event \u2014 fields depend on the sender</div>
+          <div style="font-size:9px;color:#636e72;margin-top:4px;">Webhook: POST /api/webhooks/{project}/${eventName === '__custom__' ? '{event}' : eventName}<br>Body JSON keys become meta fields</div>`;
+        metaBox.style.display = 'block';
+      } else {
+        metaBox.style.display = 'none';
+      }
+    };
+
+    const updateNode = () => {
+      const bodyEl = entry.el.querySelector('.flow-node-body');
+      if (bodyEl) bodyEl.textContent = this._getNodeSummary(entry.data);
+    };
+
+    select.addEventListener('change', () => {
+      if (select.value === '__custom__') {
+        customInput.style.display = 'block';
+        customInput.focus();
+        entry.data.config[key] = customInput.value || '';
+      } else {
+        customInput.style.display = 'none';
+        entry.data.config[key] = select.value;
+      }
+      updateMeta(select.value === '__custom__' ? (customInput.value || '__custom__') : select.value);
+      updateNode();
+    });
+
+    customInput.addEventListener('input', () => {
+      entry.data.config[key] = customInput.value;
+      updateMeta(customInput.value || '__custom__');
+      updateNode();
+    });
+
+    // Init meta display
+    updateMeta(isCustom ? '__custom__' : currentVal);
+  }
+
+  _renderCronSelect(wrap, entry, key) {
+    const currentVal = entry.data.config[key] || '';
+    const isPreset = CRON_PRESETS.some(p => p.value === currentVal);
+
+    // Preset dropdown
+    const select = document.createElement('select');
+    select.style.cssText = 'width:100%;margin-bottom:6px;';
+
+    const placeholder = document.createElement('option');
+    placeholder.value = '';
+    placeholder.textContent = '-- Choose a schedule --';
+    placeholder.disabled = true;
+    if (!currentVal) placeholder.selected = true;
+    select.appendChild(placeholder);
+
+    for (const preset of CRON_PRESETS) {
+      const o = document.createElement('option');
+      o.value = preset.value;
+      o.textContent = preset.value === '__custom__' ? preset.label : `${preset.label}  (${preset.value})`;
+      if (preset.value === currentVal) o.selected = true;
+      if (preset.value === '__custom__' && !isPreset && currentVal) o.selected = true;
+      select.appendChild(o);
+    }
+    wrap.appendChild(select);
+
+    // Custom cron input
+    const customInput = document.createElement('input');
+    customInput.type = 'text';
+    customInput.placeholder = '*/10 * * * *';
+    customInput.value = (!isPreset && currentVal) ? currentVal : '';
+    customInput.style.cssText = `display:${(!isPreset && currentVal) ? 'block' : 'none'};margin-bottom:6px;`;
+    wrap.appendChild(customInput);
+
+    // Explanation
+    const helpBox = document.createElement('div');
+    helpBox.style.cssText = 'font-size:9px;color:#636e72;padding:4px 0;';
+    helpBox.textContent = currentVal && currentVal !== '__custom__' ? this._cronToHuman(currentVal) : '';
+    wrap.appendChild(helpBox);
+
+    const updateNode = () => {
+      const bodyEl = entry.el.querySelector('.flow-node-body');
+      if (bodyEl) bodyEl.textContent = this._getNodeSummary(entry.data);
+    };
+
+    select.addEventListener('change', () => {
+      if (select.value === '__custom__') {
+        customInput.style.display = 'block';
+        customInput.focus();
+        entry.data.config[key] = customInput.value || '';
+        helpBox.textContent = '';
+      } else {
+        customInput.style.display = 'none';
+        entry.data.config[key] = select.value;
+        helpBox.textContent = this._cronToHuman(select.value);
+      }
+      updateNode();
+    });
+
+    customInput.addEventListener('input', () => {
+      entry.data.config[key] = customInput.value;
+      helpBox.textContent = this._cronToHuman(customInput.value);
+      updateNode();
+    });
+  }
+
+  _renderWebhookConfig(wrap, entry, key) {
+    const currentVal = entry.data.config[key] || '';
+
+    // Event name input
+    const input = document.createElement('input');
+    input.type = 'text';
+    input.placeholder = 'e.g. deploy_done, github_push';
+    input.value = currentVal;
+    input.style.cssText = 'width:100%;margin-bottom:8px;';
+    wrap.appendChild(input);
+
+    // Auto-generated URL display
+    const urlBox = document.createElement('div');
+    urlBox.className = 'flow-webhook-url';
+    const updateUrl = (val) => {
+      if (val) {
+        urlBox.innerHTML = `<div class="flow-meta-title">Webhook URL:</div>
+          <code class="flow-webhook-code">POST /api/webhooks/{project}/${esc(val)}</code>
+          <div style="font-size:9px;color:#636e72;margin-top:6px;">Send a JSON body \u2014 all top-level keys become meta fields available in downstream nodes.</div>
+          <div style="font-size:9px;color:#a29bfe;margin-top:4px;">Example: <code>{"branch":"main","status":"ok"}</code><br>\u2192 <code>{{.meta.branch}}</code>, <code>{{.meta.status}}</code></div>`;
+      } else {
+        urlBox.innerHTML = '<div style="font-size:9px;color:#636e72;">Enter an event name to generate the webhook URL</div>';
+      }
+    };
+    wrap.appendChild(urlBox);
+    updateUrl(currentVal);
+
+    const updateNode = () => {
+      const bodyEl = entry.el.querySelector('.flow-node-body');
+      if (bodyEl) bodyEl.textContent = this._getNodeSummary(entry.data);
+    };
+
+    input.addEventListener('input', () => {
+      entry.data.config[key] = input.value;
+      updateUrl(input.value);
+      updateNode();
+    });
+  }
+
+  _cronToHuman(expr) {
+    if (!expr) return '';
+    const parts = expr.split(' ');
+    if (parts.length !== 5) return expr;
+    const [min, hour, dom, mon, dow] = parts;
+    if (min === '*' && hour === '*') return 'Every minute';
+    if (min.startsWith('*/')) return `Every ${min.slice(2)} minutes`;
+    if (hour.startsWith('*/') && min === '0') return `Every ${hour.slice(2)} hours`;
+    if (hour !== '*' && min !== '*' && dom === '*' && mon === '*' && dow === '*') return `Daily at ${hour.padStart(2,'0')}:${min.padStart(2,'0')}`;
+    if (dow !== '*' && dom === '*') { const days = ['Sun','Mon','Tue','Wed','Thu','Fri','Sat']; return `${days[dow] || 'Day '+dow} at ${hour.padStart(2,'0')}:${min.padStart(2,'0')}`; }
+    return expr;
+  }
+
+  _hideConfig() {
+    if (this.configPanel) {
+      this.configPanel.classList.remove('open');
+      this.configPanel.innerHTML = '';
+    }
+  }
+
+  // ── Interaction: Node drag ──
+
+  _onNodeMouseDown(e, nodeId) {
+    if (e.button !== 0) return;
+    e.preventDefault();
+    e.stopPropagation();
+
+    this._selectNode(nodeId);
+
+    const entry = this.nodes.get(nodeId);
+    if (!entry) return;
+
+    this.dragState = {
+      type: 'node',
+      nodeId,
+      startX: e.clientX,
+      startY: e.clientY,
+      origX: entry.data.x,
+      origY: entry.data.y,
+    };
+  }
+
+  // ── Interaction: Port drag (edge creation) ──
+
+  _onPortMouseDown(e, nodeId, portType, portIndex) {
+    if (e.button !== 0) return;
+    e.preventDefault();
+    e.stopPropagation();
+
+    // Only start edge from output ports
+    if (portType !== 'output') return;
+
+    const pos = this._getPortPosition(nodeId, 'output', portIndex);
+    if (!pos) return;
+
+    // Create temp SVG path
+    this._tempEdgePath = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+    this._tempEdgePath.classList.add('flow-edge-temp');
+    this.svgLayer.appendChild(this._tempEdgePath);
+
+    this.canvas.classList.add('connecting');
+
+    this.dragState = {
+      type: 'edge',
+      sourceNode: nodeId,
+      sourcePort: portIndex,
+      startPos: pos,
+    };
+  }
+
+  // ── Interaction: Canvas pan ──
+
+  _onCanvasMouseDown(e) {
+    if (e.target !== this.canvas && !e.target.classList.contains('flow-canvas-wrap')) return;
+    if (e.button !== 0) return;
+    e.preventDefault();
+
+    this._deselectAll();
+    this._removeContextMenu();
+
+    this.dragState = {
+      type: 'pan',
+      startX: e.clientX,
+      startY: e.clientY,
+      origPanX: this.panOffset.x,
+      origPanY: this.panOffset.y,
+    };
+    this.canvas.classList.add('grabbing');
+  }
+
+  _onMouseMove(e) {
+    if (!this.dragState) return;
+
+    const dx = e.clientX - this.dragState.startX;
+    const dy = e.clientY - this.dragState.startY;
+
+    if (this.dragState.type === 'node') {
+      const nx = this.dragState.origX + dx / this.zoom;
+      const ny = this.dragState.origY + dy / this.zoom;
+      this._updateNodePosition(this.dragState.nodeId, Math.round(nx), Math.round(ny));
+
+    } else if (this.dragState.type === 'pan') {
+      this.panOffset.x = this.dragState.origPanX + dx;
+      this.panOffset.y = this.dragState.origPanY + dy;
+      this._updateTransform();
+
+    } else if (this.dragState.type === 'edge') {
+      // Update temp edge path to follow cursor
+      const rect = this.canvas.getBoundingClientRect();
+      const mx = (e.clientX - rect.left - this.panOffset.x) / this.zoom;
+      const my = (e.clientY - rect.top - this.panOffset.y) / this.zoom;
+      const sp = this.dragState.startPos;
+      const offset = Math.max(80, Math.abs(mx - sp.x) * 0.5);
+      const d = `M ${sp.x},${sp.y} C ${sp.x + offset},${sp.y} ${mx - offset},${my} ${mx},${my}`;
+      if (this._tempEdgePath) this._tempEdgePath.setAttribute('d', d);
+    }
+  }
+
+  _onMouseUp(e) {
+    if (!this.dragState) return;
+
+    if (this.dragState.type === 'edge') {
+      // Check if released over an input port
+      const target = document.elementFromPoint(e.clientX, e.clientY);
+      if (target && target.classList.contains('port-input')) {
+        const targetNodeId = target.closest('.flow-node')?.dataset.nodeId;
+        const targetPortIndex = parseInt(target.dataset.portIndex, 10);
+        if (targetNodeId && targetNodeId !== this.dragState.sourceNode) {
+          this._addEdge(
+            this.dragState.sourceNode,
+            targetNodeId,
+            this.dragState.sourcePort,
+            targetPortIndex
+          );
+        }
+      }
+      // Remove temp path
+      if (this._tempEdgePath && this._tempEdgePath.parentNode) {
+        this._tempEdgePath.parentNode.removeChild(this._tempEdgePath);
+      }
+      this._tempEdgePath = null;
+      this.canvas.classList.remove('connecting');
+    }
+
+    if (this.dragState.type === 'pan') {
+      this.canvas.classList.remove('grabbing');
+    }
+
+    this.dragState = null;
+  }
+
+  // ── Zoom ──
+
+  _onWheel(e) {
+    e.preventDefault();
+    const delta = e.deltaY > 0 ? -0.08 : 0.08;
+    const newZoom = Math.max(0.25, Math.min(2.0, this.zoom + delta));
+
+    // Zoom toward cursor
+    const rect = this.canvas.getBoundingClientRect();
+    const mx = e.clientX - rect.left;
+    const my = e.clientY - rect.top;
+
+    const scale = newZoom / this.zoom;
+    this.panOffset.x = mx - scale * (mx - this.panOffset.x);
+    this.panOffset.y = my - scale * (my - this.panOffset.y);
+    this.zoom = newZoom;
+
+    this._updateTransform();
+  }
+
+  _updateTransform() {
+    const t = `translate(${this.panOffset.x}px, ${this.panOffset.y}px) scale(${this.zoom})`;
+    this.nodesLayer.style.transform = t;
+    this.svgLayer.style.transform = t;
+  }
+
+  // ── Context menu ──
+
+  _onContextMenu(e) {
+    e.preventDefault();
+    this._removeContextMenu();
+
+    const items = [];
+    const nodeEl = e.target.closest('.flow-node');
+
+    if (nodeEl) {
+      const nodeId = nodeEl.dataset.nodeId;
+      items.push({ label: 'Configure', action: () => this._selectNode(nodeId) });
+      items.push({ label: 'Duplicate', action: () => this._duplicateNode(nodeId) });
+      items.push({ label: 'Delete Node', cls: 'danger', action: () => this._removeNode(nodeId) });
+    } else {
+      // Canvas context menu: add node submenu by category
+      for (const [typeKey, def] of Object.entries(NODE_TYPES)) {
+        items.push({
+          label: `${def.icon} ${def.label}`,
+          action: () => {
+            const rect = this.canvas.getBoundingClientRect();
+            const x = (e.clientX - rect.left - this.panOffset.x) / this.zoom;
+            const y = (e.clientY - rect.top - this.panOffset.y) / this.zoom;
+            if (!this.currentWorkflow) {
+              this._newWorkflow();
+              this._emptyEl.style.display = 'none';
+            }
+            this._addNode(typeKey, Math.round(x), Math.round(y));
+          },
+        });
+      }
+    }
+
+    const menu = document.createElement('div');
+    menu.className = 'flow-context-menu';
+    menu.style.left = `${e.clientX}px`;
+    menu.style.top = `${e.clientY}px`;
+
+    for (const item of items) {
+      const el = document.createElement('div');
+      el.className = `flow-context-item${item.cls ? ' ' + item.cls : ''}`;
+      el.textContent = item.label;
+      el.addEventListener('click', () => {
+        this._removeContextMenu();
+        item.action();
+      });
+      menu.appendChild(el);
+    }
+
+    document.body.appendChild(menu);
+    this._contextMenu = menu;
+
+    // Close on next click
+    const close = (ev) => {
+      if (!menu.contains(ev.target)) {
+        this._removeContextMenu();
+        document.removeEventListener('mousedown', close);
+      }
+    };
+    setTimeout(() => document.addEventListener('mousedown', close), 0);
+  }
+
+  _removeContextMenu() {
+    if (this._contextMenu && this._contextMenu.parentNode) {
+      this._contextMenu.parentNode.removeChild(this._contextMenu);
+    }
+    this._contextMenu = null;
+  }
+
+  // ── Keyboard ──
+
+  _onKeyDown(e) {
+    // Only handle when flow editor is visible
+    if (!this.root || !this.root.offsetParent) return;
+
+    if (e.key === 'Delete' || e.key === 'Backspace') {
+      // Don't intercept when typing in inputs
+      if (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA' || e.target.tagName === 'SELECT') return;
+
+      if (this.selectedNode) {
+        this._removeNode(this.selectedNode);
+      } else if (this.selectedEdge) {
+        this._removeEdge(this.selectedEdge);
+      }
+    }
+
+    if (e.key === 'Escape') {
+      this._deselectAll();
+      this._removeContextMenu();
+    }
+  }
+
+  // ── Helpers ──
+
+  _duplicateNode(nodeId) {
+    const entry = this.nodes.get(nodeId);
+    if (!entry) return;
+    this._addNode(entry.data.type, entry.data.x + 30, entry.data.y + 30, null, { ...entry.data.config });
+  }
+}

--- a/internal/web/static/js/main.js
+++ b/internal/web/static/js/main.js
@@ -5,6 +5,8 @@ import { APIClient } from "./api-client.js";
 import { MessageOrb } from "./message-orb.js";
 import { KanbanBoard } from "./kanban.js";
 import { VaultBrowser } from "./vault.js";
+import { OpsConsole } from "./ops.js";
+import { CommandPanel } from "./command-panel.js";
 import { ShortcutManager } from "./shortcuts.js";
 import { ConnectionOverlay } from "./connections.js";
 import { MCPEffects } from "./mcp-effects.js";
@@ -1154,7 +1156,10 @@ function openDetail(av) {
 
   focusedAgent = agentKey(av.project, av.name);
   focusedTeam = null;
-  detailPanel.classList.add("open");
+  // Side drawer no longer opens — command panel handles everything
+  detailPanel.classList.remove("open");
+  // Hide sidebar panels when agent focused — full width for canvas+command panel
+  document.getElementById("main").classList.add("agent-focused");
 
   // ── MACRO: Identity ──
   detailName.textContent = av.name;
@@ -1331,6 +1336,39 @@ function openDetail(av) {
   // Token usage
   updateAgentTokenDetail(av.project, av.name);
 
+  // Skills
+  const detailSkillsEl = document.getElementById("detail-skills");
+  if (detailSkillsEl) {
+    client.fetchSkills(av.project).then(skills => {
+      // Filter to skills linked to this agent's profile
+      const agentSkills = skills.filter(s => {
+        // If skill has profiles, check if agent is in them
+        return true; // Show all skills for now, profiles loaded on expand
+      });
+      OpsConsole.renderSkillsSection(detailSkillsEl, agentSkills);
+    });
+  }
+
+  // Quotas
+  const detailQuotasEl = document.getElementById("detail-quotas");
+  if (detailQuotasEl) {
+    client.fetchAgentQuota(av.name, av.project).then(quota => {
+      OpsConsole.renderQuotasSection(detailQuotasEl, quota);
+    });
+  }
+
+  // Elevation
+  const detailElevationEl = document.getElementById("detail-elevation");
+  if (detailElevationEl) {
+    client.fetchElevations(av.project).then(elevations => {
+      const agentElevations = (elevations || []).filter(e =>
+        (e.agent === av.name || e.profile_slug === av.name) &&
+        (!e.expires_at || new Date(e.expires_at) > Date.now())
+      );
+      OpsConsole.renderElevationSection(detailElevationEl, agentElevations, client, av.project, av.name);
+    });
+  }
+
   // Nav label
   const keys = getAgentKeys();
   const currentIdx = keys.indexOf(focusedAgent);
@@ -1345,10 +1383,65 @@ function openDetail(av) {
   }
 
   loadMessages();
+
+  // Feed command panel with ALL agent data (replaces side drawer)
+  (async () => {
+    const slug = av.name;
+    const [profile, quota, skills, allMsgs, spawnChildren] = await Promise.all([
+      client.fetchProfile(slug, av.project),
+      client.fetchAgentQuota(slug, av.project),
+      client.fetchSkills(av.project, slug),
+      client.fetchAllMessagesAllProjects(),
+      client.fetchSpawnChildren(av.project, slug, ''),
+    ]);
+
+    // Agent tasks
+    const agentTasks = allTasks.filter(t => {
+      const tp = t.project || "default";
+      return tp === av.project && (t.assigned_to === av.name || t.dispatched_by === av.name);
+    }).filter(t => t.status !== "done").slice(0, 10);
+
+    // Recent messages
+    const agentMsgs = allMsgs.filter(m => {
+      const mp = m.project || "default";
+      return mp === av.project && (m.from === av.name || m.to === av.name);
+    }).slice(-8).reverse();
+
+    // Direct reports
+    const directReports = agentsData
+      .filter(a => a.reports_to === av.name && (a.project || "default") === av.project)
+      .map(a => a.name);
+
+    // Nav label
+    const keys = getAgentKeys();
+    const idx = keys.indexOf(focusedAgent);
+
+    const agentData = {
+      ...av,
+      slug: profile?.slug || slug,
+      name: profile?.name || av.name,
+      role: profile?.role || av.role,
+      context_pack: profile?.context_pack || '',
+      vault_paths: profile?.vault_paths || '',
+      allowed_tools: profile?.allowed_tools || '',
+      pool_size: profile?.pool_size || 1,
+      _quota: quota || {},
+      _skills: skills || [],
+      _tasks: agentTasks,
+      _recentMsgs: agentMsgs,
+      _reportsTo: av._reportsTo,
+      _directReports: directReports,
+      _teams: av._teams || [],
+      _spawnChildren: spawnChildren || [],
+      _navLabel: `${idx + 1} / ${keys.length}`,
+    };
+    commandPanel.setAgent(agentData);
+  })();
 }
 
 detailClose.addEventListener("click", () => {
   detailPanel.classList.remove("open");
+  document.getElementById("main").classList.remove("agent-focused");
   focusedAgent = null;
   // Restore all agents + clear selection ring
   for (const [, av] of agentViews) {
@@ -1356,6 +1449,7 @@ detailClose.addEventListener("click", () => {
     av.dimMode = false;
     av.selected = false;
   }
+  commandPanel.clearAgent();
   loadMessages();
 });
 
@@ -1562,6 +1656,7 @@ canvas.addEventListener("click", (e) => {
 
   // 4. Colony: click on empty space → clear focus (stay in colony)
   detailPanel.classList.remove("open");
+  document.getElementById("main").classList.remove("agent-focused");
   focusedAgent = null;
   focusedTeam = null;
   for (const [, av] of agentViews) {
@@ -1569,6 +1664,7 @@ canvas.addEventListener("click", (e) => {
     av.highlighted = true;
     av.dimMode = false;
   }
+  commandPanel.clearAgent();
   loadMessages();
 });
 
@@ -1790,7 +1886,7 @@ tabMessages.addEventListener("click", () => {
   messagesPanel.classList.remove("hidden");
   memoriesPanel.classList.add("hidden");
   tasksPanel.classList.add("hidden");
-  if (currentMode === "kanban" || currentMode === "vault") setMode("canvas");
+  if (currentMode === "kanban" || currentMode === "vault" || currentMode === "ops") setMode("canvas");
 });
 
 tabMemories.addEventListener("click", () => {
@@ -1801,7 +1897,7 @@ tabMemories.addEventListener("click", () => {
   memoriesPanel.classList.remove("hidden");
   messagesPanel.classList.add("hidden");
   tasksPanel.classList.add("hidden");
-  if (currentMode === "kanban" || currentMode === "vault") setMode("canvas");
+  if (currentMode === "kanban" || currentMode === "vault" || currentMode === "ops") setMode("canvas");
   loadMemories();
 });
 
@@ -1821,7 +1917,7 @@ tabTasks.addEventListener("click", () => {
   tasksPanel.classList.remove("hidden");
   messagesPanel.classList.add("hidden");
   memoriesPanel.classList.add("hidden");
-  if (currentMode === "kanban" || currentMode === "vault") setMode("canvas");
+  if (currentMode === "kanban" || currentMode === "vault" || currentMode === "ops") setMode("canvas");
   loadTasks();
 });
 
@@ -2351,7 +2447,7 @@ function updateConvFilterOptions() {
 
 // --- Layout modes ---
 
-let currentMode = "canvas"; // "canvas" | "detail" | "kanban" | "vault"
+let currentMode = "canvas"; // "canvas" | "detail" | "kanban" | "vault" | "ops"
 let viewMode = "galaxy"; // "galaxy" | "colony" — top-level screen state
 let projectsData = []; // cached ProjectInfo[] from /api/projects
 let colonyProject = null; // project name when in colony view
@@ -2359,7 +2455,7 @@ let colonyProject = null; // project name when in colony view
 function setMode(mode) {
   currentMode = mode;
   const main = document.getElementById("main");
-  main.classList.remove("mode-canvas", "mode-detail", "mode-kanban", "mode-vault");
+  main.classList.remove("mode-canvas", "mode-detail", "mode-kanban", "mode-vault", "mode-ops");
 
   // Update header mode buttons
   document.querySelectorAll(".mode-btn").forEach(btn => {
@@ -2403,8 +2499,15 @@ function setMode(mode) {
     vaultBrowser.hide();
   }
 
-  // Messages panel: hidden in kanban/vault mode
-  if (mode === "kanban" || mode === "vault") {
+  // Show/hide ops
+  if (mode === "ops") {
+    opsConsole.show(focusedProject || "default");
+  } else {
+    opsConsole.hide();
+  }
+
+  // Messages panel: hidden in kanban/vault/ops mode
+  if (mode === "kanban" || mode === "vault" || mode === "ops") {
     messagesPanel.classList.add("hidden");
     memoriesPanel.classList.add("hidden");
     tasksPanel.classList.add("hidden");
@@ -2597,10 +2700,12 @@ function setViewMode(mode, project) {
     focusedAgent = null;
     focusedTeam = null;
     detailPanel.classList.remove("open");
+    document.getElementById("main").classList.remove("agent-focused");
     setMode("canvas");
     if (questTracker) questTracker.classList.add("hidden");
     stopTokenPolling();
     startGalaxyTokenPolling();
+    commandPanel.hide();
     // Defer layout to after DOM reflow so engine.width reflects new container size
     requestAnimationFrame(() => { engine.resize(); layoutAgents(); updateHierarchyLinks(); });
   } else if (mode === "colony" && project) {
@@ -2610,6 +2715,7 @@ function setViewMode(mode, project) {
     focusedTeam = null;
     if (colonyProjectNameEl) colonyProjectNameEl.textContent = project.toUpperCase();
     setMode("canvas");
+    commandPanel.show(project);
     requestAnimationFrame(() => { engine.resize(); layoutAgents(); updateHierarchyLinks(); });
     loadMessages();
     if (activeTab === "tasks") renderTasks();
@@ -2894,6 +3000,11 @@ const vaultPanel = document.getElementById("vault-panel");
 const vaultBrowser = new VaultBrowser(vaultPanel);
 vaultBrowser.hide();
 
+// --- Ops console (early init, client wired later) ---
+const opsPanel = document.getElementById("ops-panel");
+const opsConsole = new OpsConsole(opsPanel);
+opsConsole.hide();
+
 vaultBrowser.onSearch = async (query) => {
   const project = focusedProject || "";
   const result = await client.searchVaultDocs(project, query);
@@ -2924,6 +3035,9 @@ shortcuts.register("2", "mode-kanban", "Kanban view", () => {
 });
 shortcuts.register("3", "mode-vault", "Docs view", () => {
   if (viewMode === "colony") setMode("vault");
+});
+shortcuts.register("4", "mode-ops", "Ops view", () => {
+  if (viewMode === "colony") setMode("ops");
 });
 
 // Colony sidebar tabs
@@ -2970,7 +3084,7 @@ shortcuts.register("ArrowDown", "colony-next", "Next colony", () => {
   setViewMode("colony", names[next]);
 });
 shortcuts.register("/", "search", "Focus search", () => {
-  if (viewMode !== "colony" || currentMode === "kanban") return;
+  if (viewMode !== "colony" || currentMode === "kanban" || currentMode === "ops") return;
   if (msgSearchInput) msgSearchInput.focus();
 });
 shortcuts.register("n", "new-task", "New task", () => {
@@ -3016,6 +3130,39 @@ shortcuts.start();
 console.log("[relay] UI initializing...");
 const client = new APIClient(onAgents, onConversations, onNewMessages, onNewTasks, onActivity);
 kanbanBoard.apiClient = client;
+
+// --- Command panel (wire client) ---
+const commandPanel = new CommandPanel(
+  document.getElementById('command-panel'),
+  document.getElementById('cmd-resize-handle')
+);
+commandPanel.setClient(client);
+
+// --- Command panel navigation ---
+commandPanel.onNavigate = (arg) => {
+  if (typeof arg === 'number') {
+    // +1 or -1: prev/next agent
+    const keys = getAgentKeys();
+    if (!keys.length) return;
+    navIndex = (navIndex + arg + keys.length) % keys.length;
+    const av = agentViews.get(keys[navIndex]);
+    if (av) { av.triggerRipple(); openDetail(av); }
+  } else if (typeof arg === 'string') {
+    // Agent name: navigate to specific agent (hierarchy click)
+    const key = agentKey(colonyProject || 'default', arg);
+    const av = agentViews.get(key);
+    if (av) { av.triggerRipple(); openDetail(av); }
+  }
+};
+
+// --- Ops console (wire client) ---
+opsConsole.client = client;
+opsConsole.onAgentClick = (project, name) => {
+  const key = agentKey(project, name);
+  const av = agentViews.get(key);
+  if (av) { av.triggerRipple(); openDetail(av); }
+};
+
 client.onGoals = (goals) => {
   if (currentMode === "kanban") {
     kanbanBoard.setGoals(goals);

--- a/internal/web/static/js/ops.js
+++ b/internal/web/static/js/ops.js
@@ -1,0 +1,2789 @@
+// ops.js — Ops Console: OS Primitives (triggers, polls, skills, quotas, flows)
+// Pixel art management aesthetic — purple neon on dark
+
+import { FlowEditor } from './flow-editor.js';
+
+function esc(str) {
+  if (!str) return '';
+  const d = document.createElement('div');
+  d.textContent = str;
+  return d.innerHTML;
+}
+
+function timeAgo(dateStr) {
+  if (!dateStr) return '';
+  const diff = Date.now() - new Date(dateStr).getTime();
+  const secs = Math.floor(diff / 1000);
+  if (secs < 60) return `${secs}s ago`;
+  const mins = Math.floor(secs / 60);
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  const days = Math.floor(hrs / 24);
+  return `${days}d ago`;
+}
+
+function fmtTime(dateStr) {
+  if (!dateStr) return '';
+  const d = new Date(dateStr);
+  return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' });
+}
+
+const OPS_STYLES = `
+@import url('https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;600;700&display=swap');
+
+@keyframes slideIn {
+  from { opacity: 0; transform: translateY(8px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes formIn {
+  from { opacity: 0; transform: scale(0.95); }
+  to   { opacity: 1; transform: scale(1); }
+}
+
+.ops-root {
+  font-family: 'JetBrains Mono', monospace;
+  background: #0a0a12;
+  color: #dfe6e9;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  position: relative;
+}
+
+/* ── Sub-tab bar ── */
+.ops-tabs {
+  display: flex;
+  gap: 0;
+  border-bottom: 1px solid rgba(108, 92, 231, 0.2);
+  flex-shrink: 0;
+  padding: 0 20px;
+  background: rgba(15, 15, 26, 0.95);
+}
+.ops-tab {
+  padding: 10px 18px;
+  font-size: 9px;
+  font-weight: 600;
+  letter-spacing: 1px;
+  color: #636e72;
+  cursor: pointer;
+  border: none;
+  background: none;
+  position: relative;
+  transition: all 0.15s;
+  font-family: inherit;
+  border-radius: 2px;
+}
+.ops-tab:hover {
+  color: #a29bfe;
+  border-color: rgba(108, 92, 231, 0.4);
+}
+.ops-tab.active {
+  color: #6c5ce7;
+  text-shadow: 0 0 6px rgba(108, 92, 231, 0.4);
+}
+.ops-tab.active::after {
+  content: '';
+  position: absolute;
+  bottom: -1px;
+  left: 4px;
+  right: 4px;
+  height: 2px;
+  background: #6c5ce7;
+  box-shadow: 0 0 8px rgba(108, 92, 231, 0.5);
+}
+
+/* ── Content area ── */
+.ops-content {
+  flex: 1;
+  overflow-y: auto;
+  padding: 14px 16px;
+}
+.ops-content::-webkit-scrollbar { width: 4px; }
+.ops-content::-webkit-scrollbar-track { background: transparent; }
+.ops-content::-webkit-scrollbar-thumb { background: rgba(108, 92, 231, 0.3); border-radius: 2px; }
+
+/* ── Common card ── */
+.ops-card {
+  background: rgba(30, 30, 50, 0.6);
+  border: 1px solid rgba(108, 92, 231, 0.15);
+  border-radius: 3px;
+  padding: 10px 12px;
+  margin-bottom: 10px;
+  transition: all 0.15s;
+  animation: slideIn 0.25s ease-out;
+}
+.ops-card:hover {
+  border-color: rgba(108, 92, 231, 0.4);
+  box-shadow: 0 0 10px rgba(108, 92, 231, 0.15);
+  transform: translateY(-1px);
+}
+.ops-card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 8px;
+}
+.ops-card-title {
+  font-size: 12px;
+  font-weight: 700;
+  color: #dfe6e9;
+}
+.ops-card-subtitle {
+  font-size: 9px;
+  color: #636e72;
+  margin-top: 2px;
+}
+
+/* ── Buttons (aligned with kb-add-btn / kb-form-btn) ── */
+.ops-btn {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 1px;
+  padding: 6px 14px;
+  border: 1px solid rgba(108, 92, 231, 0.35);
+  background: rgba(108, 92, 231, 0.15);
+  color: #6c5ce7;
+  border-radius: 2px;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+.ops-btn:hover {
+  background: rgba(108, 92, 231, 0.3);
+  box-shadow: 0 0 12px rgba(108, 92, 231, 0.4);
+}
+.ops-btn-danger {
+  color: #ff6b6b;
+  border-color: rgba(255, 107, 107, 0.35);
+  background: rgba(255, 107, 107, 0.1);
+}
+.ops-btn-danger:hover {
+  background: rgba(255, 107, 107, 0.2);
+  border-color: rgba(255, 107, 107, 0.6);
+  box-shadow: 0 0 12px rgba(255, 107, 107, 0.3);
+}
+.ops-btn-success {
+  color: #00e676;
+  border-color: rgba(0, 230, 118, 0.35);
+  background: rgba(0, 230, 118, 0.1);
+}
+.ops-btn-success:hover {
+  background: rgba(0, 230, 118, 0.2);
+  border-color: rgba(0, 230, 118, 0.6);
+  box-shadow: 0 0 12px rgba(0, 230, 118, 0.3);
+}
+.ops-btn-sm { padding: 3px 8px; font-size: 9px; }
+
+/* ── Badge / pill ── */
+.ops-badge {
+  display: inline-block;
+  font-size: 8px;
+  font-weight: 700;
+  letter-spacing: 0.5px;
+  padding: 2px 6px;
+  border-radius: 2px;
+  text-transform: uppercase;
+}
+.ops-badge-green  { color: #00e676; background: rgba(0, 230, 118, 0.12); }
+.ops-badge-red    { color: #ff6b6b; background: rgba(255, 107, 107, 0.12); }
+.ops-badge-yellow { color: #ffd93d; background: rgba(255, 217, 61, 0.12); }
+.ops-badge-gray   { color: #636e72; background: rgba(99, 110, 114, 0.12); }
+.ops-badge-purple { color: #a29bfe; background: rgba(162, 155, 254, 0.12); }
+
+/* ── Toggle switch ── */
+.ops-toggle {
+  position: relative;
+  width: 28px;
+  height: 14px;
+  background: rgba(99, 110, 114, 0.3);
+  border-radius: 7px;
+  cursor: pointer;
+  transition: background 0.2s;
+  flex-shrink: 0;
+}
+.ops-toggle.on { background: rgba(0, 230, 118, 0.3); }
+.ops-toggle::after {
+  content: '';
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: #636e72;
+  transition: all 0.2s;
+}
+.ops-toggle.on::after {
+  left: 16px;
+  background: #00e676;
+  box-shadow: 0 0 4px #00e676;
+}
+
+/* ── Triggers layout ── */
+.ops-triggers-layout {
+  display: flex;
+  gap: 16px;
+  height: 100%;
+}
+.ops-triggers-rules {
+  flex: 7;
+  overflow-y: auto;
+}
+.ops-triggers-history {
+  flex: 3;
+  overflow-y: auto;
+  border-left: 1px solid rgba(108, 92, 231, 0.12);
+  padding-left: 16px;
+}
+.ops-history-title {
+  font-size: 10px;
+  font-weight: 700;
+  color: #6c5ce7;
+  letter-spacing: 2px;
+  text-transform: uppercase;
+  margin-bottom: 10px;
+  text-shadow: 0 0 8px rgba(108, 92, 231, 0.4);
+}
+.ops-history-item {
+  padding: 6px 8px;
+  margin-bottom: 6px;
+  background: rgba(30, 30, 50, 0.4);
+  border-left: 2px solid rgba(108, 92, 231, 0.15);
+  border-radius: 2px;
+  font-size: 9px;
+  animation: slideIn 0.2s ease-out;
+}
+.ops-history-item.success { border-left-color: #00e676; }
+.ops-history-item.error { border-left-color: #ff6b6b; }
+.ops-history-time {
+  color: #4a4e60;
+  font-size: 8px;
+}
+.ops-history-event {
+  color: #a29bfe;
+  font-weight: 600;
+}
+.ops-history-child {
+  color: #74b9ff;
+  cursor: pointer;
+}
+.ops-history-child:hover { text-decoration: underline; }
+.ops-history-error {
+  color: #ff6b6b;
+  font-size: 8px;
+  margin-top: 2px;
+}
+
+/* ── Inline forms (aligned with kb-form / kb-field) ── */
+.ops-form {
+  background: rgba(15, 15, 26, 0.98);
+  border: 1px solid rgba(108, 92, 231, 0.3);
+  border-radius: 4px;
+  padding: 16px;
+  margin-bottom: 12px;
+  animation: formIn 0.2s ease-out;
+  box-shadow: 0 0 30px rgba(108, 92, 231, 0.15);
+}
+.ops-form-row {
+  margin-bottom: 12px;
+}
+.ops-form-label {
+  font-size: 10px;
+  color: #636e72;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  margin-bottom: 4px;
+  display: block;
+}
+.ops-form input, .ops-form select, .ops-form textarea {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 12px;
+  background: rgba(30, 30, 50, 0.6);
+  color: #dfe6e9;
+  border: 1px solid rgba(108, 92, 231, 0.2);
+  border-radius: 2px;
+  padding: 7px 10px;
+  width: 100%;
+  outline: none;
+  transition: border-color 0.15s;
+  box-sizing: border-box;
+}
+.ops-form input:focus, .ops-form select:focus, .ops-form textarea:focus {
+  border-color: rgba(108, 92, 231, 0.6);
+  box-shadow: 0 0 8px rgba(108, 92, 231, 0.2);
+}
+.ops-form textarea { resize: vertical; min-height: 60px; }
+.ops-form-actions {
+  display: flex;
+  gap: 8px;
+  margin-top: 12px;
+}
+
+/* ── Empty state ── */
+.ops-empty {
+  text-align: center;
+  padding: 40px 20px;
+  color: #636e72;
+  font-size: 10px;
+  letter-spacing: 1px;
+}
+.ops-empty-icon {
+  font-size: 24px;
+  margin-bottom: 10px;
+  opacity: 0.25;
+  color: #6c5ce7;
+}
+
+/* ── Trigger card specifics ── */
+.ops-trigger-event {
+  font-size: 11px;
+  color: #6c5ce7;
+  font-weight: 700;
+  text-shadow: 0 0 6px rgba(108, 92, 231, 0.3);
+}
+.ops-trigger-meta {
+  font-size: 9px;
+  color: #636e72;
+  margin-top: 6px;
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+.ops-trigger-meta span { white-space: nowrap; }
+.ops-trigger-rules {
+  font-size: 9px;
+  color: #dfe6e9;
+  margin-top: 6px;
+  background: rgba(15, 15, 26, 0.6);
+  border: 1px solid rgba(108, 92, 231, 0.1);
+  padding: 6px 8px;
+  border-radius: 2px;
+  overflow-x: auto;
+  white-space: pre-wrap;
+  max-height: 80px;
+}
+.ops-trigger-actions {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+}
+
+/* ── Poll card ── */
+.ops-poll-url {
+  font-size: 9px;
+  color: #636e72;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 400px;
+}
+.ops-poll-condition {
+  font-size: 9px;
+  color: #8890a4;
+  margin-top: 4px;
+}
+.ops-poll-result {
+  display: inline-block;
+  margin-left: 8px;
+  font-size: 9px;
+  padding: 2px 6px;
+  border-radius: 2px;
+  animation: formIn 0.2s ease;
+}
+
+/* ── Skills ── */
+.ops-skill-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-top: 6px;
+}
+.ops-skill-tag {
+  font-size: 8px;
+  padding: 2px 6px;
+  background: rgba(162, 155, 254, 0.08);
+  border: 1px solid rgba(162, 155, 254, 0.15);
+  border-radius: 2px;
+  color: #a29bfe;
+}
+.ops-skill-agents {
+  font-size: 9px;
+  color: #636e72;
+  margin-top: 6px;
+}
+.ops-skill-profiles {
+  margin-top: 8px;
+  padding-top: 8px;
+  border-top: 1px solid rgba(108, 92, 231, 0.1);
+}
+.ops-skill-profile {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 0;
+  font-size: 10px;
+}
+.ops-skill-profile-name {
+  color: #dfe6e9;
+  font-weight: 600;
+  min-width: 100px;
+}
+.ops-proficiency-dots {
+  display: flex;
+  gap: 3px;
+}
+.ops-proficiency-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: rgba(108, 92, 231, 0.15);
+  border: 1px solid rgba(108, 92, 231, 0.2);
+}
+.ops-proficiency-dot.filled {
+  background: #a29bfe;
+  border-color: #a29bfe;
+  box-shadow: 0 0 4px rgba(162, 155, 254, 0.4);
+}
+
+/* ── Discover result ── */
+.ops-discover-result {
+  margin-top: 8px;
+  padding: 8px;
+  background: rgba(10, 10, 18, 0.5);
+  border-radius: 2px;
+  border-left: 2px solid rgba(0, 230, 118, 0.3);
+}
+.ops-discover-agent {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 3px 0;
+  font-size: 10px;
+}
+.ops-discover-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+.ops-discover-dot.active { background: #00e676; box-shadow: 0 0 4px #00e676; }
+.ops-discover-dot.inactive { background: #636e72; }
+.ops-discover-name {
+  color: #74b9ff;
+  cursor: pointer;
+}
+.ops-discover-name:hover { text-decoration: underline; }
+.ops-discover-role {
+  color: #5a5e78;
+  font-size: 9px;
+}
+
+/* ── Quotas table ── */
+.ops-quota-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+.ops-quota-table th {
+  font-size: 9px;
+  color: #636e72;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  text-align: left;
+  padding: 8px 10px;
+  border-bottom: 1px solid rgba(108, 92, 231, 0.2);
+}
+.ops-quota-table td {
+  padding: 8px 10px;
+  font-size: 10px;
+  border-bottom: 1px solid rgba(108, 92, 231, 0.08);
+}
+.ops-quota-table tr { transition: background 0.15s; cursor: pointer; }
+.ops-quota-table tr:hover { background: rgba(108, 92, 231, 0.05); }
+.ops-quota-table tr.warning { background: rgba(255, 107, 107, 0.04); }
+.ops-quota-table tr.warning:hover { background: rgba(255, 107, 107, 0.08); }
+
+.ops-quota-agent {
+  color: #dfe6e9;
+  font-weight: 600;
+}
+
+/* ── Health bar (10 segments, Zelda hearts style) ── */
+.ops-health-bar {
+  display: flex;
+  gap: 2px;
+  align-items: center;
+}
+.ops-health-seg {
+  width: 8px;
+  height: 10px;
+  background: rgba(30, 30, 50, 0.6);
+  border: 1px solid rgba(108, 92, 231, 0.15);
+  border-radius: 0;
+  transition: all 0.15s;
+  image-rendering: pixelated;
+}
+.ops-health-seg.filled { background: #00e676; border-color: rgba(0, 230, 118, 0.6); box-shadow: 0 0 3px rgba(0, 230, 118, 0.4); }
+.ops-health-seg.warn   { background: #ffd93d; border-color: rgba(255, 217, 61, 0.6); box-shadow: 0 0 3px rgba(255, 217, 61, 0.4); }
+.ops-health-seg.danger { background: #ff6b6b; border-color: rgba(255, 107, 107, 0.6); box-shadow: 0 0 4px rgba(255, 107, 107, 0.5); }
+.ops-quota-text {
+  font-size: 8px;
+  color: #5a5e78;
+  margin-left: 6px;
+  white-space: nowrap;
+}
+.ops-quota-warning {
+  color: #ffd93d;
+  font-size: 10px;
+  margin-left: 4px;
+}
+
+/* ── Elevation section in detail ── */
+.ops-elevation-active {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 8px;
+  background: rgba(255, 215, 0, 0.06);
+  border-left: 2px solid rgba(255, 215, 0, 0.4);
+  border-radius: 2px;
+  margin-bottom: 6px;
+}
+.ops-elevation-role {
+  font-size: 11px;
+  font-weight: 700;
+  color: #ffd700;
+}
+.ops-elevation-countdown {
+  font-size: 9px;
+  color: #5a5e78;
+  margin-left: auto;
+}
+.ops-elevation-granted-by {
+  font-size: 8px;
+  color: #5a5e78;
+}
+
+/* ── Agents tab — master/detail layout ── */
+.ops-agents-layout {
+  display: flex;
+  gap: 0;
+  height: 100%;
+}
+.ops-agents-list {
+  width: 240px;
+  min-width: 200px;
+  overflow-y: auto;
+  border-right: 1px solid rgba(108, 92, 231, 0.12);
+  padding-right: 12px;
+  flex-shrink: 0;
+}
+.ops-agents-detail {
+  flex: 1;
+  overflow-y: auto;
+  padding-left: 16px;
+}
+.ops-agent-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 10px;
+  margin-bottom: 4px;
+  border-radius: 3px;
+  cursor: pointer;
+  transition: all 0.15s;
+  border: 1px solid transparent;
+}
+.ops-agent-row:hover {
+  background: rgba(108, 92, 231, 0.08);
+  border-color: rgba(108, 92, 231, 0.2);
+}
+.ops-agent-row.selected {
+  background: rgba(108, 92, 231, 0.12);
+  border-color: rgba(108, 92, 231, 0.35);
+}
+.ops-agent-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+.ops-agent-dot.active { background: #00e676; box-shadow: 0 0 4px #00e676; }
+.ops-agent-dot.sleeping { background: #ffd93d; box-shadow: 0 0 4px rgba(255,217,61,0.4); }
+.ops-agent-dot.inactive { background: #636e72; }
+.ops-agent-name {
+  font-size: 11px;
+  font-weight: 600;
+  color: #dfe6e9;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.ops-agent-role-sm {
+  font-size: 8px;
+  color: #636e72;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* ── Agent detail sections ── */
+.ops-detail-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 16px;
+  padding-bottom: 12px;
+  border-bottom: 1px solid rgba(108, 92, 231, 0.15);
+}
+.ops-detail-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+.ops-detail-dot.active { background: #00e676; box-shadow: 0 0 6px #00e676; }
+.ops-detail-dot.sleeping { background: #ffd93d; box-shadow: 0 0 6px rgba(255,217,61,0.5); }
+.ops-detail-dot.inactive { background: #636e72; }
+.ops-detail-name {
+  font-size: 16px;
+  font-weight: 700;
+  color: #dfe6e9;
+}
+.ops-detail-role {
+  font-size: 10px;
+  color: #a29bfe;
+  margin-top: 2px;
+}
+.ops-detail-section {
+  margin-bottom: 16px;
+}
+.ops-detail-section-title {
+  font-size: 9px;
+  font-weight: 700;
+  color: #6c5ce7;
+  letter-spacing: 1.5px;
+  text-transform: uppercase;
+  margin-bottom: 8px;
+  text-shadow: 0 0 6px rgba(108, 92, 231, 0.3);
+}
+.ops-detail-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 0;
+  font-size: 10px;
+}
+.ops-detail-label {
+  color: #636e72;
+  min-width: 90px;
+  font-size: 9px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+.ops-detail-value {
+  color: #dfe6e9;
+}
+.ops-detail-empty {
+  text-align: center;
+  padding: 60px 20px;
+  color: #4a4e60;
+  font-size: 10px;
+  letter-spacing: 1px;
+}
+
+/* ── Profile section tab bar ── */
+.ops-profile-tabs {
+  display: flex;
+  gap: 0;
+  margin-bottom: 12px;
+  border-bottom: 1px solid rgba(108, 92, 231, 0.12);
+}
+.ops-profile-tab {
+  padding: 6px 12px;
+  font-size: 8px;
+  font-weight: 600;
+  letter-spacing: 1px;
+  color: #4a4e60;
+  cursor: pointer;
+  border: none;
+  background: none;
+  font-family: inherit;
+  transition: color 0.15s;
+}
+.ops-profile-tab:hover { color: #a29bfe; }
+.ops-profile-tab.active {
+  color: #6c5ce7;
+  border-bottom: 1px solid #6c5ce7;
+  margin-bottom: -1px;
+}
+
+/* ── Scrollbar ── */
+.ops-root ::-webkit-scrollbar { width: 4px; }
+.ops-root ::-webkit-scrollbar-track { background: transparent; }
+.ops-root ::-webkit-scrollbar-thumb { background: rgba(108, 92, 231, 0.2); border-radius: 2px; }
+`;
+
+export class OpsConsole {
+  constructor(container) {
+    this.container = container;
+    this.project = null;
+    this.activeTab = 'agents';
+    this._timers = [];
+    this._visible = false;
+    this.onAgentClick = null; // callback(project, name) to open agent detail
+
+    // API client set externally
+    this.client = null;
+    this.agents = []; // agent list for discovery
+  }
+
+  show(project) {
+    this.project = project;
+    this._visible = true;
+    this.container.classList.remove('hidden');
+    this._build();
+    this._switchTab(this.activeTab);
+  }
+
+  hide() {
+    this._visible = false;
+    this.container.classList.add('hidden');
+    this._clearTimers();
+    if (this._flowEditor) this._flowEditor.hide();
+  }
+
+  _clearTimers() {
+    this._timers.forEach(t => clearInterval(t));
+    this._timers = [];
+  }
+
+  _build() {
+    this._clearTimers();
+    this.container.innerHTML = '';
+
+    const shadow = this.container.attachShadow
+      ? null // don't use shadow DOM, keep it simple
+      : null;
+
+    // Inject styles
+    const style = document.createElement('style');
+    style.textContent = OPS_STYLES;
+    this.container.appendChild(style);
+
+    const root = document.createElement('div');
+    root.className = 'ops-root';
+
+    // Tab bar
+    const tabs = document.createElement('div');
+    tabs.className = 'ops-tabs';
+    const tabDefs = [
+      { id: 'agents', label: 'AGENTS' },
+      { id: 'triggers', label: 'TRIGGERS' },
+      { id: 'polls', label: 'POLLS' },
+      { id: 'cycles', label: 'CYCLES' },
+      { id: 'flows', label: 'FLOWS' },
+    ];
+    for (const t of tabDefs) {
+      const btn = document.createElement('button');
+      btn.className = `ops-tab${t.id === this.activeTab ? ' active' : ''}`;
+      btn.textContent = t.label;
+      btn.dataset.tab = t.id;
+      btn.addEventListener('click', () => this._switchTab(t.id));
+      tabs.appendChild(btn);
+    }
+    root.appendChild(tabs);
+
+    // Content area
+    const content = document.createElement('div');
+    content.className = 'ops-content';
+    this._contentEl = content;
+    root.appendChild(content);
+
+    this.container.appendChild(root);
+  }
+
+  _switchTab(tabId) {
+    this.activeTab = tabId;
+    this._clearTimers();
+
+    // Update active state
+    const tabs = this.container.querySelectorAll('.ops-tab');
+    tabs.forEach(t => t.classList.toggle('active', t.dataset.tab === tabId));
+
+    // Render content
+    switch (tabId) {
+      case 'agents': this._renderAgents(); break;
+      case 'triggers': this._renderTriggers(); break;
+      case 'polls': this._renderPolls(); break;
+      case 'cycles': this._renderCycles(); break;
+      case 'flows': this._renderFlows(); break;
+    }
+  }
+
+  // ═══════════════════════════════════════
+  // AGENTS TAB
+  // ═══════════════════════════════════════
+
+  async _renderAgents() {
+    const content = this._contentEl;
+    content.innerHTML = '<div class="ops-empty"><div class="ops-empty-icon">&#9881;</div>Loading agents...</div>';
+
+    const [agents, profiles, skills, quotas, elevations] = await Promise.all([
+      this._fetchProjectAgents(),
+      this.client.fetchProfiles(this.project),
+      this.client.fetchSkills(this.project),
+      this.client.fetchQuotas(this.project),
+      this.client.fetchElevations(this.project),
+    ]);
+
+    content.innerHTML = '';
+
+    if ((!agents || agents.length === 0) && (!profiles || profiles.length === 0)) {
+      content.innerHTML = '<div class="ops-empty"><div class="ops-empty-icon">&#9881;</div>No agents or profiles registered</div>';
+      return;
+    }
+
+    // Build lookup maps
+    const profileMap = {};
+    for (const p of (profiles || [])) profileMap[p.slug] = p;
+    const quotaMap = {};
+    for (const q of (quotas || [])) quotaMap[q.agent || q.profile_slug || q.name] = q;
+    const elevMap = {};
+    for (const e of (elevations || [])) {
+      const key = e.agent || e.agent_name;
+      if (!elevMap[key]) elevMap[key] = [];
+      elevMap[key].push(e);
+    }
+
+    // Layout: list (left) + detail (right)
+    const layout = document.createElement('div');
+    layout.className = 'ops-agents-layout';
+
+    const listCol = document.createElement('div');
+    listCol.className = 'ops-agents-list';
+
+    const detailCol = document.createElement('div');
+    detailCol.className = 'ops-agents-detail';
+
+    // Section header: Agents
+    const agentHeader = document.createElement('div');
+    agentHeader.style.cssText = 'font-size:9px;font-weight:700;color:#6c5ce7;letter-spacing:1.5px;text-transform:uppercase;margin-bottom:8px;text-shadow:0 0 6px rgba(108,92,231,0.3)';
+    agentHeader.textContent = `AGENTS (${(agents || []).length})`;
+    listCol.appendChild(agentHeader);
+
+    // Agent rows
+    for (const a of (agents || [])) {
+      const row = document.createElement('div');
+      row.className = 'ops-agent-row';
+      row.dataset.name = a.name;
+
+      const dot = document.createElement('div');
+      dot.className = `ops-agent-dot ${a.status || 'inactive'}`;
+      row.appendChild(dot);
+
+      const info = document.createElement('div');
+      info.style.cssText = 'overflow:hidden;flex:1';
+      const nameEl = document.createElement('div');
+      nameEl.className = 'ops-agent-name';
+      nameEl.textContent = a.name;
+      info.appendChild(nameEl);
+      if (a.role) {
+        const roleEl = document.createElement('div');
+        roleEl.className = 'ops-agent-role-sm';
+        roleEl.textContent = a.role;
+        info.appendChild(roleEl);
+      }
+      row.appendChild(info);
+
+      if (a.profile_slug) {
+        const badge = document.createElement('span');
+        badge.className = 'ops-badge ops-badge-purple';
+        badge.textContent = a.profile_slug;
+        badge.style.flexShrink = '0';
+        row.appendChild(badge);
+      }
+
+      row.addEventListener('click', () => {
+        listCol.querySelectorAll('.ops-agent-row').forEach(r => r.classList.remove('selected'));
+        row.classList.add('selected');
+        this._renderAgentDetail(detailCol, a, profileMap, skills || [], quotaMap, elevMap);
+      });
+
+      listCol.appendChild(row);
+    }
+
+    // Profiles section
+    const allProfiles = profiles || [];
+    const activeAgentSlugs = new Set((agents || []).filter(a => a.profile_slug).map(a => a.profile_slug));
+    const unlinkedProfiles = allProfiles.filter(p => !activeAgentSlugs.has(p.slug));
+
+    const profHeader = document.createElement('div');
+    profHeader.style.cssText = 'display:flex;align-items:center;justify-content:space-between;font-size:9px;font-weight:700;color:#636e72;letter-spacing:1.5px;text-transform:uppercase;margin:16px 0 8px;border-top:1px solid rgba(108,92,231,0.1);padding-top:12px';
+    profHeader.innerHTML = `<span>PROFILES (${allProfiles.length})</span>`;
+    const addProfBtn = document.createElement('button');
+    addProfBtn.className = 'ops-btn ops-btn-sm';
+    addProfBtn.textContent = '+ NEW';
+    addProfBtn.addEventListener('click', () => {
+      listCol.querySelectorAll('.ops-agent-row').forEach(r => r.classList.remove('selected'));
+      this._showProfileForm(detailCol, null);
+    });
+    profHeader.appendChild(addProfBtn);
+    listCol.appendChild(profHeader);
+
+    for (const p of unlinkedProfiles) {
+      const row = document.createElement('div');
+      row.className = 'ops-agent-row';
+
+      const dot = document.createElement('div');
+      dot.className = 'ops-agent-dot inactive';
+      row.appendChild(dot);
+
+      const info = document.createElement('div');
+      info.style.cssText = 'overflow:hidden;flex:1';
+      const nameEl = document.createElement('div');
+      nameEl.className = 'ops-agent-name';
+      nameEl.textContent = p.name || p.slug;
+      info.appendChild(nameEl);
+      const roleEl = document.createElement('div');
+      roleEl.className = 'ops-agent-role-sm';
+      roleEl.textContent = p.role || 'profile';
+      info.appendChild(roleEl);
+      row.appendChild(info);
+
+      row.addEventListener('click', () => {
+        listCol.querySelectorAll('.ops-agent-row').forEach(r => r.classList.remove('selected'));
+        row.classList.add('selected');
+        this._renderProfileDetail(detailCol, p, skills || [], quotaMap);
+      });
+
+      listCol.appendChild(row);
+    }
+
+    // Also show linked profiles
+    const linkedProfiles = allProfiles.filter(p => activeAgentSlugs.has(p.slug));
+    for (const p of linkedProfiles) {
+      const row = document.createElement('div');
+      row.className = 'ops-agent-row';
+      const dot = document.createElement('div');
+      dot.className = 'ops-agent-dot active';
+      dot.style.cssText = 'width:5px;height:5px';
+      row.appendChild(dot);
+      const info = document.createElement('div');
+      info.style.cssText = 'overflow:hidden;flex:1';
+      info.innerHTML = `<div class="ops-agent-name" style="font-size:10px;color:#8890a4">${esc(p.slug)}</div>`;
+      row.appendChild(info);
+      const badge = document.createElement('span');
+      badge.style.cssText = 'font-size:7px;color:#4a4e60';
+      badge.textContent = 'LINKED';
+      row.appendChild(badge);
+      row.addEventListener('click', () => {
+        listCol.querySelectorAll('.ops-agent-row').forEach(r => r.classList.remove('selected'));
+        row.classList.add('selected');
+        this._renderProfileDetail(detailCol, p, skills || [], quotaMap);
+      });
+      listCol.appendChild(row);
+    }
+
+    layout.appendChild(listCol);
+
+    // Default detail view
+    detailCol.innerHTML = '<div class="ops-detail-empty">Select an agent or profile</div>';
+    layout.appendChild(detailCol);
+
+    content.appendChild(layout);
+
+    // Auto-select first agent
+    const firstRow = listCol.querySelector('.ops-agent-row');
+    if (firstRow) firstRow.click();
+  }
+
+  async _fetchProjectAgents() {
+    // Filter all agents by current project
+    try {
+      const res = await fetch(`/api/agents?project=${encodeURIComponent(this.project)}`);
+      if (!res.ok) return [];
+      return await res.json();
+    } catch { return []; }
+  }
+
+  _renderAgentDetail(container, agent, profileMap, skills, quotaMap, elevMap) {
+    container.innerHTML = '';
+
+    // Header with actions
+    const header = document.createElement('div');
+    header.className = 'ops-detail-header';
+    const dot = document.createElement('div');
+    dot.className = `ops-detail-dot ${agent.status || 'inactive'}`;
+    header.appendChild(dot);
+    const headerInfo = document.createElement('div');
+    headerInfo.style.flex = '1';
+    headerInfo.innerHTML = `<div class="ops-detail-name">${esc(agent.name)}</div>
+      <div class="ops-detail-role">${esc(agent.role || 'agent')}</div>`;
+    header.appendChild(headerInfo);
+
+    const headerRight = document.createElement('div');
+    headerRight.style.cssText = 'display:flex;align-items:center;gap:8px';
+    const statusBadge = agent.status === 'active' ? 'ops-badge-green' : agent.status === 'sleeping' ? 'ops-badge-yellow' : 'ops-badge-gray';
+    headerRight.innerHTML = `<span class="ops-badge ${statusBadge}">${agent.status || 'unknown'}</span>`;
+
+    // Deactivate button
+    if (agent.status === 'active' || agent.status === 'sleeping') {
+      const deactBtn = document.createElement('button');
+      deactBtn.className = 'ops-btn ops-btn-sm ops-btn-danger';
+      deactBtn.textContent = 'DEACTIVATE';
+      deactBtn.addEventListener('click', async () => {
+        if (!confirm(`Deactivate agent "${agent.name}"?`)) return;
+        await this.client.deactivateAgent(agent.name, this.project);
+        this._renderAgents();
+      });
+      headerRight.appendChild(deactBtn);
+    }
+    header.appendChild(headerRight);
+    container.appendChild(header);
+
+    if (agent.last_seen) {
+      const seenEl = document.createElement('div');
+      seenEl.style.cssText = 'font-size:8px;color:#4a4e60;margin:-12px 0 12px 22px';
+      seenEl.textContent = `Last seen ${timeAgo(agent.last_seen)}`;
+      container.appendChild(seenEl);
+    }
+
+    // Description
+    if (agent.description) {
+      const desc = document.createElement('div');
+      desc.style.cssText = 'font-size:10px;color:#8890a4;margin-bottom:16px;line-height:1.5';
+      desc.textContent = agent.description;
+      container.appendChild(desc);
+    }
+
+    // Meta info
+    const metaSection = document.createElement('div');
+    metaSection.className = 'ops-detail-section';
+    metaSection.innerHTML = `<div class="ops-detail-section-title">Info</div>`;
+    const rows = [
+      ['Profile', agent.profile_slug || '--'],
+      ['Reports to', agent.reports_to || '--'],
+      ['Executive', agent.is_executive ? 'Yes' : 'No'],
+    ];
+    for (const [label, value] of rows) {
+      const row = document.createElement('div');
+      row.className = 'ops-detail-row';
+      row.innerHTML = `<span class="ops-detail-label">${label}</span><span class="ops-detail-value">${esc(String(value))}</span>`;
+      metaSection.appendChild(row);
+    }
+    container.appendChild(metaSection);
+
+    // Profile detail (if linked)
+    const profile = agent.profile_slug ? profileMap[agent.profile_slug] : null;
+    if (profile) {
+      const profSection = document.createElement('div');
+      profSection.className = 'ops-detail-section';
+      profSection.innerHTML = `<div class="ops-detail-section-title">Profile: ${esc(profile.slug)}</div>`;
+
+      let soulKeys = [];
+      try { soulKeys = JSON.parse(profile.soul_keys || '[]'); } catch {}
+      if (soulKeys.length > 0) {
+        const keysEl = document.createElement('div');
+        keysEl.style.cssText = 'display:flex;flex-wrap:wrap;gap:4px;margin-bottom:8px';
+        for (const k of soulKeys) {
+          const tag = document.createElement('span');
+          tag.className = 'ops-skill-tag';
+          tag.textContent = k;
+          keysEl.appendChild(tag);
+        }
+        profSection.appendChild(keysEl);
+      }
+
+      if (profile.context_pack) {
+        const cpRow = document.createElement('div');
+        cpRow.className = 'ops-detail-row';
+        const cpVal = profile.context_pack.length > 120 ? profile.context_pack.substring(0, 120) + '...' : profile.context_pack;
+        cpRow.innerHTML = `<span class="ops-detail-label">Context</span><span class="ops-detail-value" style="font-size:9px;color:#8890a4">${esc(cpVal)}</span>`;
+        profSection.appendChild(cpRow);
+      }
+
+      const poolRow = document.createElement('div');
+      poolRow.className = 'ops-detail-row';
+      poolRow.innerHTML = `<span class="ops-detail-label">Pool size</span><span class="ops-detail-value">${profile.pool_size || 3}</span>`;
+      profSection.appendChild(poolRow);
+
+      container.appendChild(profSection);
+    }
+
+    // Skills
+    const skillsSection = document.createElement('div');
+    skillsSection.className = 'ops-detail-section';
+    skillsSection.innerHTML = `<div class="ops-detail-section-title">Skills</div>`;
+    const skillsEl = document.createElement('div');
+    let agentSkills = [];
+    if (profile) {
+      try { agentSkills = JSON.parse(profile.skills || '[]'); } catch {}
+    }
+    if (agentSkills.length > 0) {
+      OpsConsole.renderSkillsSection(skillsEl, agentSkills);
+    } else {
+      skillsEl.innerHTML = '<span style="color:#4a4e60;font-size:9px">No skills assigned</span>';
+    }
+    skillsSection.appendChild(skillsEl);
+    container.appendChild(skillsSection);
+
+    // Quota — with set/edit button
+    const quotaSection = document.createElement('div');
+    quotaSection.className = 'ops-detail-section';
+    const quotaHeader = document.createElement('div');
+    quotaHeader.style.cssText = 'display:flex;align-items:center;justify-content:space-between';
+    quotaHeader.innerHTML = `<div class="ops-detail-section-title" style="margin-bottom:0">Quota</div>`;
+    const quotaBtnArea = document.createElement('div');
+    quotaBtnArea.style.cssText = 'display:flex;gap:4px';
+    const setQuotaBtn = document.createElement('button');
+    setQuotaBtn.className = 'ops-btn ops-btn-sm';
+    setQuotaBtn.textContent = 'SET';
+    setQuotaBtn.addEventListener('click', () => this._showQuotaForm(container, agent.name));
+    quotaBtnArea.appendChild(setQuotaBtn);
+    const quota = quotaMap[agent.name] || quotaMap[agent.profile_slug];
+    if (quota) {
+      const delQuotaBtn = document.createElement('button');
+      delQuotaBtn.className = 'ops-btn ops-btn-sm ops-btn-danger';
+      delQuotaBtn.textContent = 'DEL';
+      delQuotaBtn.addEventListener('click', async () => {
+        await this.client.deleteQuota(agent.name, this.project);
+        this._renderAgents();
+      });
+      quotaBtnArea.appendChild(delQuotaBtn);
+    }
+    quotaHeader.appendChild(quotaBtnArea);
+    quotaSection.appendChild(quotaHeader);
+    const quotaEl = document.createElement('div');
+    quotaEl.style.marginTop = '8px';
+    OpsConsole.renderQuotasSection(quotaEl, quota);
+    quotaSection.appendChild(quotaEl);
+    container.appendChild(quotaSection);
+
+    // Elevations — with grant button
+    const agentElevations = elevMap[agent.name] || [];
+    const elevSection = document.createElement('div');
+    elevSection.className = 'ops-detail-section';
+    const elevHeader = document.createElement('div');
+    elevHeader.style.cssText = 'display:flex;align-items:center;justify-content:space-between';
+    elevHeader.innerHTML = `<div class="ops-detail-section-title" style="margin-bottom:0">Elevations</div>`;
+    const grantBtn = document.createElement('button');
+    grantBtn.className = 'ops-btn ops-btn-sm';
+    grantBtn.textContent = 'GRANT';
+    grantBtn.addEventListener('click', () => this._showElevationForm(container, agent.name));
+    elevHeader.appendChild(grantBtn);
+    elevSection.appendChild(elevHeader);
+    const elevEl = document.createElement('div');
+    elevEl.style.marginTop = '8px';
+    if (agentElevations.length === 0) {
+      elevEl.innerHTML = '<span style="color:#4a4e60;font-size:9px">No active elevation</span>';
+    } else {
+      for (const e of agentElevations) {
+        const eRow = document.createElement('div');
+        eRow.style.cssText = 'display:flex;align-items:center;gap:8px;padding:6px 8px;background:rgba(255,215,0,0.06);border-left:2px solid rgba(255,215,0,0.4);border-radius:2px;margin-bottom:4px';
+        const remaining = e.expires_at ? Math.max(0, Math.floor((new Date(e.expires_at) - Date.now()) / 1000)) : null;
+        const countdown = remaining !== null ? `${Math.floor(remaining / 60)}m ${remaining % 60}s` : 'permanent';
+        eRow.innerHTML = `<span style="font-size:11px;font-weight:700;color:#ffd700">${esc(e.elevated_role || e.role)}</span>
+          <span style="font-size:9px;color:#5a5e78;flex:1">${countdown}</span>`;
+        const revokeBtn = document.createElement('button');
+        revokeBtn.className = 'ops-btn ops-btn-sm ops-btn-danger';
+        revokeBtn.textContent = 'REVOKE';
+        revokeBtn.addEventListener('click', async () => {
+          await this.client.revokeElevation(e.id);
+          this._renderAgents();
+        });
+        eRow.appendChild(revokeBtn);
+        elevEl.appendChild(eRow);
+      }
+    }
+    elevSection.appendChild(elevEl);
+    container.appendChild(elevSection);
+  }
+
+  _renderProfileDetail(container, profile, skills, quotaMap) {
+    container.innerHTML = '';
+
+    // Header with actions
+    const header = document.createElement('div');
+    header.className = 'ops-detail-header';
+    const dot = document.createElement('div');
+    dot.className = 'ops-detail-dot inactive';
+    header.appendChild(dot);
+    const headerInfo = document.createElement('div');
+    headerInfo.style.flex = '1';
+    headerInfo.innerHTML = `<div class="ops-detail-name">${esc(profile.name || profile.slug)}</div>
+      <div class="ops-detail-role">${esc(profile.role || 'profile')}</div>`;
+    header.appendChild(headerInfo);
+    const headerRight = document.createElement('div');
+    headerRight.style.cssText = 'display:flex;align-items:center;gap:8px';
+    headerRight.innerHTML = `<span class="ops-badge ops-badge-purple">PROFILE</span>`;
+    const editBtn = document.createElement('button');
+    editBtn.className = 'ops-btn ops-btn-sm';
+    editBtn.textContent = 'EDIT';
+    editBtn.addEventListener('click', () => this._showProfileForm(container, profile));
+    headerRight.appendChild(editBtn);
+    const delBtn = document.createElement('button');
+    delBtn.className = 'ops-btn ops-btn-sm ops-btn-danger';
+    delBtn.textContent = 'DELETE';
+    delBtn.addEventListener('click', async () => {
+      if (!confirm(`Delete profile "${profile.slug}"?`)) return;
+      await this.client.deleteProfile(profile.slug, this.project);
+      this._renderAgents();
+    });
+    headerRight.appendChild(delBtn);
+    header.appendChild(headerRight);
+    container.appendChild(header);
+
+    // Info
+    const infoSection = document.createElement('div');
+    infoSection.className = 'ops-detail-section';
+    infoSection.innerHTML = `<div class="ops-detail-section-title">Info</div>`;
+    const infoRows = [
+      ['Slug', profile.slug],
+      ['Pool size', profile.pool_size || 3],
+    ];
+    for (const [label, value] of infoRows) {
+      const row = document.createElement('div');
+      row.className = 'ops-detail-row';
+      row.innerHTML = `<span class="ops-detail-label">${label}</span><span class="ops-detail-value">${esc(String(value))}</span>`;
+      infoSection.appendChild(row);
+    }
+    container.appendChild(infoSection);
+
+    // Soul keys
+    let soulKeys = [];
+    try { soulKeys = JSON.parse(profile.soul_keys || '[]'); } catch {}
+    if (soulKeys.length > 0) {
+      const keysSection = document.createElement('div');
+      keysSection.className = 'ops-detail-section';
+      keysSection.innerHTML = `<div class="ops-detail-section-title">Soul Keys</div>`;
+      const keysEl = document.createElement('div');
+      keysEl.style.cssText = 'display:flex;flex-wrap:wrap;gap:4px';
+      for (const k of soulKeys) {
+        const tag = document.createElement('span');
+        tag.className = 'ops-skill-tag';
+        tag.textContent = k;
+        keysEl.appendChild(tag);
+      }
+      keysSection.appendChild(keysEl);
+      container.appendChild(keysSection);
+    }
+
+    // Context pack
+    if (profile.context_pack) {
+      const cpSection = document.createElement('div');
+      cpSection.className = 'ops-detail-section';
+      cpSection.innerHTML = `<div class="ops-detail-section-title">Context Pack</div>`;
+      const cpEl = document.createElement('div');
+      cpEl.style.cssText = 'font-size:9px;color:#8890a4;line-height:1.5;max-height:120px;overflow-y:auto;background:rgba(15,15,26,0.5);padding:8px;border-radius:2px;border:1px solid rgba(108,92,231,0.1)';
+      cpEl.textContent = profile.context_pack;
+      cpSection.appendChild(cpEl);
+      container.appendChild(cpSection);
+    }
+
+    // Skills
+    const skillsSection = document.createElement('div');
+    skillsSection.className = 'ops-detail-section';
+    skillsSection.innerHTML = `<div class="ops-detail-section-title">Skills</div>`;
+    const skillsEl = document.createElement('div');
+    let profSkills = [];
+    try { profSkills = JSON.parse(profile.skills || '[]'); } catch {}
+    if (profSkills.length > 0) {
+      OpsConsole.renderSkillsSection(skillsEl, profSkills);
+    } else {
+      skillsEl.innerHTML = '<span style="color:#4a4e60;font-size:9px">No skills assigned</span>';
+    }
+    skillsSection.appendChild(skillsEl);
+    container.appendChild(skillsSection);
+
+    // Quota — with set button
+    const quotaSection = document.createElement('div');
+    quotaSection.className = 'ops-detail-section';
+    const quotaHeader = document.createElement('div');
+    quotaHeader.style.cssText = 'display:flex;align-items:center;justify-content:space-between';
+    quotaHeader.innerHTML = `<div class="ops-detail-section-title" style="margin-bottom:0">Quota</div>`;
+    const setQuotaBtn = document.createElement('button');
+    setQuotaBtn.className = 'ops-btn ops-btn-sm';
+    setQuotaBtn.textContent = 'SET';
+    setQuotaBtn.addEventListener('click', () => this._showQuotaForm(container, profile.slug));
+    quotaHeader.appendChild(setQuotaBtn);
+    quotaSection.appendChild(quotaHeader);
+    const quotaEl = document.createElement('div');
+    quotaEl.style.marginTop = '8px';
+    const quota = quotaMap[profile.slug];
+    OpsConsole.renderQuotasSection(quotaEl, quota);
+    quotaSection.appendChild(quotaEl);
+    container.appendChild(quotaSection);
+
+    // Allowed tools
+    let allowedTools = [];
+    try { allowedTools = JSON.parse(profile.allowed_tools || '[]'); } catch {}
+    if (allowedTools.length > 0) {
+      const toolsSection = document.createElement('div');
+      toolsSection.className = 'ops-detail-section';
+      toolsSection.innerHTML = `<div class="ops-detail-section-title">Allowed Tools</div>`;
+      const toolsEl = document.createElement('div');
+      toolsEl.style.cssText = 'display:flex;flex-wrap:wrap;gap:4px';
+      for (const t of allowedTools) {
+        const tag = document.createElement('span');
+        tag.className = 'ops-skill-tag';
+        tag.textContent = t;
+        toolsEl.appendChild(tag);
+      }
+      toolsSection.appendChild(toolsEl);
+      container.appendChild(toolsSection);
+    }
+  }
+
+  // ── CRUD Forms ──
+
+  _showProfileForm(container, existing) {
+    container.innerHTML = '';
+    const isEdit = !!existing;
+    const title = isEdit ? `Edit Profile: ${existing.slug}` : 'New Profile';
+
+    let existingSoulKeys = [];
+    let existingSkills = [];
+    let existingAllowedTools = [];
+    let existingVaultPaths = [];
+    if (existing) {
+      try { existingSoulKeys = JSON.parse(existing.soul_keys || '[]'); } catch {}
+      try { existingSkills = JSON.parse(existing.skills || '[]'); } catch {}
+      try { existingAllowedTools = JSON.parse(existing.allowed_tools || '[]'); } catch {}
+      try { existingVaultPaths = JSON.parse(existing.vault_paths || '[]'); } catch {}
+    }
+
+    const form = document.createElement('div');
+    form.className = 'ops-form';
+    form.innerHTML = `
+      <div style="font-size:12px;font-weight:700;color:#6c5ce7;margin-bottom:14px">${title}</div>
+      <div class="ops-form-row">
+        <label class="ops-form-label">Slug (unique ID)</label>
+        <input type="text" id="pf-slug" value="${esc(existing?.slug || '')}" ${isEdit ? 'disabled style="opacity:0.5"' : ''} placeholder="e.g. backend-dev" />
+      </div>
+      <div class="ops-form-row">
+        <label class="ops-form-label">Name</label>
+        <input type="text" id="pf-name" value="${esc(existing?.name || '')}" placeholder="e.g. Backend Developer" />
+      </div>
+      <div class="ops-form-row">
+        <label class="ops-form-label">Role</label>
+        <input type="text" id="pf-role" value="${esc(existing?.role || '')}" placeholder="e.g. Senior Engineer" />
+      </div>
+      <div class="ops-form-row">
+        <label class="ops-form-label">Context Pack</label>
+        <textarea id="pf-context" rows="3" placeholder="System prompt / instructions for agents using this profile">${esc(existing?.context_pack || '')}</textarea>
+      </div>
+      <div class="ops-form-row">
+        <label class="ops-form-label">Soul Keys (comma-separated)</label>
+        <input type="text" id="pf-soulkeys" value="${existingSoulKeys.join(', ')}" placeholder="e.g. precision, autonomy, team-player" />
+      </div>
+      <div class="ops-form-row">
+        <label class="ops-form-label">Allowed Tools (comma-separated)</label>
+        <input type="text" id="pf-tools" value="${existingAllowedTools.join(', ')}" placeholder="e.g. send_message, dispatch_task, *" />
+      </div>
+      <div class="ops-form-row">
+        <label class="ops-form-label">Vault Paths (comma-separated globs)</label>
+        <input type="text" id="pf-vault" value="${existingVaultPaths.join(', ')}" placeholder="e.g. docs/*, specs/*" />
+      </div>
+      <div class="ops-form-row">
+        <label class="ops-form-label">Pool Size (max concurrent spawns)</label>
+        <input type="number" id="pf-pool" value="${existing?.pool_size || 3}" min="1" max="20" />
+      </div>
+      <div class="ops-form-actions">
+        <button class="ops-btn ops-btn-success" id="pf-save">${isEdit ? 'UPDATE' : 'CREATE'}</button>
+        <button class="ops-btn" id="pf-cancel">CANCEL</button>
+      </div>
+    `;
+    container.appendChild(form);
+
+    form.querySelector('#pf-cancel').addEventListener('click', () => this._renderAgents());
+    form.querySelector('#pf-save').addEventListener('click', async () => {
+      const slug = form.querySelector('#pf-slug').value.trim();
+      if (!slug) { alert('Slug is required'); return; }
+
+      const soulKeysRaw = form.querySelector('#pf-soulkeys').value;
+      const soulKeys = soulKeysRaw ? soulKeysRaw.split(',').map(s => s.trim()).filter(Boolean) : [];
+      const toolsRaw = form.querySelector('#pf-tools').value;
+      const tools = toolsRaw ? toolsRaw.split(',').map(s => s.trim()).filter(Boolean) : [];
+      const vaultRaw = form.querySelector('#pf-vault').value;
+      const vaultPaths = vaultRaw ? vaultRaw.split(',').map(s => s.trim()).filter(Boolean) : [];
+
+      const data = {
+        project: this.project,
+        slug,
+        name: form.querySelector('#pf-name').value.trim(),
+        role: form.querySelector('#pf-role').value.trim(),
+        context_pack: form.querySelector('#pf-context').value,
+        soul_keys: JSON.stringify(soulKeys),
+        skills: existing ? existing.skills : '[]',
+        vault_paths: JSON.stringify(vaultPaths),
+        allowed_tools: JSON.stringify(tools),
+        pool_size: parseInt(form.querySelector('#pf-pool').value) || 3,
+      };
+
+      if (isEdit) {
+        await this.client.updateProfile(slug, data);
+      } else {
+        await this.client.createProfile(data);
+      }
+      this._renderAgents();
+    });
+  }
+
+  _showQuotaForm(container, agentName) {
+    // Remove any existing quota form
+    const existing = container.querySelector('.ops-quota-form');
+    if (existing) { existing.remove(); return; }
+
+    const form = document.createElement('div');
+    form.className = 'ops-form ops-quota-form';
+    form.innerHTML = `
+      <div style="font-size:11px;font-weight:700;color:#6c5ce7;margin-bottom:12px">Set Quota: ${esc(agentName)}</div>
+      <div class="ops-form-row">
+        <label class="ops-form-label">Tokens / day</label>
+        <input type="number" id="qf-tokens" value="0" min="0" placeholder="0 = unlimited" />
+      </div>
+      <div class="ops-form-row">
+        <label class="ops-form-label">Messages / hour</label>
+        <input type="number" id="qf-msgs" value="0" min="0" placeholder="0 = unlimited" />
+      </div>
+      <div class="ops-form-row">
+        <label class="ops-form-label">Tasks / hour</label>
+        <input type="number" id="qf-tasks" value="0" min="0" placeholder="0 = unlimited" />
+      </div>
+      <div class="ops-form-row">
+        <label class="ops-form-label">Spawns / hour</label>
+        <input type="number" id="qf-spawns" value="0" min="0" placeholder="0 = unlimited" />
+      </div>
+      <div class="ops-form-actions">
+        <button class="ops-btn ops-btn-success" id="qf-save">SAVE</button>
+        <button class="ops-btn" id="qf-cancel">CANCEL</button>
+      </div>
+    `;
+    container.appendChild(form);
+    form.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+
+    form.querySelector('#qf-cancel').addEventListener('click', () => form.remove());
+    form.querySelector('#qf-save').addEventListener('click', async () => {
+      const data = {
+        project: this.project,
+        max_tokens_per_day: parseInt(form.querySelector('#qf-tokens').value) || 0,
+        max_messages_per_hour: parseInt(form.querySelector('#qf-msgs').value) || 0,
+        max_tasks_per_hour: parseInt(form.querySelector('#qf-tasks').value) || 0,
+        max_spawns_per_hour: parseInt(form.querySelector('#qf-spawns').value) || 0,
+      };
+      await this.client.updateAgentQuota(agentName, data);
+      this._renderAgents();
+    });
+  }
+
+  _showElevationForm(container, agentName) {
+    const existing = container.querySelector('.ops-elev-form');
+    if (existing) { existing.remove(); return; }
+
+    const form = document.createElement('div');
+    form.className = 'ops-form ops-elev-form';
+    form.innerHTML = `
+      <div style="font-size:11px;font-weight:700;color:#ffd700;margin-bottom:12px">Grant Elevation: ${esc(agentName)}</div>
+      <div class="ops-form-row">
+        <label class="ops-form-label">Role</label>
+        <select id="ef-role">
+          <option value="admin">Admin</option>
+          <option value="lead">Lead</option>
+          <option value="supervisor">Supervisor</option>
+        </select>
+      </div>
+      <div class="ops-form-row">
+        <label class="ops-form-label">Duration</label>
+        <select id="ef-duration">
+          <option value="15m">15 minutes</option>
+          <option value="30m">30 minutes</option>
+          <option value="1h" selected>1 hour</option>
+          <option value="2h">2 hours</option>
+          <option value="4h">4 hours</option>
+          <option value="24h">24 hours</option>
+        </select>
+      </div>
+      <div class="ops-form-row">
+        <label class="ops-form-label">Reason (optional)</label>
+        <input type="text" id="ef-reason" placeholder="e.g. deployment supervision" />
+      </div>
+      <div class="ops-form-actions">
+        <button class="ops-btn ops-btn-success" id="ef-save">GRANT</button>
+        <button class="ops-btn" id="ef-cancel">CANCEL</button>
+      </div>
+    `;
+    container.appendChild(form);
+    form.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+
+    form.querySelector('#ef-cancel').addEventListener('click', () => form.remove());
+    form.querySelector('#ef-save').addEventListener('click', async () => {
+      const data = {
+        project: this.project,
+        agent: agentName,
+        role: form.querySelector('#ef-role').value,
+        granted_by: 'user',
+        duration: form.querySelector('#ef-duration').value,
+        reason: form.querySelector('#ef-reason').value,
+      };
+      await this.client.grantElevation(data);
+      this._renderAgents();
+    });
+  }
+
+  // ═══════════════════════════════════════
+  // TRIGGERS TAB
+  // ═══════════════════════════════════════
+
+  async _renderTriggers() {
+    const content = this._contentEl;
+    content.innerHTML = '<div class="ops-empty"><div class="ops-empty-icon">&#9889;</div>Loading triggers...</div>';
+
+    const [triggers, history] = await Promise.all([
+      this.client.fetchTriggers(this.project),
+      this.client.fetchTriggerHistory(this.project),
+    ]);
+
+    content.innerHTML = '';
+
+    const layout = document.createElement('div');
+    layout.className = 'ops-triggers-layout';
+
+    // Left: rules
+    const rulesCol = document.createElement('div');
+    rulesCol.className = 'ops-triggers-rules';
+
+    const addBtn = document.createElement('button');
+    addBtn.className = 'ops-btn';
+    addBtn.textContent = '+ NEW TRIGGER';
+    addBtn.style.marginBottom = '12px';
+    addBtn.addEventListener('click', () => this._showTriggerForm(rulesCol, addBtn));
+    rulesCol.appendChild(addBtn);
+
+    if (!triggers || triggers.length === 0) {
+      const empty = document.createElement('div');
+      empty.className = 'ops-empty';
+      empty.innerHTML = '<div class="ops-empty-icon">&#9889;</div>No triggers configured';
+      rulesCol.appendChild(empty);
+    } else {
+      for (const tr of triggers) {
+        rulesCol.appendChild(this._triggerCard(tr));
+      }
+    }
+
+    // Right: history
+    const histCol = document.createElement('div');
+    histCol.className = 'ops-triggers-history';
+    this._renderHistoryColumn(histCol, history);
+
+    layout.appendChild(rulesCol);
+    layout.appendChild(histCol);
+    content.appendChild(layout);
+
+    // Auto-refresh history every 5s
+    const timer = setInterval(async () => {
+      if (!this._visible || this.activeTab !== 'triggers') return;
+      const h = await this.client.fetchTriggerHistory(this.project);
+      this._renderHistoryColumn(histCol, h);
+    }, 5000);
+    this._timers.push(timer);
+  }
+
+  _triggerCard(tr) {
+    const card = document.createElement('div');
+    card.className = 'ops-card';
+
+    const header = document.createElement('div');
+    header.className = 'ops-card-header';
+
+    const left = document.createElement('div');
+    const evSpan = document.createElement('span');
+    evSpan.className = 'ops-trigger-event';
+    evSpan.textContent = tr.event_name || tr.event || '(any)';
+    left.appendChild(evSpan);
+
+    const actions = document.createElement('div');
+    actions.className = 'ops-trigger-actions';
+
+    const toggle = document.createElement('div');
+    toggle.className = `ops-toggle${tr.enabled !== false ? ' on' : ''}`;
+    toggle.title = tr.enabled !== false ? 'Enabled' : 'Disabled';
+    actions.appendChild(toggle);
+
+    const delBtn = document.createElement('button');
+    delBtn.className = 'ops-btn ops-btn-danger ops-btn-sm';
+    delBtn.textContent = 'DEL';
+    delBtn.addEventListener('click', async () => {
+      await this.client.deleteTrigger(tr.id);
+      this._renderTriggers();
+    });
+    actions.appendChild(delBtn);
+
+    header.appendChild(left);
+    header.appendChild(actions);
+    card.appendChild(header);
+
+    // Meta
+    const meta = document.createElement('div');
+    meta.className = 'ops-trigger-meta';
+    if (tr.profile_slug) meta.innerHTML += `<span>Profile: <b>${esc(tr.profile_slug)}</b></span>`;
+    if (tr.cycle) meta.innerHTML += `<span>Cycle: ${esc(tr.cycle)}</span>`;
+    if (tr.cooldown_seconds) meta.innerHTML += `<span>Cooldown: ${tr.cooldown_seconds}s</span>`;
+    if (tr.max_duration && tr.max_duration !== '10m') meta.innerHTML += `<span>Max: ${esc(tr.max_duration)}</span>`;
+    card.appendChild(meta);
+
+    // Match rules — visual pills instead of raw JSON
+    if (tr.match_rules && tr.match_rules !== '{}') {
+      try {
+        const parsed = JSON.parse(tr.match_rules);
+        const keys = Object.keys(parsed).filter(k => parsed[k] !== '');
+        if (keys.length > 0) {
+          const rulesEl = document.createElement('div');
+          rulesEl.className = 'ops-trigger-rules';
+          rulesEl.style.cssText = 'display:flex;flex-wrap:wrap;gap:4px;padding:6px 0;';
+          for (const key of keys) {
+            const val = parsed[key];
+            let op = '=';
+            let displayVal = val;
+            if (typeof val === 'string') {
+              if (val.startsWith('>')) { op = '>'; displayVal = val.slice(1); }
+              else if (val.startsWith('<')) { op = '<'; displayVal = val.slice(1); }
+              else if (val.startsWith('!')) { op = '\u2260'; displayVal = val.slice(1); }
+              else if (val.startsWith('~')) { op = '\u2248'; displayVal = val.slice(1); }
+            }
+            const pill = document.createElement('span');
+            pill.style.cssText = 'display:inline-flex;align-items:center;gap:3px;font-size:9px;background:rgba(108,92,231,0.1);border:1px solid rgba(108,92,231,0.2);border-radius:3px;padding:2px 8px;color:#a29bfe;';
+            pill.innerHTML = `<b>${esc(key)}</b> <span style="color:#636e72">${op}</span> <span style="color:#dfe6e9">${esc(displayVal)}</span>`;
+            rulesEl.appendChild(pill);
+          }
+          card.appendChild(rulesEl);
+        } else {
+          const noRules = document.createElement('div');
+          noRules.style.cssText = 'font-size:9px;color:#636e72;padding:4px 0;';
+          noRules.textContent = 'Matches all events';
+          card.appendChild(noRules);
+        }
+      } catch {
+        // Fallback: show raw
+        const rules = document.createElement('div');
+        rules.className = 'ops-trigger-rules';
+        rules.textContent = tr.match_rules;
+        card.appendChild(rules);
+      }
+    }
+
+    return card;
+  }
+
+  _renderHistoryColumn(el, history) {
+    el.innerHTML = '';
+    const title = document.createElement('div');
+    title.className = 'ops-history-title';
+    title.textContent = 'FIRE HISTORY';
+    el.appendChild(title);
+
+    if (!history || history.length === 0) {
+      const empty = document.createElement('div');
+      empty.style.cssText = 'color:#636e72;font-size:9px;text-align:center;padding:20px';
+      empty.textContent = 'No fires yet';
+      el.appendChild(empty);
+      return;
+    }
+
+    for (const h of history.slice(0, 50)) {
+      const item = document.createElement('div');
+      item.className = `ops-history-item ${h.error ? 'error' : 'success'}`;
+
+      let html = `<div class="ops-history-time">${fmtTime(h.fired_at || h.created_at)}</div>`;
+      html += `<div class="ops-history-event">${esc(h.event_name || h.event || '')}</div>`;
+      if (h.child_id) {
+        html += `<div class="ops-history-child" data-child="${esc(h.child_id)}">&#8594; ${esc(h.child_id)}</div>`;
+      }
+      if (h.error) {
+        html += `<div class="ops-history-error">${esc(h.error)}</div>`;
+      }
+      item.innerHTML = html;
+      el.appendChild(item);
+    }
+  }
+
+  async _showTriggerForm(parent, afterEl) {
+    // Remove existing form if any
+    const existing = parent.querySelector('.ops-form');
+    if (existing) { existing.remove(); return; }
+
+    // Fetch profiles + custom events for dropdowns
+    let profiles = [];
+    let customEvents = [];
+    try {
+      const [pRes, eRes] = await Promise.all([
+        fetch(`/api/profiles?project=${encodeURIComponent(this.project)}`),
+        fetch(`/api/custom-events?project=${encodeURIComponent(this.project)}`),
+      ]);
+      if (pRes.ok) profiles = await pRes.json();
+      if (eRes.ok) customEvents = await eRes.json();
+    } catch { /* ignore */ }
+
+    // Known system events
+    const EVENTS = [
+      { value: 'message_received',  label: 'Message Received',  icon: '\uD83D\uDCE8', meta: ['from_agent', 'to_agent', 'subject', 'type', 'priority'] },
+      { value: 'signal:interrupt',  label: 'P0 Interrupt',      icon: '\uD83D\uDEA8', meta: ['from_agent', 'to_agent', 'subject', 'priority'] },
+      { value: 'task_pending',      label: 'Task Dispatched',   icon: '\uD83D\uDCCB', meta: ['task_id', 'profile', 'priority', 'dispatched_by', 'title'] },
+      { value: 'task_completed',    label: 'Task Completed',    icon: '\u2705',       meta: ['task_id', 'profile', 'completed_by', 'title'] },
+      { value: 'task_blocked',      label: 'Task Blocked',      icon: '\uD83D\uDED1', meta: ['task_id', 'profile', 'blocked_by', 'title', 'reason'] },
+      { value: 'signal:alert',      label: 'Alert Signal',      icon: '\u26A0\uFE0F', meta: ['task_id', 'profile', 'blocked_by', 'reason'] },
+    ];
+
+    const COOLDOWNS = [
+      { label: 'None', value: 0 },
+      { label: '30s', value: 30 },
+      { label: '1 min', value: 60 },
+      { label: '5 min', value: 300 },
+      { label: '10 min', value: 600 },
+      { label: '30 min', value: 1800 },
+      { label: '1 hour', value: 3600 },
+    ];
+
+    const form = document.createElement('div');
+    form.className = 'ops-form';
+
+    // ── Event select ──
+    const eventRow = document.createElement('div');
+    eventRow.className = 'ops-form-row';
+    eventRow.innerHTML = '<label class="ops-form-label">WHEN THIS EVENT FIRES</label>';
+    const eventSelect = document.createElement('select');
+    eventSelect.id = 'ops-tf-event';
+    let eventOptions = '<option value="" disabled selected>-- Choose an event --</option>'
+      + '<optgroup label="System Events">'
+      + EVENTS.map(e => `<option value="${e.value}">${e.icon}  ${e.label}</option>`).join('')
+      + '</optgroup>';
+    if (customEvents.length > 0) {
+      eventOptions += '<optgroup label="Your Events">'
+        + customEvents.map(e => {
+          const icon = e.icon || '\uD83D\uDD36';
+          return `<option value="${esc(e.name)}" data-custom="1">${icon}  ${esc(e.name)}${e.description ? ' \u2014 ' + esc(e.description) : ''}</option>`;
+        }).join('')
+        + '</optgroup>';
+    }
+    eventOptions += '<optgroup label="New">'
+      + '<option value="__custom__">\u270F\uFE0F  Custom event name...</option>'
+      + '<option value="__create__">\u2795  Create &amp; register new event...</option>'
+      + '</optgroup>';
+    eventSelect.innerHTML = eventOptions;
+    eventRow.appendChild(eventSelect);
+
+    // Custom event input (hidden by default)
+    const customEventInput = document.createElement('input');
+    customEventInput.type = 'text';
+    customEventInput.placeholder = 'my_custom_event';
+    customEventInput.style.cssText = 'display:none;margin-top:6px;';
+    customEventInput.id = 'ops-tf-event-custom';
+    eventRow.appendChild(customEventInput);
+
+    // Create new event panel (hidden by default)
+    const createEventPanel = document.createElement('div');
+    createEventPanel.style.cssText = 'display:none;margin-top:8px;background:rgba(108,92,231,0.06);border:1px solid rgba(108,92,231,0.15);border-radius:4px;padding:10px;';
+    createEventPanel.innerHTML = `
+      <div style="font-size:8px;color:#636e72;font-weight:600;letter-spacing:0.5px;margin-bottom:6px;">REGISTER NEW EVENT TYPE</div>
+      <input type="text" id="ops-ce-name" placeholder="event_name (e.g. deploy_done)" style="width:100%;margin-bottom:6px;font-size:10px;" />
+      <input type="text" id="ops-ce-desc" placeholder="Short description (optional)" style="width:100%;margin-bottom:6px;font-size:10px;" />
+      <input type="text" id="ops-ce-meta" placeholder="Meta fields, comma-separated: branch, status, author" style="width:100%;margin-bottom:6px;font-size:10px;" />
+      <div style="display:flex;gap:6px;align-items:center;">
+        <input type="text" id="ops-ce-icon" placeholder="Icon (emoji)" style="width:50px;font-size:10px;" maxlength="4" />
+        <button class="ops-btn ops-btn-success" id="ops-ce-save" style="font-size:9px;padding:4px 10px;">REGISTER</button>
+        <div id="ops-ce-status" style="font-size:9px;color:#00b894;"></div>
+      </div>
+      <div style="font-size:8px;color:#636e72;margin-top:6px;">Once registered, this event appears in the dropdown. Fire it via:<br><code style="color:#a29bfe;">POST /api/webhooks/{project}/{name}</code></div>
+    `;
+    eventRow.appendChild(createEventPanel);
+
+    // Wire up create event button (after DOM is appended)
+    setTimeout(() => {
+      const saveBtn = createEventPanel.querySelector('#ops-ce-save');
+      if (saveBtn) saveBtn.addEventListener('click', async () => {
+        const name = createEventPanel.querySelector('#ops-ce-name').value.trim();
+        if (!name) return;
+        const desc = createEventPanel.querySelector('#ops-ce-desc').value.trim();
+        const metaRaw = createEventPanel.querySelector('#ops-ce-meta').value.trim();
+        const icon = createEventPanel.querySelector('#ops-ce-icon').value.trim();
+        const metaFields = metaRaw ? JSON.stringify(metaRaw.split(',').map(s => s.trim()).filter(Boolean)) : '[]';
+
+        const res = await fetch('/api/custom-events', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ project: this.project, name, description: desc, meta_fields: metaFields, icon: icon || '\uD83D\uDD36' }),
+        });
+        if (res.ok) {
+          const evt = await res.json();
+          customEvents.push(evt);
+          // Add to dropdown
+          const yourGroup = eventSelect.querySelector('optgroup[label="Your Events"]')
+            || (() => { const g = document.createElement('optgroup'); g.label = 'Your Events'; eventSelect.insertBefore(g, eventSelect.lastElementChild); return g; })();
+          const opt = document.createElement('option');
+          opt.value = name;
+          opt.textContent = `${icon || '\uD83D\uDD36'}  ${name}${desc ? ' \u2014 ' + desc : ''}`;
+          opt.dataset.custom = '1';
+          yourGroup.appendChild(opt);
+          // Auto-select it
+          eventSelect.value = name;
+          createEventPanel.style.display = 'none';
+          updateMetaPreview(name);
+          createEventPanel.querySelector('#ops-ce-status').textContent = '\u2713 Registered!';
+        }
+      });
+    }, 0);
+
+    // Meta preview
+    const metaPreview = document.createElement('div');
+    metaPreview.style.cssText = 'margin-top:6px;';
+    eventRow.appendChild(metaPreview);
+    form.appendChild(eventRow);
+
+    const updateMetaPreview = (eventVal) => {
+      // Check system events
+      const sysDef = EVENTS.find(e => e.value === eventVal);
+      if (sysDef && sysDef.meta.length) {
+        renderMetaTags(sysDef.meta);
+        return;
+      }
+      // Check custom events
+      const custDef = customEvents.find(e => e.name === eventVal);
+      if (custDef) {
+        try {
+          const fields = JSON.parse(custDef.meta_fields || '[]');
+          if (fields.length) { renderMetaTags(fields); return; }
+        } catch { /* ignore */ }
+        metaPreview.innerHTML = '<div style="font-size:9px;color:#636e72;">No meta fields defined for this event. Edit it to add fields.</div>';
+        return;
+      }
+      if (eventVal === '__custom__' || eventVal === '__create__') {
+        metaPreview.innerHTML = '';
+      } else if (eventVal) {
+        metaPreview.innerHTML = '<div style="font-size:9px;color:#636e72;">Webhook body JSON keys become meta fields</div>';
+      } else {
+        metaPreview.innerHTML = '';
+      }
+    };
+
+    function renderMetaTags(fields) {
+      metaPreview.innerHTML = `<div style="font-size:8px;color:#636e72;font-weight:600;letter-spacing:0.5px;margin-bottom:4px;">AVAILABLE FIELDS \u2014 click to add as condition</div>`
+        + fields.map(m => `<span style="display:inline-block;font-size:9px;background:rgba(108,92,231,0.12);color:#a29bfe;border:1px solid rgba(108,92,231,0.2);border-radius:3px;padding:2px 6px;margin:2px 3px 2px 0;cursor:pointer;" data-field="${m}">${m}</span>`).join('');
+      metaPreview.querySelectorAll('[data-field]').forEach(tag => {
+        tag.addEventListener('click', () => addMatchRule(tag.dataset.field, 'eq', ''));
+      });
+    }
+
+    eventSelect.addEventListener('change', () => {
+      if (eventSelect.value === '__custom__') {
+        customEventInput.style.display = 'block';
+        customEventInput.focus();
+        createEventPanel.style.display = 'none';
+      } else if (eventSelect.value === '__create__') {
+        customEventInput.style.display = 'none';
+        createEventPanel.style.display = 'block';
+      } else {
+        customEventInput.style.display = 'none';
+        createEventPanel.style.display = 'none';
+      }
+      updateMetaPreview(eventSelect.value);
+    });
+
+    // ── Match rules builder ──
+    const rulesRow = document.createElement('div');
+    rulesRow.className = 'ops-form-row';
+    rulesRow.innerHTML = '<label class="ops-form-label">ONLY IF (MATCH RULES) <span style="color:#636e72;font-weight:400;">optional</span></label>';
+    const rulesContainer = document.createElement('div');
+    rulesContainer.id = 'ops-tf-rules-list';
+    rulesContainer.style.cssText = 'display:flex;flex-direction:column;gap:6px;';
+    rulesRow.appendChild(rulesContainer);
+
+    const addRuleBtn = document.createElement('button');
+    addRuleBtn.className = 'ops-btn';
+    addRuleBtn.textContent = '+ Add condition';
+    addRuleBtn.style.cssText = 'margin-top:6px;font-size:9px;padding:4px 10px;';
+    addRuleBtn.addEventListener('click', () => addMatchRule('', 'eq', ''));
+    rulesRow.appendChild(addRuleBtn);
+    form.appendChild(rulesRow);
+
+    function addMatchRule(field, op, value) {
+      const row = document.createElement('div');
+      row.style.cssText = 'display:flex;gap:4px;align-items:center;';
+      row.innerHTML = `
+        <input type="text" class="mr-field" value="${esc(field)}" placeholder="field" style="flex:1;font-size:10px;" />
+        <select class="mr-op" style="width:60px;font-size:10px;">
+          <option value="eq" ${op === 'eq' ? 'selected' : ''}>=</option>
+          <option value="neq" ${op === 'neq' ? 'selected' : ''}>\u2260</option>
+          <option value="contains" ${op === 'contains' ? 'selected' : ''}>contains</option>
+          <option value="gt" ${op === 'gt' ? 'selected' : ''}>&gt;</option>
+          <option value="lt" ${op === 'lt' ? 'selected' : ''}>&lt;</option>
+        </select>
+        <input type="text" class="mr-value" value="${esc(value)}" placeholder="value" style="flex:1;font-size:10px;" />
+      `;
+      const delBtn = document.createElement('button');
+      delBtn.textContent = '\u2715';
+      delBtn.style.cssText = 'background:none;border:none;color:#636e72;cursor:pointer;font-size:11px;padding:2px 4px;';
+      delBtn.addEventListener('click', () => row.remove());
+      row.appendChild(delBtn);
+      rulesContainer.appendChild(row);
+    }
+
+    // ── Profile select ──
+    const profileRow = document.createElement('div');
+    profileRow.className = 'ops-form-row';
+    profileRow.innerHTML = '<label class="ops-form-label">SPAWN THIS PROFILE</label>';
+    const profileSelect = document.createElement('select');
+    profileSelect.id = 'ops-tf-profile';
+    if (profiles.length > 0) {
+      profileSelect.innerHTML = '<option value="" disabled selected>-- Choose a profile --</option>'
+        + profiles.map(p => `<option value="${esc(p.slug)}">${esc(p.slug)} \u2014 ${esc(p.role || p.name || '')}</option>`).join('');
+    } else {
+      profileSelect.innerHTML = '<option value="" disabled selected>No profiles found</option>';
+    }
+    profileRow.appendChild(profileSelect);
+    form.appendChild(profileRow);
+
+    // ── Cycle + Cooldown row ──
+    const bottomRow = document.createElement('div');
+    bottomRow.className = 'ops-form-row';
+    bottomRow.style.cssText = 'display:flex;gap:12px;';
+
+    // Cycle input
+    const cycleDiv = document.createElement('div');
+    cycleDiv.style.cssText = 'flex:1;';
+    cycleDiv.innerHTML = '<label class="ops-form-label">CYCLE</label>';
+    const cycleInput = document.createElement('input');
+    cycleInput.type = 'text';
+    cycleInput.id = 'ops-tf-cycle';
+    cycleInput.placeholder = 'default';
+    cycleInput.value = 'default';
+    cycleDiv.appendChild(cycleInput);
+    bottomRow.appendChild(cycleDiv);
+
+    // Cooldown select
+    const cdDiv = document.createElement('div');
+    cdDiv.style.cssText = 'flex:1;';
+    cdDiv.innerHTML = '<label class="ops-form-label">COOLDOWN</label>';
+    const cdSelect = document.createElement('select');
+    cdSelect.id = 'ops-tf-cooldown';
+    cdSelect.innerHTML = COOLDOWNS.map(c => `<option value="${c.value}">${c.label}</option>`).join('');
+    cdSelect.value = '60';
+    cdDiv.appendChild(cdSelect);
+    bottomRow.appendChild(cdDiv);
+
+    // Max duration select
+    const durDiv = document.createElement('div');
+    durDiv.style.cssText = 'flex:1;';
+    durDiv.innerHTML = '<label class="ops-form-label">MAX DURATION</label>';
+    const durSelect = document.createElement('select');
+    durSelect.id = 'ops-tf-duration';
+    durSelect.innerHTML = '<option value="5m">5 min</option><option value="10m" selected>10 min</option><option value="30m">30 min</option><option value="1h">1 hour</option>';
+    durDiv.appendChild(durSelect);
+    bottomRow.appendChild(durDiv);
+
+    form.appendChild(bottomRow);
+
+    // ── Actions ──
+    const actions = document.createElement('div');
+    actions.className = 'ops-form-actions';
+    actions.innerHTML = `
+      <button class="ops-btn ops-btn-success" id="ops-tf-save">CREATE TRIGGER</button>
+      <button class="ops-btn" id="ops-tf-cancel">CANCEL</button>
+    `;
+    form.appendChild(actions);
+
+    afterEl.after(form);
+
+    form.querySelector('#ops-tf-cancel').addEventListener('click', () => form.remove());
+    form.querySelector('#ops-tf-save').addEventListener('click', async () => {
+      // Resolve event name
+      let event = eventSelect.value;
+      if (event === '__custom__') event = customEventInput.value;
+      if (!event) return;
+
+      // Build match rules from visual builder
+      const ruleRows = rulesContainer.querySelectorAll('div');
+      const rules = {};
+      ruleRows.forEach(row => {
+        const field = row.querySelector('.mr-field')?.value?.trim();
+        const op = row.querySelector('.mr-op')?.value;
+        const value = row.querySelector('.mr-value')?.value?.trim();
+        if (field && value) {
+          if (op === 'gt') rules[field] = '>' + value;
+          else if (op === 'lt') rules[field] = '<' + value;
+          else if (op === 'neq') rules[field] = '!' + value;
+          else if (op === 'contains') rules[field] = '~' + value;
+          else rules[field] = value; // eq
+        }
+      });
+
+      const data = {
+        project: this.project,
+        event: event,
+        match_rules: JSON.stringify(rules),
+        profile_slug: profileSelect.value,
+        cycle: cycleInput.value || 'default',
+        max_duration: durSelect.value,
+      };
+
+      if (!data.profile_slug) return;
+
+      await this.client.createTrigger(data);
+      form.remove();
+      this._renderTriggers();
+    });
+  }
+
+  // ═══════════════════════════════════════
+  // POLLS TAB
+  // ═══════════════════════════════════════
+
+  async _renderPolls() {
+    const content = this._contentEl;
+    content.innerHTML = '<div class="ops-empty"><div class="ops-empty-icon">&#128225;</div>Loading polls...</div>';
+
+    const polls = await this.client.fetchPollTriggers(this.project);
+    content.innerHTML = '';
+
+    const addBtn = document.createElement('button');
+    addBtn.className = 'ops-btn';
+    addBtn.textContent = '+ NEW POLL';
+    addBtn.style.marginBottom = '12px';
+    addBtn.addEventListener('click', () => this._showPollForm(content, addBtn));
+    content.appendChild(addBtn);
+
+    if (!polls || polls.length === 0) {
+      const empty = document.createElement('div');
+      empty.className = 'ops-empty';
+      empty.innerHTML = '<div class="ops-empty-icon">&#128225;</div>No poll triggers configured';
+      content.appendChild(empty);
+      return;
+    }
+
+    for (const p of polls) {
+      content.appendChild(this._pollCard(p));
+    }
+
+    // Auto-refresh every 10s
+    const timer = setInterval(async () => {
+      if (!this._visible || this.activeTab !== 'polls') return;
+      const updated = await this.client.fetchPollTriggers(this.project);
+      // Only refresh if still on this tab
+      if (this.activeTab === 'polls') {
+        const cards = content.querySelectorAll('.ops-card');
+        // Simple: re-render if count changed
+        if (cards.length !== (updated || []).length) {
+          this._renderPolls();
+        }
+      }
+    }, 10000);
+    this._timers.push(timer);
+  }
+
+  _pollCard(p) {
+    const card = document.createElement('div');
+    card.className = 'ops-card';
+
+    const header = document.createElement('div');
+    header.className = 'ops-card-header';
+
+    const left = document.createElement('div');
+    left.innerHTML = `<span class="ops-card-title">${esc(p.name || p.id)}</span>`;
+    if (p.url) {
+      const urlEl = document.createElement('div');
+      urlEl.className = 'ops-poll-url';
+      urlEl.textContent = p.url;
+      left.appendChild(urlEl);
+    }
+
+    const actions = document.createElement('div');
+    actions.className = 'ops-trigger-actions';
+    actions.style.gap = '6px';
+
+    const testBtn = document.createElement('button');
+    testBtn.className = 'ops-btn ops-btn-sm';
+    testBtn.textContent = 'TEST NOW';
+    testBtn.addEventListener('click', async () => {
+      testBtn.textContent = '...';
+      try {
+        const result = await this.client.testPollTrigger(p.id);
+        const badge = document.createElement('span');
+        badge.className = 'ops-poll-result';
+        if (result && result.matched) {
+          badge.className += ' ops-badge-green';
+          badge.textContent = 'MATCHED';
+        } else if (result && result.error) {
+          badge.className += ' ops-badge-red';
+          badge.textContent = 'ERROR';
+        } else {
+          badge.className += ' ops-badge-gray';
+          badge.textContent = 'NO MATCH';
+        }
+        testBtn.textContent = 'TEST NOW';
+        // Insert badge after button, remove after 3s
+        const existing = actions.querySelector('.ops-poll-result');
+        if (existing) existing.remove();
+        actions.appendChild(badge);
+        setTimeout(() => badge.remove(), 3000);
+      } catch {
+        testBtn.textContent = 'TEST NOW';
+      }
+    });
+    actions.appendChild(testBtn);
+
+    const delBtn = document.createElement('button');
+    delBtn.className = 'ops-btn ops-btn-danger ops-btn-sm';
+    delBtn.textContent = 'DEL';
+    delBtn.addEventListener('click', async () => {
+      await this.client.deletePollTrigger(p.id);
+      this._renderPolls();
+    });
+    actions.appendChild(delBtn);
+
+    header.appendChild(left);
+    header.appendChild(actions);
+    card.appendChild(header);
+
+    // Condition
+    if (p.condition_path || p.condition_op) {
+      const cond = document.createElement('div');
+      cond.className = 'ops-poll-condition';
+      cond.textContent = `${p.condition_path || ''} ${p.condition_op || ''} ${p.condition_value || ''}`;
+      card.appendChild(cond);
+    }
+
+    // Meta
+    const meta = document.createElement('div');
+    meta.className = 'ops-trigger-meta';
+    if (p.interval_secs) meta.innerHTML += `<span>Every ${p.interval_secs}s</span>`;
+    if (p.fire_event) meta.innerHTML += `<span>Fires: <b>${esc(p.fire_event)}</b></span>`;
+    if (p.last_status) {
+      const cls = p.last_status === 'matched' ? 'green' : p.last_status === 'error' ? 'red' : 'gray';
+      meta.innerHTML += `<span class="ops-badge ops-badge-${cls}">${esc(p.last_status)}</span>`;
+    }
+    card.appendChild(meta);
+
+    return card;
+  }
+
+  _showPollForm(parent, afterEl) {
+    const existing = parent.querySelector('.ops-form');
+    if (existing) { existing.remove(); return; }
+
+    const form = document.createElement('div');
+    form.className = 'ops-form';
+    form.innerHTML = `
+      <div class="ops-form-row">
+        <label class="ops-form-label">Name</label>
+        <input type="text" id="ops-pf-name" placeholder="e.g. check-deploy-status" />
+      </div>
+      <div class="ops-form-row">
+        <label class="ops-form-label">URL</label>
+        <input type="text" id="ops-pf-url" placeholder="https://api.example.com/status" />
+      </div>
+      <div class="ops-form-row" style="display:flex;gap:8px">
+        <div style="flex:2">
+          <label class="ops-form-label">Condition Path</label>
+          <input type="text" id="ops-pf-path" placeholder="$.status" />
+        </div>
+        <div style="flex:1">
+          <label class="ops-form-label">Op</label>
+          <select id="ops-pf-op">
+            <option value="eq">eq</option>
+            <option value="neq">neq</option>
+            <option value="contains">contains</option>
+            <option value="gt">gt</option>
+            <option value="lt">lt</option>
+          </select>
+        </div>
+        <div style="flex:1">
+          <label class="ops-form-label">Value</label>
+          <input type="text" id="ops-pf-value" placeholder="ready" />
+        </div>
+      </div>
+      <div class="ops-form-row" style="display:flex;gap:8px">
+        <div style="flex:1">
+          <label class="ops-form-label">Interval (secs)</label>
+          <input type="number" id="ops-pf-interval" value="60" />
+        </div>
+        <div style="flex:1">
+          <label class="ops-form-label">Fire Event</label>
+          <input type="text" id="ops-pf-fire" placeholder="deploy.ready" />
+        </div>
+      </div>
+      <div class="ops-form-actions">
+        <button class="ops-btn ops-btn-success" id="ops-pf-save">CREATE</button>
+        <button class="ops-btn" id="ops-pf-cancel">CANCEL</button>
+      </div>
+    `;
+    afterEl.after(form);
+
+    form.querySelector('#ops-pf-cancel').addEventListener('click', () => form.remove());
+    form.querySelector('#ops-pf-save').addEventListener('click', async () => {
+      const data = {
+        project: this.project,
+        name: form.querySelector('#ops-pf-name').value,
+        url: form.querySelector('#ops-pf-url').value,
+        condition_path: form.querySelector('#ops-pf-path').value,
+        condition_op: form.querySelector('#ops-pf-op').value,
+        condition_value: form.querySelector('#ops-pf-value').value,
+        interval_secs: parseInt(form.querySelector('#ops-pf-interval').value) || 60,
+        fire_event: form.querySelector('#ops-pf-fire').value,
+      };
+      await this.client.createPollTrigger(data);
+      form.remove();
+      this._renderPolls();
+    });
+  }
+
+  // ═══════════════════════════════════════
+  // SKILLS TAB
+  // ═══════════════════════════════════════
+
+  async _renderSkills() {
+    const content = this._contentEl;
+    content.innerHTML = '<div class="ops-empty"><div class="ops-empty-icon">&#9733;</div>Loading skills...</div>';
+
+    const skills = await this.client.fetchSkills(this.project);
+    content.innerHTML = '';
+
+    const addBtn = document.createElement('button');
+    addBtn.className = 'ops-btn';
+    addBtn.textContent = '+ NEW SKILL';
+    addBtn.style.marginBottom = '12px';
+    addBtn.addEventListener('click', () => this._showSkillForm(content, addBtn));
+    content.appendChild(addBtn);
+
+    if (!skills || skills.length === 0) {
+      const empty = document.createElement('div');
+      empty.className = 'ops-empty';
+      empty.innerHTML = '<div class="ops-empty-icon">&#9733;</div>No skills registered';
+      content.appendChild(empty);
+      return;
+    }
+
+    for (const s of skills) {
+      content.appendChild(this._skillCard(s));
+    }
+  }
+
+  _skillCard(s) {
+    const card = document.createElement('div');
+    card.className = 'ops-card';
+
+    const header = document.createElement('div');
+    header.className = 'ops-card-header';
+
+    const left = document.createElement('div');
+    left.innerHTML = `<span class="ops-card-title">${esc(s.name)}</span>`;
+    if (s.description) {
+      const desc = document.createElement('div');
+      desc.className = 'ops-card-subtitle';
+      desc.textContent = s.description;
+      left.appendChild(desc);
+    }
+
+    const right = document.createElement('div');
+    right.style.display = 'flex';
+    right.style.gap = '6px';
+    right.style.alignItems = 'center';
+
+    // Agent count
+    if (s.agent_count !== undefined) {
+      const count = document.createElement('span');
+      count.className = 'ops-badge ops-badge-purple';
+      count.textContent = `${s.agent_count} agents`;
+      right.appendChild(count);
+    }
+
+    // Discover button
+    const discoverBtn = document.createElement('button');
+    discoverBtn.className = 'ops-btn ops-btn-sm';
+    discoverBtn.textContent = 'DISCOVER';
+    discoverBtn.addEventListener('click', () => this._discoverSkill(card, s.name));
+    right.appendChild(discoverBtn);
+
+    header.appendChild(left);
+    header.appendChild(right);
+    card.appendChild(header);
+
+    // Tags
+    if (s.tags && s.tags.length > 0) {
+      const tagsEl = document.createElement('div');
+      tagsEl.className = 'ops-skill-tags';
+      const tags = typeof s.tags === 'string' ? JSON.parse(s.tags) : s.tags;
+      for (const t of tags) {
+        const tag = document.createElement('span');
+        tag.className = 'ops-skill-tag';
+        tag.textContent = t;
+        tagsEl.appendChild(tag);
+      }
+      card.appendChild(tagsEl);
+    }
+
+    // Expandable profiles (click to load)
+    const expandBtn = document.createElement('button');
+    expandBtn.className = 'ops-btn ops-btn-sm';
+    expandBtn.style.marginTop = '8px';
+    expandBtn.textContent = 'SHOW PROFILES';
+    expandBtn.addEventListener('click', async () => {
+      if (card.querySelector('.ops-skill-profiles')) {
+        card.querySelector('.ops-skill-profiles').remove();
+        expandBtn.textContent = 'SHOW PROFILES';
+        return;
+      }
+      expandBtn.textContent = '...';
+      const profiles = await this.client.fetchSkillProfiles(s.name, this.project);
+      expandBtn.textContent = 'HIDE PROFILES';
+      const profilesEl = document.createElement('div');
+      profilesEl.className = 'ops-skill-profiles';
+      if (!profiles || profiles.length === 0) {
+        profilesEl.innerHTML = '<div style="color:#3a3e52;font-size:9px">No profiles linked</div>';
+      } else {
+        for (const p of profiles) {
+          const row = document.createElement('div');
+          row.className = 'ops-skill-profile';
+
+          const name = document.createElement('span');
+          name.className = 'ops-skill-profile-name';
+          name.textContent = p.profile_slug || p.name || p.profile;
+          row.appendChild(name);
+
+          // Proficiency dots (1-5)
+          const dots = document.createElement('div');
+          dots.className = 'ops-proficiency-dots';
+          const level = p.proficiency || 0;
+          for (let i = 1; i <= 5; i++) {
+            const dot = document.createElement('div');
+            dot.className = `ops-proficiency-dot${i <= level ? ' filled' : ''}`;
+            dots.appendChild(dot);
+          }
+          row.appendChild(dots);
+
+          profilesEl.appendChild(row);
+        }
+      }
+      card.appendChild(profilesEl);
+    });
+    card.appendChild(expandBtn);
+
+    return card;
+  }
+
+  async _discoverSkill(card, skillName) {
+    // Remove existing result
+    const existing = card.querySelector('.ops-discover-result');
+    if (existing) { existing.remove(); return; }
+
+    const result = await this.client.discoverBySkill(this.project, skillName);
+    const div = document.createElement('div');
+    div.className = 'ops-discover-result';
+
+    if (!result || !result.agents || result.agents.length === 0) {
+      div.innerHTML = '<div style="color:#3a3e52;font-size:9px">No active agents found</div>';
+    } else {
+      for (const a of result.agents) {
+        const row = document.createElement('div');
+        row.className = 'ops-discover-agent';
+
+        const dot = document.createElement('div');
+        dot.className = `ops-discover-dot ${a.active || a.online ? 'active' : 'inactive'}`;
+        row.appendChild(dot);
+
+        const name = document.createElement('span');
+        name.className = 'ops-discover-name';
+        name.textContent = a.name || a.profile_slug || a.agent;
+        name.addEventListener('click', () => {
+          if (this.onAgentClick) this.onAgentClick(this.project, a.name || a.profile_slug || a.agent);
+        });
+        row.appendChild(name);
+
+        if (a.role) {
+          const role = document.createElement('span');
+          role.className = 'ops-discover-role';
+          role.textContent = a.role;
+          row.appendChild(role);
+        }
+
+        div.appendChild(row);
+      }
+    }
+    card.appendChild(div);
+  }
+
+  _showSkillForm(parent, afterEl) {
+    const existing = parent.querySelector('.ops-form');
+    if (existing) { existing.remove(); return; }
+
+    const form = document.createElement('div');
+    form.className = 'ops-form';
+    form.innerHTML = `
+      <div class="ops-form-row">
+        <label class="ops-form-label">Skill Name</label>
+        <input type="text" id="ops-sf-name" placeholder="e.g. code-review" />
+      </div>
+      <div class="ops-form-row">
+        <label class="ops-form-label">Description</label>
+        <input type="text" id="ops-sf-desc" placeholder="Reviews pull requests" />
+      </div>
+      <div class="ops-form-row">
+        <label class="ops-form-label">Tags (comma-separated)</label>
+        <input type="text" id="ops-sf-tags" placeholder="backend, review, go" />
+      </div>
+      <div class="ops-form-actions">
+        <button class="ops-btn ops-btn-success" id="ops-sf-save">CREATE</button>
+        <button class="ops-btn" id="ops-sf-cancel">CANCEL</button>
+      </div>
+    `;
+    afterEl.after(form);
+
+    form.querySelector('#ops-sf-cancel').addEventListener('click', () => form.remove());
+    form.querySelector('#ops-sf-save').addEventListener('click', async () => {
+      const tagsRaw = form.querySelector('#ops-sf-tags').value;
+      const tags = tagsRaw ? tagsRaw.split(',').map(t => t.trim()).filter(Boolean) : [];
+      const data = {
+        project: this.project,
+        name: form.querySelector('#ops-sf-name').value,
+        description: form.querySelector('#ops-sf-desc').value,
+        tags,
+      };
+      await this.client.createSkill(data);
+      form.remove();
+      this._renderSkills();
+    });
+  }
+
+  // ═══════════════════════════════════════
+  // QUOTAS TAB
+  // ═══════════════════════════════════════
+
+  async _renderQuotas() {
+    const content = this._contentEl;
+    content.innerHTML = '<div class="ops-empty"><div class="ops-empty-icon">&#9632;</div>Loading quotas...</div>';
+
+    const quotas = await this.client.fetchQuotas(this.project);
+    content.innerHTML = '';
+
+    if (!quotas || quotas.length === 0) {
+      content.innerHTML = '<div class="ops-empty"><div class="ops-empty-icon">&#9632;</div>No quotas configured</div>';
+      return;
+    }
+
+    const table = document.createElement('table');
+    table.className = 'ops-quota-table';
+
+    const thead = document.createElement('thead');
+    thead.innerHTML = `<tr>
+      <th>Agent</th>
+      <th>Tokens/day</th>
+      <th>Msgs/hr</th>
+      <th>Tasks/hr</th>
+      <th>Spawns/hr</th>
+    </tr>`;
+    table.appendChild(thead);
+
+    const tbody = document.createElement('tbody');
+    for (const q of quotas) {
+      const row = document.createElement('tr');
+
+      // Check if any quota >80%
+      const ratios = [];
+      if (q.max_tokens_per_day && q.tokens_used) ratios.push(q.tokens_used / q.max_tokens_per_day);
+      if (q.max_messages_per_hour && q.messages_used) ratios.push(q.messages_used / q.max_messages_per_hour);
+      if (q.max_tasks_per_hour && q.tasks_used) ratios.push(q.tasks_used / q.max_tasks_per_hour);
+      if (q.max_spawns_per_hour && q.spawns_used) ratios.push(q.spawns_used / q.max_spawns_per_hour);
+      const maxRatio = ratios.length > 0 ? Math.max(...ratios) : 0;
+      if (maxRatio > 0.8) row.className = 'warning';
+
+      row.innerHTML = `
+        <td class="ops-quota-agent">${esc(q.agent || q.profile_slug || q.name)}${maxRatio > 0.8 ? '<span class="ops-quota-warning">&#9888;</span>' : ''}</td>
+        <td>${this._healthBar(q.tokens_used || 0, q.max_tokens_per_day || 0)}</td>
+        <td>${this._healthBar(q.messages_used || 0, q.max_messages_per_hour || 0)}</td>
+        <td>${this._healthBar(q.tasks_used || 0, q.max_tasks_per_hour || 0)}</td>
+        <td>${this._healthBar(q.spawns_used || 0, q.max_spawns_per_hour || 0)}</td>
+      `;
+
+      row.addEventListener('click', () => {
+        if (this.onAgentClick) this.onAgentClick(this.project, q.agent || q.profile_slug || q.name);
+      });
+
+      tbody.appendChild(row);
+    }
+    table.appendChild(tbody);
+    content.appendChild(table);
+  }
+
+  _healthBar(used, limit) {
+    if (!limit) return '<span style="color:#3a3e52">--</span>';
+    const ratio = Math.min(used / limit, 1);
+    const filled = Math.round(ratio * 10);
+    let html = '<div class="ops-health-bar">';
+    for (let i = 0; i < 10; i++) {
+      if (i < filled) {
+        const cls = ratio > 0.8 ? 'danger' : ratio > 0.6 ? 'warn' : 'filled';
+        html += `<div class="ops-health-seg ${cls}"></div>`;
+      } else {
+        html += '<div class="ops-health-seg"></div>';
+      }
+    }
+    html += `<span class="ops-quota-text">${used}/${limit}</span></div>`;
+    return html;
+  }
+
+  // ═══════════════════════════════════════
+  // AGENT DETAIL ENRICHMENT (static helpers)
+  // ═══════════════════════════════════════
+
+  static renderSkillsSection(el, skills) {
+    if (!el) return;
+    if (!skills || skills.length === 0) {
+      el.innerHTML = '<span style="color:#5a5e78">No skills</span>';
+      return;
+    }
+    el.innerHTML = skills.map(s => {
+      const level = s.proficiency || 0;
+      let dots = '';
+      for (let i = 1; i <= 5; i++) {
+        const filled = i <= level;
+        dots += `<span style="display:inline-block;width:6px;height:6px;border-radius:50%;margin-right:2px;${
+          filled ? 'background:#a29bfe;box-shadow:0 0 3px rgba(162,155,254,0.4)' : 'background:rgba(108,92,231,0.15);border:1px solid rgba(108,92,231,0.2)'
+        }"></span>`;
+      }
+      return `<div style="display:flex;align-items:center;gap:8px;padding:3px 0;font-size:10px">
+        <span style="color:#dfe6e9;font-weight:600;min-width:80px">${esc(s.name || s.skill_name)}</span>
+        <span>${dots}</span>
+      </div>`;
+    }).join('');
+  }
+
+  static renderQuotasSection(el, quota) {
+    if (!el) return;
+    if (!quota) {
+      el.innerHTML = '<span style="color:#5a5e78">No quotas</span>';
+      return;
+    }
+
+    const bars = [];
+    const metrics = [
+      { label: 'Tokens/day', used: quota.tokens_used || 0, limit: quota.max_tokens_per_day || 0 },
+      { label: 'Msgs/hr', used: quota.messages_used || 0, limit: quota.max_messages_per_hour || 0 },
+      { label: 'Tasks/hr', used: quota.tasks_used || 0, limit: quota.max_tasks_per_hour || 0 },
+      { label: 'Spawns/hr', used: quota.spawns_used || 0, limit: quota.max_spawns_per_hour || 0 },
+    ];
+
+    for (const m of metrics) {
+      if (!m.limit) continue;
+      const ratio = Math.min(m.used / m.limit, 1);
+      const filled = Math.round(ratio * 10);
+      let segs = '';
+      for (let i = 0; i < 10; i++) {
+        if (i < filled) {
+          const c = ratio > 0.8 ? '#ff6b6b' : ratio > 0.6 ? '#ffd93d' : '#00e676';
+          segs += `<span style="display:inline-block;width:7px;height:9px;margin-right:1px;background:${c};border-radius:1px;box-shadow:0 0 2px ${c}44"></span>`;
+        } else {
+          segs += `<span style="display:inline-block;width:7px;height:9px;margin-right:1px;background:rgba(30,30,50,0.6);border:1px solid rgba(108,92,231,0.15);border-radius:0"></span>`;
+        }
+      }
+      bars.push(`<div style="display:flex;align-items:center;gap:6px;padding:3px 0;font-size:9px">
+        <span style="color:#7a7e98;min-width:60px;text-transform:uppercase;letter-spacing:0.5px">${m.label}</span>
+        <span>${segs}</span>
+        <span style="color:#5a5e78;font-size:8px">${m.used}/${m.limit}</span>
+      </div>`);
+    }
+
+    el.innerHTML = bars.length > 0 ? bars.join('') : '<span style="color:#5a5e78">No limits set</span>';
+  }
+
+  // ═══════════════════════════════════════
+  // CYCLES TAB
+  // ═══════════════════════════════════════
+
+  async _renderCycles() {
+    const content = this._contentEl;
+    content.innerHTML = '<div class="ops-empty"><div class="ops-empty-icon">&#8634;</div>Loading cycles...</div>';
+
+    const cycles = await this.client.fetchCycles(this.project);
+    content.innerHTML = '';
+
+    // Add button
+    const addBtn = document.createElement('button');
+    addBtn.className = 'ops-btn';
+    addBtn.textContent = '+ NEW CYCLE';
+    addBtn.style.margin = '12px 16px';
+    addBtn.addEventListener('click', () => this._showCycleForm(content, addBtn));
+    content.appendChild(addBtn);
+
+    if (!cycles || cycles.length === 0) {
+      const empty = document.createElement('div');
+      empty.className = 'ops-empty';
+      empty.innerHTML = '<div class="ops-empty-icon">&#8634;</div>No cycles configured';
+      content.appendChild(empty);
+      return;
+    }
+
+    for (const c of cycles) {
+      content.appendChild(this._cycleCard(c));
+    }
+  }
+
+  _cycleCard(cycle) {
+    const card = document.createElement('div');
+    card.className = 'ops-card';
+    card.style.margin = '0 16px 8px';
+
+    const header = document.createElement('div');
+    header.className = 'ops-card-header';
+
+    const left = document.createElement('div');
+    const nameSpan = document.createElement('span');
+    nameSpan.className = 'ops-trigger-event';
+    nameSpan.textContent = cycle.name;
+    left.appendChild(nameSpan);
+
+    const ttlSpan = document.createElement('span');
+    ttlSpan.style.cssText = 'font-size:9px;color:#636e72;margin-left:8px;';
+    ttlSpan.textContent = `TTL: ${cycle.ttl || 10}m`;
+    left.appendChild(ttlSpan);
+
+    const actions = document.createElement('div');
+    actions.className = 'ops-trigger-actions';
+
+    const editBtn = document.createElement('button');
+    editBtn.className = 'ops-btn ops-btn-sm';
+    editBtn.textContent = 'EDIT';
+    editBtn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      this._showCycleForm(card.parentElement, card, cycle);
+    });
+    actions.appendChild(editBtn);
+
+    const delBtn = document.createElement('button');
+    delBtn.className = 'ops-btn ops-btn-danger ops-btn-sm';
+    delBtn.textContent = 'DEL';
+    delBtn.addEventListener('click', async (e) => {
+      e.stopPropagation();
+      await this.client.deleteCycle(cycle.name, this.project);
+      this._renderCycles();
+    });
+    actions.appendChild(delBtn);
+
+    header.appendChild(left);
+    header.appendChild(actions);
+    card.appendChild(header);
+
+    // Prompt preview
+    if (cycle.prompt) {
+      const prompt = document.createElement('div');
+      prompt.style.cssText = 'font-size:10px;color:#7a7e98;padding:6px 10px;max-height:60px;overflow:hidden;white-space:pre-wrap;line-height:1.4;';
+      prompt.textContent = cycle.prompt.length > 200 ? cycle.prompt.slice(0, 200) + '...' : cycle.prompt;
+      card.appendChild(prompt);
+    }
+
+    return card;
+  }
+
+  async _showCycleForm(parent, afterEl, existing = null) {
+    // Remove existing form
+    const old = parent.querySelector('.ops-form');
+    if (old) { old.remove(); return; }
+
+    const form = document.createElement('div');
+    form.className = 'ops-form';
+    form.style.margin = '0 16px 12px';
+
+    const isEdit = !!existing;
+
+    form.innerHTML = `
+      <div class="ops-form-title">${isEdit ? 'EDIT' : 'NEW'} CYCLE</div>
+      <div class="ops-form-row">
+        <label>Name</label>
+        <input type="text" class="ops-input" id="cycle-name" value="${esc(existing?.name || '')}" ${isEdit ? 'disabled' : ''} placeholder="e.g. heartbeat-5min" />
+      </div>
+      <div class="ops-form-row">
+        <label>TTL (minutes)</label>
+        <input type="number" class="ops-input" id="cycle-ttl" value="${existing?.ttl || 10}" min="1" placeholder="10" />
+      </div>
+      <div class="ops-form-row">
+        <label>Prompt</label>
+        <textarea class="ops-input" id="cycle-prompt" rows="6" placeholder="Instructions for the agent during this cycle...">${esc(existing?.prompt || '')}</textarea>
+      </div>
+      <div class="ops-form-actions">
+        <button class="ops-btn" id="cycle-save">${isEdit ? 'UPDATE' : 'CREATE'}</button>
+        <button class="ops-btn ops-btn-ghost" id="cycle-cancel">CANCEL</button>
+      </div>
+    `;
+
+    if (afterEl.nextSibling) {
+      parent.insertBefore(form, afterEl.nextSibling);
+    } else {
+      parent.appendChild(form);
+    }
+
+    form.querySelector('#cycle-cancel').addEventListener('click', () => form.remove());
+    form.querySelector('#cycle-save').addEventListener('click', async () => {
+      const name = form.querySelector('#cycle-name').value.trim();
+      const ttl = parseInt(form.querySelector('#cycle-ttl').value) || 10;
+      const prompt = form.querySelector('#cycle-prompt').value;
+
+      if (!name) return;
+
+      const data = { project: this.project, name, prompt, ttl };
+
+      if (isEdit) {
+        await this.client.updateCycle(name, data);
+      } else {
+        await this.client.createCycle(data);
+      }
+      this._renderCycles();
+    });
+  }
+
+  // ═══════════════════════════════════════
+  // FLOWS TAB
+  // ═══════════════════════════════════════
+
+  _renderFlows() {
+    const content = this._contentEl;
+    content.innerHTML = '';
+    content.style.padding = '0';
+    content.style.overflow = 'hidden';
+
+    // Create flow editor container that fills the content area
+    const flowContainer = document.createElement('div');
+    flowContainer.style.cssText = 'width:100%;height:100%;position:relative;';
+    content.appendChild(flowContainer);
+
+    // Lazy-init the FlowEditor
+    if (!this._flowEditor) {
+      this._flowEditor = new FlowEditor(flowContainer, this.client);
+    } else {
+      // Re-attach to new container
+      this._flowEditor.container = flowContainer;
+    }
+    this._flowEditor.show(this.project);
+  }
+
+  static renderElevationSection(el, elevations, client, project, agentName) {
+    if (!el) return;
+    if (!elevations || elevations.length === 0) {
+      // Show grant button
+      el.innerHTML = `<div style="display:flex;align-items:center;gap:8px">
+        <span style="color:#5a5e78;font-size:10px">No active elevation</span>
+      </div>`;
+      return;
+    }
+
+    el.innerHTML = elevations.map(e => {
+      const remaining = e.expires_at ? Math.max(0, Math.floor((new Date(e.expires_at) - Date.now()) / 1000)) : null;
+      const countdown = remaining !== null ? `${Math.floor(remaining / 60)}m ${remaining % 60}s remaining` : 'permanent';
+      return `<div style="display:flex;align-items:center;gap:8px;padding:6px 8px;background:rgba(255,215,0,0.06);border-left:2px solid rgba(255,215,0,0.4);border-radius:2px;margin-bottom:4px">
+        <span style="font-size:10px">&#9812;</span>
+        <span style="font-size:11px;font-weight:700;color:#ffd700">${esc(e.elevated_role || e.role)}</span>
+        <span style="font-size:9px;color:#5a5e78;margin-left:auto">${countdown}</span>
+      </div>
+      <div style="font-size:8px;color:#5a5e78">Granted by: ${esc(e.granted_by || '?')}</div>`;
+    }).join('');
+  }
+}

--- a/internal/web/static/style.css
+++ b/internal/web/static/style.css
@@ -185,35 +185,104 @@ main {
 }
 
 /* Layout modes */
-main.mode-canvas #canvas-container { flex: 2; }
+#left-column {
+  display: flex;
+  flex-direction: column;
+  flex: 2;
+  min-width: 200px;
+  overflow: visible;
+}
+
+main.mode-canvas #left-column { flex: 2; }
 main.mode-canvas #kanban-panel { display: none; }
 
-main.mode-detail #canvas-container { flex: 1; }
+main.mode-detail #left-column { flex: 1; }
 main.mode-detail #messages-panel { flex: 1; }
 main.mode-detail #kanban-panel { display: none; }
 
-main.mode-kanban #canvas-container { display: none !important; }
+main.mode-kanban #left-column { display: none !important; }
 main.mode-kanban #kanban-panel { flex: 1; display: flex !important; }
 main.mode-kanban #messages-panel { display: none !important; }
 main.mode-kanban #memories-panel { display: none !important; }
 main.mode-kanban #tasks-panel { display: none !important; }
 main.mode-kanban #vault-panel { display: none !important; }
+main.mode-kanban #ops-panel { display: none !important; }
 
-main.mode-vault #canvas-container { display: none !important; }
+main.mode-vault #left-column { display: none !important; }
 main.mode-vault #vault-panel { flex: 1; display: flex !important; }
 main.mode-vault #kanban-panel { display: none !important; }
 main.mode-vault #messages-panel { display: none !important; }
 main.mode-vault #memories-panel { display: none !important; }
 main.mode-vault #tasks-panel { display: none !important; }
+main.mode-vault #ops-panel { display: none !important; }
+
+main.mode-ops #left-column { display: none !important; }
+main.mode-ops #ops-panel { flex: 1; display: flex !important; }
+main.mode-ops #kanban-panel { display: none !important; }
+main.mode-ops #vault-panel { display: none !important; }
+main.mode-ops #messages-panel { display: none !important; }
+main.mode-ops #memories-panel { display: none !important; }
+main.mode-ops #tasks-panel { display: none !important; }
 
 main.mode-canvas #vault-panel { display: none; }
+main.mode-canvas #ops-panel { display: none; }
 main.mode-detail #vault-panel { display: none; }
+main.mode-detail #ops-panel { display: none; }
+
+/* Agent focused: hide sidebar, full-width canvas+command panel */
+main.agent-focused #messages-panel,
+main.agent-focused #memories-panel,
+main.agent-focused #tasks-panel { display: none !important; }
+main.agent-focused #left-column { flex: 1; }
+/* Also hide header sidebar tabs when agent focused */
+main.agent-focused ~ #_dummy_ { /* selector anchor — real rule below */ }
+body:has(main.agent-focused) .header-tabs { opacity: 0.3; pointer-events: none; }
+
+#ops-panel {
+  flex-direction: column;
+  overflow: hidden;
+}
 
 #canvas-container {
-  flex: 2;
+  flex: 1;
   position: relative;
   overflow: hidden;
-  min-width: 200px;
+  min-height: 0;
+}
+
+/* Command Panel */
+#command-panel {
+  height: 280px;
+  min-height: 120px;
+  max-height: 60vh;
+  background: rgba(15, 15, 35, 0.98);
+  border-top: 2px solid rgba(108, 92, 231, 0.7);
+  box-shadow: 0 -4px 20px rgba(108, 92, 231, 0.15), inset 0 1px 0 rgba(108, 92, 231, 0.2);
+  overflow-y: auto;
+  display: none;
+  flex-direction: column;
+  flex-shrink: 0;
+}
+body.view-colony #command-panel {
+  display: flex !important;
+}
+
+#cmd-resize-handle {
+  height: 6px;
+  cursor: ns-resize;
+  background: linear-gradient(180deg, rgba(108, 92, 231, 0.15), rgba(108, 92, 231, 0.05));
+  border-top: 1px solid rgba(108, 92, 231, 0.4);
+  border-bottom: 1px solid rgba(108, 92, 231, 0.3);
+  flex-shrink: 0;
+  display: none;
+}
+body.view-colony #cmd-resize-handle {
+  display: block !important;
+}
+
+#cmd-resize-handle:hover {
+  background: rgba(108, 92, 231, 0.3);
+  box-shadow: 0 0 8px rgba(108, 92, 231, 0.4);
 }
 
 /* Colony zoom-in flash transition */
@@ -1178,7 +1247,7 @@ body.view-galaxy #memories-panel,
 body.view-galaxy #tasks-panel { display: none !important; }
 body.view-galaxy #kanban-panel { display: none !important; }
 body.view-galaxy #vault-panel { display: none !important; }
-body.view-galaxy #canvas-container { flex: 1 !important; }
+body.view-galaxy #left-column { flex: 1 !important; }
 body.view-galaxy .font-scale-toggle { display: none !important; }
 
 /* Colony mode: show everything normally */

--- a/internal/workflow/actions.go
+++ b/internal/workflow/actions.go
@@ -1,0 +1,145 @@
+package workflow
+
+import (
+	"context"
+	"fmt"
+)
+
+// execAction executes an action node.
+func (e *Engine) execAction(ctx context.Context, project string, node *Node, execData *execContext) (map[string]any, error) {
+	switch node.Type {
+	case "action:spawn":
+		return e.actionSpawn(ctx, project, node, execData)
+	case "action:message":
+		return e.actionMessage(ctx, project, node, execData)
+	case "action:task":
+		return e.actionTask(ctx, project, node, execData)
+	case "action:team_notify":
+		return e.actionTeamNotify(ctx, project, node, execData)
+	case "action:broadcast":
+		return e.actionBroadcast(ctx, project, node, execData)
+	case "action:webhook_out":
+		return e.actionWebhookOut(ctx, project, node, execData)
+	case "action:elevate":
+		return e.actionElevate(ctx, project, node, execData)
+	case "action:schedule":
+		return e.actionSchedule(ctx, project, node, execData)
+	case "action:task_transition":
+		return e.actionTaskTransition(ctx, project, node, execData)
+	default:
+		return nil, fmt.Errorf("unknown action type: %s", node.Type)
+	}
+}
+
+// actionSpawn spawns a child agent via SpawnWithContext.
+func (e *Engine) actionSpawn(ctx context.Context, project string, node *Node, execData *execContext) (map[string]any, error) {
+	profile := e.configStr(node, "profile", execData)
+	cycle := e.configStr(node, "cycle", execData)
+	taskID := e.configStr(node, "task_id", execData)
+
+	if profile == "" {
+		return nil, fmt.Errorf("action:spawn requires profile")
+	}
+	if cycle == "" {
+		cycle = "default"
+	}
+
+	if e.spawnMgr == nil {
+		return map[string]any{"status": "skipped", "reason": "spawn manager not available"}, nil
+	}
+
+	childID, err := e.spawnMgr.SpawnWithContext(project, profile, cycle, taskID)
+	if err != nil {
+		return nil, fmt.Errorf("spawn failed: %w", err)
+	}
+
+	return map[string]any{
+		"status":   "spawned",
+		"child_id": childID,
+		"profile":  profile,
+		"cycle":    cycle,
+	}, nil
+}
+
+// actionMessage sends a message via the relay.
+func (e *Engine) actionMessage(ctx context.Context, project string, node *Node, execData *execContext) (map[string]any, error) {
+	to := e.configStr(node, "to", execData)
+	subject := e.configStr(node, "subject", execData)
+	content := e.configStr(node, "content", execData)
+	msgType := e.configStr(node, "type", execData)
+
+	if to == "" || content == "" {
+		return nil, fmt.Errorf("action:message requires to and content")
+	}
+	if msgType == "" {
+		msgType = "notification"
+	}
+
+	if e.msgFunc == nil {
+		return map[string]any{"status": "skipped", "reason": "message function not configured"}, nil
+	}
+
+	err := e.msgFunc(project, "workflow-engine", to, msgType, subject, content)
+	if err != nil {
+		return nil, fmt.Errorf("send message: %w", err)
+	}
+
+	return map[string]any{
+		"status":  "sent",
+		"to":      to,
+		"subject": subject,
+	}, nil
+}
+
+// actionTask dispatches a task.
+func (e *Engine) actionTask(ctx context.Context, project string, node *Node, execData *execContext) (map[string]any, error) {
+	profile := e.configStr(node, "profile", execData)
+	title := e.configStr(node, "title", execData)
+	description := e.configStr(node, "description", execData)
+
+	if profile == "" || title == "" {
+		return nil, fmt.Errorf("action:task requires profile and title")
+	}
+
+	if e.taskFunc == nil {
+		return map[string]any{"status": "skipped", "reason": "task function not configured"}, nil
+	}
+
+	taskID, err := e.taskFunc(project, profile, title, description)
+	if err != nil {
+		return nil, fmt.Errorf("dispatch task: %w", err)
+	}
+
+	return map[string]any{
+		"status":  "dispatched",
+		"task_id": taskID,
+		"profile": profile,
+		"title":   title,
+	}, nil
+}
+
+// Stub implementations for Phase 3 action types
+
+func (e *Engine) actionTeamNotify(_ context.Context, project string, node *Node, execData *execContext) (map[string]any, error) {
+	return map[string]any{"status": "not_implemented", "type": "team_notify"}, nil
+}
+
+func (e *Engine) actionBroadcast(_ context.Context, project string, node *Node, execData *execContext) (map[string]any, error) {
+	return map[string]any{"status": "not_implemented", "type": "broadcast"}, nil
+}
+
+func (e *Engine) actionWebhookOut(_ context.Context, project string, node *Node, execData *execContext) (map[string]any, error) {
+	return map[string]any{"status": "not_implemented", "type": "webhook_out"}, nil
+}
+
+func (e *Engine) actionElevate(_ context.Context, project string, node *Node, execData *execContext) (map[string]any, error) {
+	return map[string]any{"status": "not_implemented", "type": "elevate"}, nil
+}
+
+func (e *Engine) actionSchedule(_ context.Context, project string, node *Node, execData *execContext) (map[string]any, error) {
+	return map[string]any{"status": "not_implemented", "type": "schedule"}, nil
+}
+
+func (e *Engine) actionTaskTransition(_ context.Context, project string, node *Node, execData *execContext) (map[string]any, error) {
+	return map[string]any{"status": "not_implemented", "type": "task_transition"}, nil
+}

--- a/internal/workflow/conditions.go
+++ b/internal/workflow/conditions.go
@@ -1,0 +1,97 @@
+package workflow
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// evalCondition evaluates a condition node and returns pass/fail output.
+func (e *Engine) evalCondition(node *Node, execData *execContext) (map[string]any, error) {
+	switch node.Type {
+	case "condition:match":
+		return e.evalMatch(node, execData)
+	case "condition:switch":
+		return e.evalSwitch(node, execData)
+	case "condition:cooldown":
+		return map[string]any{"passed": true}, nil // TODO: implement cooldown tracking
+	case "condition:quota_check":
+		return map[string]any{"passed": true}, nil // TODO: implement quota check
+	default:
+		return nil, fmt.Errorf("unknown condition type: %s", node.Type)
+	}
+}
+
+// evalMatch checks if a field in trigger meta matches a condition.
+func (e *Engine) evalMatch(node *Node, execData *execContext) (map[string]any, error) {
+	field := e.configStr(node, "field", execData)
+	op, _ := node.Config["op"].(string)
+	value := e.configStr(node, "value", execData)
+
+	if field == "" || op == "" {
+		return nil, fmt.Errorf("condition:match requires field and op")
+	}
+
+	// Get actual value from meta
+	actual := execData.Meta[field]
+
+	var passed bool
+	switch op {
+	case "eq", "==", "equals":
+		passed = actual == value
+	case "neq", "!=", "not_equals":
+		passed = actual != value
+	case "contains":
+		passed = strings.Contains(actual, value)
+	case "gt", ">":
+		a, errA := strconv.ParseFloat(actual, 64)
+		v, errV := strconv.ParseFloat(value, 64)
+		passed = errA == nil && errV == nil && a > v
+	case "lt", "<":
+		a, errA := strconv.ParseFloat(actual, 64)
+		v, errV := strconv.ParseFloat(value, 64)
+		passed = errA == nil && errV == nil && a < v
+	case "exists":
+		_, passed = execData.Meta[field]
+	default:
+		return nil, fmt.Errorf("unknown op: %s", op)
+	}
+
+	return map[string]any{
+		"passed": passed,
+		"field":  field,
+		"actual": actual,
+		"op":     op,
+		"value":  value,
+	}, nil
+}
+
+// evalSwitch does multi-branch routing based on field value.
+func (e *Engine) evalSwitch(node *Node, execData *execContext) (map[string]any, error) {
+	field := e.configStr(node, "field", execData)
+	actual := execData.Meta[field]
+
+	casesRaw, ok := node.Config["cases"]
+	if !ok {
+		return map[string]any{"matched_port": "default", "value": actual}, nil
+	}
+
+	// cases should be array of {value, port}
+	casesJSON, _ := json.Marshal(casesRaw)
+	var cases []struct {
+		Value string `json:"value"`
+		Port  string `json:"port"`
+	}
+	if err := json.Unmarshal(casesJSON, &cases); err != nil {
+		return map[string]any{"matched_port": "default", "value": actual}, nil
+	}
+
+	for _, c := range cases {
+		if actual == c.Value {
+			return map[string]any{"matched_port": c.Port, "value": actual}, nil
+		}
+	}
+
+	return map[string]any{"matched_port": "default", "value": actual}, nil
+}

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -1,0 +1,343 @@
+package workflow
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"strings"
+	"sync"
+	"text/template"
+	"time"
+
+	"agent-relay/internal/db"
+	"agent-relay/internal/spawn"
+)
+
+// Node represents a single node in the workflow DAG.
+type Node struct {
+	ID     string         `json:"id"`
+	Type   string         `json:"type"`   // e.g. "trigger:event", "condition:match", "action:spawn"
+	Label  string         `json:"label"`
+	Config map[string]any `json:"config"` // type-specific configuration
+	X      float64        `json:"x"`      // visual position
+	Y      float64        `json:"y"`      // visual position
+}
+
+// Edge represents a connection between two nodes.
+type Edge struct {
+	Source     string `json:"source"`
+	Target     string `json:"target"`
+	SourcePort string `json:"sourcePort,omitempty"`
+	TargetPort string `json:"targetPort,omitempty"`
+}
+
+// Engine executes workflow DAGs.
+type Engine struct {
+	db       *db.DB
+	spawnMgr *spawn.Manager
+	msgFunc  func(project, from, to, msgType, subject, content string) error // for action:message
+	taskFunc func(project, profile, title, desc string) (string, error)       // for action:task
+	logger   *log.Logger
+}
+
+// NewEngine creates a workflow engine.
+func NewEngine(database *db.DB, spawnMgr *spawn.Manager) *Engine {
+	return &Engine{
+		db:       database,
+		spawnMgr: spawnMgr,
+		logger:   log.Default(),
+	}
+}
+
+// SetMessageFunc sets the function used by action:message nodes.
+func (e *Engine) SetMessageFunc(fn func(project, from, to, msgType, subject, content string) error) {
+	e.msgFunc = fn
+}
+
+// SetTaskFunc sets the function used by action:task nodes.
+func (e *Engine) SetTaskFunc(fn func(project, profile, title, desc string) (string, error)) {
+	e.taskFunc = fn
+}
+
+// Execute runs a workflow with the given trigger metadata.
+func (e *Engine) Execute(ctx context.Context, wf *db.Workflow, triggerEvent string, triggerMeta map[string]string) (*db.WorkflowRun, error) {
+	// Parse nodes and edges from workflow JSON
+	var nodes []Node
+	var edges []Edge
+	if err := json.Unmarshal([]byte(wf.Nodes), &nodes); err != nil {
+		return nil, fmt.Errorf("parse nodes: %w", err)
+	}
+	if err := json.Unmarshal([]byte(wf.Edges), &edges); err != nil {
+		return nil, fmt.Errorf("parse edges: %w", err)
+	}
+
+	// Create workflow run
+	metaJSON, _ := json.Marshal(triggerMeta)
+	run, err := e.db.CreateWorkflowRun(wf.ID, wf.Project, triggerEvent, string(metaJSON))
+	if err != nil {
+		return nil, fmt.Errorf("create run: %w", err)
+	}
+
+	// Build adjacency list and node map
+	nodeMap := make(map[string]*Node, len(nodes))
+	children := make(map[string][]string) // nodeID -> downstream nodeIDs
+	parents := make(map[string][]string)  // nodeID -> upstream nodeIDs
+	for i := range nodes {
+		nodeMap[nodes[i].ID] = &nodes[i]
+	}
+	for _, edge := range edges {
+		children[edge.Source] = append(children[edge.Source], edge.Target)
+		parents[edge.Target] = append(parents[edge.Target], edge.Source)
+	}
+
+	// Find trigger node (entry point)
+	var triggerNode *Node
+	for _, n := range nodes {
+		if strings.HasPrefix(n.Type, "trigger:") {
+			triggerNode = nodeMap[n.ID]
+			break
+		}
+	}
+	if triggerNode == nil {
+		e.db.FinishWorkflowRun(run.ID, "failed", "no trigger node found")
+		return run, fmt.Errorf("no trigger node found")
+	}
+
+	// Execution context: stores node outputs for template resolution
+	execData := &execContext{
+		Event:       triggerEvent,
+		Meta:        triggerMeta,
+		NodeOutputs: make(map[string]map[string]any),
+		mu:          sync.RWMutex{},
+	}
+
+	// BFS execution from trigger node
+	err = e.executeBFS(ctx, run, triggerNode.ID, nodeMap, children, parents, wf.Project, execData)
+
+	if err != nil {
+		e.db.FinishWorkflowRun(run.ID, "failed", err.Error())
+	} else {
+		e.db.FinishWorkflowRun(run.ID, "completed", "")
+	}
+
+	return run, err
+}
+
+type execContext struct {
+	Event       string
+	Meta        map[string]string
+	NodeOutputs map[string]map[string]any
+	mu          sync.RWMutex
+}
+
+// executeBFS runs nodes in topological order (BFS from startID).
+func (e *Engine) executeBFS(ctx context.Context, run *db.WorkflowRun, startID string, nodeMap map[string]*Node, children, parents map[string][]string, project string, execData *execContext) error {
+	// Track completed nodes
+	completed := make(map[string]bool)
+	failed := make(map[string]bool)
+
+	// Queue starts with trigger node
+	queue := []string{startID}
+	completed[startID] = true // trigger node is auto-completed
+
+	// Create and complete trigger node run
+	triggerNR, _ := e.db.CreateNodeRun(run.ID, startID, nodeMap[startID].Type)
+	if triggerNR != nil {
+		metaJSON, _ := json.Marshal(execData.Meta)
+		e.db.UpdateNodeRun(triggerNR.ID, "completed", string(metaJSON), "")
+		execData.mu.Lock()
+		execData.NodeOutputs[startID] = map[string]any{"event": execData.Event, "meta": execData.Meta}
+		execData.mu.Unlock()
+	}
+
+	// Process downstream nodes
+	for len(queue) > 0 {
+		current := queue[0]
+		queue = queue[1:]
+
+		downstream := children[current]
+		if len(downstream) == 0 {
+			continue
+		}
+
+		// Fan-out: execute downstream nodes that have all parents completed
+		var wg sync.WaitGroup
+		var mu sync.Mutex
+		var firstErr error
+
+		for _, nextID := range downstream {
+			// Check all parents are completed
+			allDone := true
+			for _, pid := range parents[nextID] {
+				if !completed[pid] {
+					allDone = false
+					break
+				}
+			}
+			if !allDone {
+				continue
+			}
+
+			node := nodeMap[nextID]
+			if node == nil {
+				continue
+			}
+
+			wg.Add(1)
+			go func(nid string, n *Node) {
+				defer wg.Done()
+
+				// Create node run
+				nr, err := e.db.CreateNodeRun(run.ID, nid, n.Type)
+				if err != nil {
+					mu.Lock()
+					if firstErr == nil {
+						firstErr = err
+					}
+					failed[nid] = true
+					mu.Unlock()
+					return
+				}
+
+				// Execute the node
+				e.db.UpdateNodeRun(nr.ID, "running", "", "")
+				output, err := e.executeNode(ctx, project, n, execData)
+
+				if err != nil {
+					e.db.UpdateNodeRun(nr.ID, "failed", "{}", err.Error())
+					mu.Lock()
+					if firstErr == nil {
+						firstErr = err
+					}
+					failed[nid] = true
+					mu.Unlock()
+					return
+				}
+
+				// Store output
+				outputJSON, _ := json.Marshal(output)
+				e.db.UpdateNodeRun(nr.ID, "completed", string(outputJSON), "")
+
+				execData.mu.Lock()
+				execData.NodeOutputs[nid] = output
+				execData.mu.Unlock()
+
+				mu.Lock()
+				completed[nid] = true
+				queue = append(queue, nid)
+				mu.Unlock()
+			}(nextID, node)
+		}
+		wg.Wait()
+
+		if firstErr != nil {
+			return firstErr
+		}
+	}
+	return nil
+}
+
+// executeNode dispatches to the appropriate handler based on node type.
+func (e *Engine) executeNode(ctx context.Context, project string, node *Node, execData *execContext) (map[string]any, error) {
+	switch {
+	case strings.HasPrefix(node.Type, "condition:"):
+		return e.evalCondition(node, execData)
+	case strings.HasPrefix(node.Type, "action:"):
+		return e.execAction(ctx, project, node, execData)
+	default:
+		return nil, fmt.Errorf("unknown node type: %s", node.Type)
+	}
+}
+
+// resolveTemplate resolves {{.meta.KEY}} and {{.node.NODEID.output.KEY}} placeholders.
+func (e *Engine) resolveTemplate(tmplStr string, execData *execContext) string {
+	if !strings.Contains(tmplStr, "{{") {
+		return tmplStr
+	}
+
+	// Build template data
+	data := map[string]any{
+		"event": execData.Event,
+		"meta":  execData.Meta,
+		"node":  execData.NodeOutputs,
+	}
+
+	t, err := template.New("").Parse(tmplStr)
+	if err != nil {
+		return tmplStr
+	}
+
+	var buf strings.Builder
+	if err := t.Execute(&buf, data); err != nil {
+		return tmplStr
+	}
+	return buf.String()
+}
+
+// configStr gets a string config value, resolving templates.
+func (e *Engine) configStr(node *Node, key string, execData *execContext) string {
+	v, ok := node.Config[key]
+	if !ok {
+		return ""
+	}
+	s, ok := v.(string)
+	if !ok {
+		return fmt.Sprintf("%v", v)
+	}
+	return e.resolveTemplate(s, execData)
+}
+
+// FireWorkflows checks all enabled workflows in a project for matching trigger:event nodes.
+func (e *Engine) FireWorkflows(project, event string, meta map[string]string) {
+	workflows, err := e.db.ListWorkflows(project)
+	if err != nil || len(workflows) == 0 {
+		return
+	}
+
+	for _, wf := range workflows {
+		if !wf.Enabled {
+			continue
+		}
+
+		var nodes []Node
+		if err := json.Unmarshal([]byte(wf.Nodes), &nodes); err != nil {
+			continue
+		}
+
+		// Check if workflow has a trigger:event node matching this event
+		for _, n := range nodes {
+			if n.Type == "trigger:event" {
+				cfgEvent, _ := n.Config["event"].(string)
+				if cfgEvent == event || cfgEvent == "*" {
+					// Check match_rules if present
+					if rules, ok := n.Config["match_rules"].(string); ok && rules != "" && rules != "{}" {
+						rulesMap := make(map[string]string)
+						if err := json.Unmarshal([]byte(rules), &rulesMap); err == nil {
+							match := true
+							for k, v := range rulesMap {
+								if meta[k] != v {
+									match = false
+									break
+								}
+							}
+							if !match {
+								continue
+							}
+						}
+					}
+
+					// Execute workflow in background
+					go func(w db.Workflow) {
+						ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+						defer cancel()
+						if _, err := e.Execute(ctx, &w, event, meta); err != nil {
+							e.logger.Printf("[workflow] execute %s failed: %v", w.ID, err)
+						}
+					}(wf)
+					break
+				}
+			}
+		}
+	}
+}

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -17,7 +17,7 @@ import (
 // Node represents a single node in the workflow DAG.
 type Node struct {
 	ID     string         `json:"id"`
-	Type   string         `json:"type"`   // e.g. "trigger:event", "condition:match", "action:spawn"
+	Type   string         `json:"type"` // e.g. "trigger:event", "condition:match", "action:spawn"
 	Label  string         `json:"label"`
 	Config map[string]any `json:"config"` // type-specific configuration
 	X      float64        `json:"x"`      // visual position
@@ -37,7 +37,7 @@ type Engine struct {
 	db       *db.DB
 	spawnMgr *spawn.Manager
 	msgFunc  func(project, from, to, msgType, subject, content string) error // for action:message
-	taskFunc func(project, profile, title, desc string) (string, error)       // for action:task
+	taskFunc func(project, profile, title, desc string) (string, error)      // for action:task
 	logger   *log.Logger
 }
 

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"log/slog"
 	"os"
 	"os/signal"
 	"syscall"
@@ -14,6 +15,7 @@ import (
 	"agent-relay/internal/db"
 	"agent-relay/internal/ingest"
 	"agent-relay/internal/relay"
+	"agent-relay/internal/spawn"
 	"agent-relay/internal/vault"
 )
 
@@ -31,7 +33,7 @@ func main() {
 		case "serve":
 			startServer()
 			return
-		case "init", "update", "status", "agents", "inbox", "send", "thread", "stats", "conversations", "memories":
+		case "init", "update", "status", "agents", "inbox", "send", "thread", "stats", "conversations", "memories", "children", "schedules", "history":
 			cli.Run(os.Args[1:])
 			return
 		default:
@@ -74,6 +76,13 @@ func startServer() {
 
 	r := relay.New(database, ingester, vaultWatcher, cfg)
 
+	// Start scheduler and load persisted schedules
+	if r.SpawnMgr != nil {
+		r.Scheduler.Start()
+		r.SpawnMgr.LoadSchedulesFromDB()
+		defer r.Scheduler.Stop()
+	}
+
 	addr := ":8090"
 	if v := os.Getenv("PORT"); v != "" {
 		addr = ":" + v
@@ -86,6 +95,14 @@ func startServer() {
 	cleanupDone := make(chan struct{})
 	relay.StartCleanup(database, cleanupDone)
 	relay.StartACKChecker(database, r.Registry, cleanupDone)
+
+	// Start ghost reaper for spawn crash detection
+	if r.SpawnMgr != nil {
+		spawn.StartReaper(database, r.SpawnMgr, cleanupDone, slog.Default())
+	}
+
+	// Start poll trigger background worker
+	r.Handlers.StartPoller(cleanupDone)
 
 	// Log ingested events (phase 1: log only, phase 2: TouchAgent + WS broadcast)
 	go func() {


### PR DESCRIPTION
## Summary

- **Spawn engine**: headless execution (stdin + stream-json) and interactive PTY sessions with `creack/pty`. Context injection via `--append-system-prompt` with full identity/task/knowledge assembly.
- **Web terminal**: PTY ↔ WebSocket ↔ xterm.js bridge. 128KB ring buffer enables terminal reconnection with full history replay on tab switch. `TERM=xterm-256color` + `FORCE_COLOR=1` for proper TUI rendering.
- **Command panel**: bottom-dock HUD for agent management — profile CRUD, skills (full .md documents, expandable), quotas with health bars, schedules, comms log, tasks, and embedded terminal tab.
- **Workflow engine**: DAG-based workflow definitions with conditional routing and spawn integration.
- **Cron scheduler**: recurring agent tasks with trigger API and execution history.
- **Skill system overhaul**: skills as full markdown documents linked to profiles via `profile_skills`, auto-linking on create, per-agent skill API.
- **Ops console + flow editor**: real-time agent monitoring and visual workflow builder.

## Test plan

- [ ] Build: `go build -tags fts5 -o agent-relay .`
- [ ] Colony view → click agent → command panel appears with profile/skills/quotas/schedules/comms/tasks tabs
- [ ] Skills tab: add skill with full .md content, expand/collapse, delete
- [ ] Spawn Terminal → xterm.js renders Claude Code TUI with colors
- [ ] Switch agent tabs → terminal persists (ring buffer replay on reconnect)
- [ ] Kill terminal → button updates, session cleaned up
- [ ] Drag resize handle → canvas + panel resize smoothly
- [ ] Galaxy view → command panel hides

🤖 Generated with [Claude Code](https://claude.com/claude-code)