### PR TITLE
feat(relay): add GET /api/inbox/count for external poll loops

### DIFF
--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -392,3 +392,78 @@ func TestHeavyLoad(t *testing.T) {
 		t.Errorf("expected %d messages, got %d", writes, len(msgs))
 	}
 }
+
+func TestCountUnread(t *testing.T) {
+	d := testDB(t)
+
+	_, _, _ = d.RegisterAgent("default", "sender", "test", "", nil, nil, false, nil, "[]", 0)
+	_, _, _ = d.RegisterAgent("default", "receiver", "test", "", nil, nil, false, nil, "[]", 0)
+
+	// Empty inbox → count 0
+	n, err := d.CountUnread("default", "receiver")
+	if err != nil {
+		t.Fatalf("CountUnread on empty: %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("expected 0 unread on empty, got %d", n)
+	}
+
+	// Send 3 direct messages to receiver, creating deliveries
+	var msgIDs []string
+	for i := 0; i < 3; i++ {
+		msg, err := d.InsertMessage("default", "sender", "receiver", "notification", "test", fmt.Sprintf("msg-%d", i), "{}", "P2", 3600, nil, nil)
+		if err != nil {
+			t.Fatalf("InsertMessage: %v", err)
+		}
+		if err := d.CreateDeliveries(msg.ID, "default", []string{"receiver"}); err != nil {
+			t.Fatalf("CreateDeliveries: %v", err)
+		}
+		msgIDs = append(msgIDs, msg.ID)
+	}
+
+	n, err = d.CountUnread("default", "receiver")
+	if err != nil {
+		t.Fatalf("CountUnread after inserts: %v", err)
+	}
+	if n != 3 {
+		t.Fatalf("expected 3 unread after inserts, got %d", n)
+	}
+
+	// Unrelated agent should still see 0
+	n, _ = d.CountUnread("default", "sender")
+	if n != 0 {
+		t.Fatalf("expected 0 unread for sender, got %d", n)
+	}
+
+	// MarkRead one → count drops by 1
+	if _, err := d.MarkRead([]string{msgIDs[0]}, "receiver", "default"); err != nil {
+		t.Fatalf("MarkRead: %v", err)
+	}
+	n, _ = d.CountUnread("default", "receiver")
+	if n != 2 {
+		t.Fatalf("expected 2 unread after mark_read, got %d", n)
+	}
+
+	// Force-expire one of the remaining messages → count drops by 1
+	if _, err := d.conn.Exec(
+		"UPDATE messages SET expired_at = ? WHERE id = ?",
+		"2020-01-01T00:00:00.000000Z", msgIDs[1],
+	); err != nil {
+		t.Fatalf("force expire: %v", err)
+	}
+	n, _ = d.CountUnread("default", "receiver")
+	if n != 1 {
+		t.Fatalf("expected 1 unread after expiring one, got %d", n)
+	}
+
+	// Sanity: CountUnread must not flip deliveries to 'surfaced' (it's read-only).
+	// A subsequent GetInbox(unread_only=true) should still return the remaining
+	// queued message.
+	msgs, err := d.GetInbox("default", "receiver", true, 10)
+	if err != nil {
+		t.Fatalf("GetInbox: %v", err)
+	}
+	if len(msgs) != 1 {
+		t.Fatalf("expected GetInbox to still see 1 queued message after CountUnread, got %d", len(msgs))
+	}
+}

--- a/internal/db/messages.go
+++ b/internal/db/messages.go
@@ -276,3 +276,58 @@ func (d *DB) ExpireMessages() (int, error) {
 	n, _ := result.RowsAffected()
 	return int(n), nil
 }
+
+// CountUnread returns the number of unread (non-expired) messages for an agent.
+// Read-only: unlike GetInbox, it does not flip delivery state from 'queued' to
+// 'surfaced', so callers (e.g. poll loops / gate scripts) can safely use it as
+// a wake signal without affecting what the agent sees from get_inbox.
+//
+// Mirrors the same filters as GetInbox (deliveries-based when available, falls
+// back to the legacy message_reads path otherwise).
+func (d *DB) CountUnread(project, agent string) (int, error) {
+	if d.HasDeliveries() {
+		return d.countUnreadViaDeliveries(project, agent)
+	}
+	return d.countUnreadLegacy(project, agent)
+}
+
+func (d *DB) countUnreadViaDeliveries(project, agent string) (int, error) {
+	var n int
+	err := d.ro().QueryRow(
+		`SELECT COUNT(*)
+		 FROM deliveries d
+		 JOIN messages m ON d.message_id = m.id
+		 WHERE d.project = ? AND d.to_agent = ?
+		   AND d.state = 'queued'
+		   AND m.expired_at IS NULL`,
+		project, agent,
+	).Scan(&n)
+	if err != nil {
+		return 0, fmt.Errorf("count unread via deliveries: %w", err)
+	}
+	return n, nil
+}
+
+func (d *DB) countUnreadLegacy(project, agent string) (int, error) {
+	var n int
+	err := d.ro().QueryRow(
+		`SELECT COUNT(*) FROM messages m
+		 WHERE m.project = ?
+		   AND m.expired_at IS NULL
+		   AND (
+		     (m.conversation_id IS NULL AND (m.to_agent = ? OR (m.to_agent = '*' AND m.from_agent != ?)))
+		     OR (m.conversation_id IS NOT NULL AND m.conversation_id IN (
+		       SELECT conversation_id FROM conversation_members
+		       WHERE agent_name = ? AND left_at IS NULL
+		     ) AND m.from_agent != ?)
+		   )
+		   AND NOT EXISTS (
+		     SELECT 1 FROM message_reads mr WHERE mr.message_id = m.id AND mr.agent_name = ?
+		   )`,
+		project, agent, agent, agent, agent, agent,
+	).Scan(&n)
+	if err != nil {
+		return 0, fmt.Errorf("count unread legacy: %w", err)
+	}
+	return n, nil
+}

--- a/internal/relay/api.go
+++ b/internal/relay/api.go
@@ -66,6 +66,8 @@ func (r *Relay) ServeAPI(w http.ResponseWriter, req *http.Request) {
 		r.apiGetAllMessages(w, req)
 	case path == "/messages/latest" && req.Method == http.MethodGet:
 		r.apiGetLatestMessages(w, req)
+	case path == "/inbox/count" && req.Method == http.MethodGet:
+		r.apiGetInboxCount(w, req)
 	case path == "/user-response" && req.Method == http.MethodPost:
 		r.apiPostUserResponse(w, req)
 	// Memory endpoints
@@ -657,8 +659,38 @@ func (r *Relay) apiGetLatestMessages(w http.ResponseWriter, req *http.Request) {
 	if msgs == nil {
 		msgs = make([]models.Message, 0)
 	}
-
 	writeJSON(w, msgs)
+}
+
+// apiGetInboxCount returns the number of unread (non-expired) messages for an
+// agent. Read-only: does not change delivery state. Intended for external
+// poll loops that need a wake signal aligned with get_inbox semantics without
+// using the MCP transport.
+//
+// GET /api/inbox/count?project=<project>&agent=<slug>
+// Response: {"count": <int>, "project": <string>, "agent": <string>}
+func (r *Relay) apiGetInboxCount(w http.ResponseWriter, req *http.Request) {
+	project := projectFromRequest(req)
+	agent := req.URL.Query().Get("agent")
+	if agent == "" {
+		http.Error(w, `{"error":"agent query parameter is required"}`, http.StatusBadRequest)
+		return
+	}
+
+	// Expire stale messages before counting so callers see fresh state.
+	_, _ = r.DB.ExpireMessages()
+
+	n, err := r.DB.CountUnread(project, agent)
+	if err != nil {
+		apiError(w, http.StatusInternalServerError, "failed to count unread", err)
+		return
+	}
+
+	writeJSON(w, map[string]any{
+		"count":   n,
+		"project": project,
+		"agent":   agent,
+	})
 }
 
 // apiGetOrgTree returns the agent hierarchy as a nested tree structure.


### PR DESCRIPTION
Closes #17 (feature request with the problem writeup — happy to iterate on API shape there first).

## Summary

- Adds `GET /api/inbox/count?project=<p>&agent=<slug>` — a read-only HTTP endpoint returning the count of unread, non-expired messages for an agent, using the same deliveries/message_reads filter `get_inbox` applies via MCP.
- Closes the gap for external poll loops (gate scripts, watchers) that have no HTTP equivalent of `get_inbox` and currently resort to filtering `/api/messages` by `read_at` — which never matches anything useful because `messages.read_at` is schema-declared but never written. Full background in #17.
- Additive only: no changes to existing endpoints, MCP handlers, or schema.

## Changes

- `internal/db/messages.go` — new `DB.CountUnread(project, agent)`:
  - Deliveries path when `HasDeliveries()`: counts `d.state = 'queued' AND m.expired_at IS NULL`.
  - Legacy path otherwise: counts via `message_reads` with the same `expired_at` and conversation-membership filters as `getInboxLegacy`.
  - Read-only — does **not** flip `queued → surfaced`, so a polling caller cannot consume a delivery the agent hasn't seen.
- `internal/relay/api.go` — new `apiGetInboxCount` handler + route. Calls `ExpireMessages()` first (same as `HandleGetInbox`), returns `{"count": N, "project": "...", "agent": "..."}`. `400` if `agent` missing.
- `internal/db/db_test.go` — `TestCountUnread` covering: empty inbox, inserts increment, unrelated agent sees 0, `MarkRead` decrements, expired messages excluded, and the no-side-effect invariant (a subsequent `GetInbox(unread_only=true)` still sees the queued message after a `CountUnread` call).

## Test plan

- [x] `go build -tags fts5 .` compiles (golang:1.25 container, CGO enabled, 24 MB binary)
- [x] `go test -tags fts5 ./internal/db/... ./internal/relay/...` — both packages PASS
- [x] `go test -tags fts5 ./internal/db/... -run TestCountUnread -v` — PASS
- [ ] Tested locally with the relay running (have not run the binary against a live relay yet — can do if it's blocking)
- [x] No breaking changes to existing MCP tools