### PR TITLE
fix(installer): use /api/health for verification probe

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1005,7 +1005,7 @@ verify_installation() {
 
     local health_ok=false
     for attempt in 1 2 3; do
-      if curl -sf "http://localhost:${PORT}/health" &>/dev/null || \
+      if curl -sf "http://localhost:${PORT}/api/health" &>/dev/null || \
          curl -sf "http://localhost:${PORT}/mcp" &>/dev/null; then
         health_ok=true
         break


### PR DESCRIPTION
## Summary
- The installer's verify step probes `http://localhost:${PORT}/health`, which returns **404** because the relay namespaces its REST API under `/api/`. The OR-fallback to `GET /mcp` happens to return 200, so verification doesn't fail outright, but the documented health endpoint is never actually exercised.
- Switching the primary probe to `/api/health` matches `internal/relay/api.go` and `skill/tools-reference.md` and gives users a real health signal during install.

## Repro
```
$ curl -s -o /dev/null -w '%{http_code}\n' http://localhost:8090/health
404
$ curl -s -o /dev/null -w '%{http_code}\n' http://localhost:8090/api/health
200
```

## Test plan
- [ ] Run `install.sh` against a host where the relay is running — `[6/7] Verifying installation` reports `Service: relay running on port 8090` on first attempt instead of falling through to the `/mcp` retry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)