### PR TITLE
fix(installer): scan deeper for Claude Code projects, prune heavy dirs

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -769,8 +769,9 @@ scan_and_configure_projects() {
 
   # Scan home directory for Claude Code projects up to 5 levels deep, so common
   # layouts like ~/dev/projects/<repo>/ and ~/work/<org>/<team>/<repo>/ are
-  # picked up. Heavy directories (node_modules, vendor, .git, .cache, .venv)
-  # are pruned so the walk stays fast even at the deeper limit.
+  # picked up. Heavy directories (node_modules, vendor, .git, .cache, .venv,
+  # Library — the huge macOS system tree under $HOME) are pruned so the walk
+  # stays fast even at the deeper limit.
   while IFS= read -r -d '' dir; do
     local project_dir
     project_dir=$(dirname "$dir")
@@ -786,7 +787,7 @@ scan_and_configure_projects() {
       projects+=("$project_dir")
     fi
   done < <(find "$HOME" -maxdepth 5 \
-    \( -type d \( -name node_modules -o -name vendor -o -name .git -o -name .cache -o -name .venv \) -prune \) -o \
+    \( -type d \( -name node_modules -o -name vendor -o -name .git -o -name .cache -o -name .venv -o -name Library \) -prune \) -o \
     \( -type f \( -name "CLAUDE.md" -o -name ".mcp.json" \) -print0 \) \
     2>/dev/null | tr '\0' '\n' | head -100 | tr '\n' '\0')
 

--- a/install.sh
+++ b/install.sh
@@ -767,7 +767,10 @@ scan_and_configure_projects() {
   local -a projects=()
   local -a project_names=()
 
-  # Scan home directory (depth 2) for Claude Code projects
+  # Scan home directory for Claude Code projects up to 5 levels deep, so common
+  # layouts like ~/dev/projects/<repo>/ and ~/work/<org>/<team>/<repo>/ are
+  # picked up. Heavy directories (node_modules, vendor, .git, .cache, .venv)
+  # are pruned so the walk stays fast even at the deeper limit.
   while IFS= read -r -d '' dir; do
     local project_dir
     project_dir=$(dirname "$dir")
@@ -782,7 +785,10 @@ scan_and_configure_projects() {
     if [[ "$already" == false ]]; then
       projects+=("$project_dir")
     fi
-  done < <(find "$HOME" -maxdepth 3 \( -name "CLAUDE.md" -o -name ".mcp.json" \) -print0 2>/dev/null | tr '\0' '\n' | head -100 | tr '\n' '\0')
+  done < <(find "$HOME" -maxdepth 5 \
+    \( -type d \( -name node_modules -o -name vendor -o -name .git -o -name .cache -o -name .venv \) -prune \) -o \
+    \( -type f \( -name "CLAUDE.md" -o -name ".mcp.json" \) -print0 \) \
+    2>/dev/null | tr '\0' '\n' | head -100 | tr '\n' '\0')
 
   # Filter out non-project directories
   local -a valid_projects=()


### PR DESCRIPTION
## Summary
- `install.sh` scans `\$HOME` with `find -maxdepth 3`, which misses very common layouts like `~/dev/projects/<repo>/` (depth 4) or `~/work/<org>/<team>/<repo>/` (depth 5). Users with those structures get `:: No Claude Code projects found` even when their `CLAUDE.md` sits one directory deeper than the limit.
- Bumping the limit to **5** covers those layouts. To keep the deeper walk fast, the `find` now **prunes** `node_modules`, `vendor`, `.git`, `.cache`, and `.venv` up front instead of relying on the post-filter to drop them after find has already descended into them.
- The comment above the loop also gets corrected (it claimed depth 2 while the code was depth 3).

## Repro (before)
```
$ ls ~/dev/projects/<some-app>/CLAUDE.md
/home/gnutix/dev/projects/<some-app>/CLAUDE.md
$ curl -fsSL https://raw.githubusercontent.com/Synergix-lab/WRAI.TH/main/install.sh | bash
...
[5/7] Scanning for Claude Code projects
:: Looking for projects with .mcp.json or CLAUDE.md...
:: No Claude Code projects found
```

## After
Tested locally on the same host (8 Claude Code projects across `~/dev/projects/`, `~/dev/oss/<org>/<repo>/`, `~/dev/tipee-sa/<repo>/`): the new walk finds all of them in well under a second.

## Test plan
- [ ] On a host with `CLAUDE.md` at depth 4 (e.g. `~/dev/projects/<repo>/CLAUDE.md`), re-run `install.sh` — the project appears in the `[5/7]` listing and the interactive prompt offers to configure it.
- [ ] On a host with no Claude Code projects, the new walk still terminates quickly and the script prints the existing "No Claude Code projects found" hint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)