### PR TITLE
fix: preserve omitted identity fields on agent re-registration

### DIFF
--- a/internal/db/agents.go
+++ b/internal/db/agents.go
@@ -17,7 +17,20 @@ func scanAgent(row interface{ Scan(...any) error }) (models.Agent, error) {
 	return a, err
 }
 
-func (d *DB) RegisterAgent(project, name, role, description string, reportsTo, profileSlug *string, isExecutive bool, sessionID *string, interestTags string, maxContextBytes int) (*models.Agent, bool, error) {
+// RegisterOptions carries presence flags for identity fields whose absence must be
+// distinguished from an explicit clear. At the MCP layer, an omitted optional param and
+// an explicitly-empty one both arrive as a nil *string (or zero bool), so the caller sets
+// the *Set flag only when the field was actually provided. On a re-register (respawn),
+// fields that were NOT provided are preserved from the existing row instead of being
+// clobbered to NULL/false. The flags are ignored on the initial insert.
+type RegisterOptions struct {
+	ReportsToSet   bool
+	ProfileSlugSet bool
+	IsExecutiveSet bool
+	SessionIDSet   bool
+}
+
+func (d *DB) RegisterAgent(project, name, role, description string, reportsTo, profileSlug *string, isExecutive bool, sessionID *string, interestTags string, maxContextBytes int, opts RegisterOptions) (*models.Agent, bool, error) {
 	now := time.Now().UTC().Format(time.RFC3339)
 	if interestTags == "" {
 		interestTags = "[]"
@@ -62,7 +75,26 @@ func (d *DB) RegisterAgent(project, name, role, description string, reportsTo, p
 		return nil, false, fmt.Errorf("query agent: %w", err)
 	}
 
-	// Existing agent — this is a respawn
+	// Existing agent — this is a respawn. Preserve identity fields that were NOT
+	// provided on this call (reports_to, profile_slug, is_executive, session_id), so a
+	// bare re-register (e.g. the agent's own in-pane /relay register, which omits
+	// profile_slug) does not clobber values set by the orchestrator. Fields like role,
+	// description, interest_tags and max_context_bytes always update — updating them is
+	// the point of a respawn. To clear an identity field, use the dedicated flows
+	// (deactivate_agent / delete_agent / remove_team_member).
+	if !opts.ReportsToSet {
+		reportsTo = a.ReportsTo
+	}
+	if !opts.ProfileSlugSet {
+		profileSlug = a.ProfileSlug
+	}
+	if !opts.IsExecutiveSet {
+		isExecutive = a.IsExecutive
+	}
+	if !opts.SessionIDSet {
+		sessionID = a.SessionID
+	}
+
 	_, err = d.conn.Exec(
 		"UPDATE agents SET role = ?, description = ?, last_seen = ?, reports_to = ?, profile_slug = ?, is_executive = ?, session_id = ?, interest_tags = ?, max_context_bytes = ?, status = 'active', deactivated_at = NULL WHERE name = ? AND project = ?",
 		role, description, now, reportsTo, profileSlug, isExecutive, sessionID, interestTags, maxContextBytes, name, project,

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -42,7 +42,7 @@ func TestConcurrentReadsAndWrite(t *testing.T) {
 	d := testDB(t)
 
 	// Seed an agent
-	_, _, _ = d.RegisterAgent("default", "bot-a", "test", "", nil, nil, false, nil, "[]", 0)
+	_, _, _ = d.RegisterAgent("default", "bot-a", "test", "", nil, nil, false, nil, "[]", 0, RegisterOptions{})
 
 	var wg sync.WaitGroup
 	var errors atomic.Int32
@@ -89,7 +89,7 @@ func TestConcurrentReadsAndWrite(t *testing.T) {
 func TestConcurrentWriters(t *testing.T) {
 	d := testDB(t)
 
-	_, _, _ = d.RegisterAgent("default", "bot-a", "test", "", nil, nil, false, nil, "[]", 0)
+	_, _, _ = d.RegisterAgent("default", "bot-a", "test", "", nil, nil, false, nil, "[]", 0, RegisterOptions{})
 
 	var wg sync.WaitGroup
 	var errors atomic.Int32
@@ -122,7 +122,7 @@ func TestOptimizeNoCorruption(t *testing.T) {
 	d := testDB(t)
 
 	// Insert some data
-	_, _, _ = d.RegisterAgent("default", "bot-a", "test", "", nil, nil, false, nil, "[]", 0)
+	_, _, _ = d.RegisterAgent("default", "bot-a", "test", "", nil, nil, false, nil, "[]", 0, RegisterOptions{})
 	for i := 0; i < 10; i++ {
 		_, _ = d.InsertMessage("default", "bot-a", "bot-b", "notification", "test", fmt.Sprintf("msg-%d", i), "{}", "P2", 3600, nil, nil)
 	}
@@ -173,7 +173,7 @@ func TestReadAfterWrite(t *testing.T) {
 	d := testDB(t)
 
 	// Write via writer
-	_, _, _ = d.RegisterAgent("default", "bot-a", "tester", "", nil, nil, false, nil, "[]", 0)
+	_, _, _ = d.RegisterAgent("default", "bot-a", "tester", "", nil, nil, false, nil, "[]", 0, RegisterOptions{})
 
 	// Read via reader should see the write (WAL visibility)
 	agents, err := d.ListAgents("default")
@@ -190,7 +190,7 @@ func TestReadAfterWrite(t *testing.T) {
 
 func TestReadsNeverBlockedByWrite(t *testing.T) {
 	d := testDB(t)
-	_, _, _ = d.RegisterAgent("default", "bot-a", "test", "", nil, nil, false, nil, "[]", 0)
+	_, _, _ = d.RegisterAgent("default", "bot-a", "test", "", nil, nil, false, nil, "[]", 0, RegisterOptions{})
 
 	// Start a long write transaction on the writer
 	tx, err := d.conn.Begin()
@@ -226,7 +226,7 @@ func TestReadsNeverBlockedByWrite(t *testing.T) {
 
 func TestWritesDontUseManyConns(t *testing.T) {
 	d := testDB(t)
-	_, _, _ = d.RegisterAgent("default", "bot-a", "test", "", nil, nil, false, nil, "[]", 0)
+	_, _, _ = d.RegisterAgent("default", "bot-a", "test", "", nil, nil, false, nil, "[]", 0, RegisterOptions{})
 
 	// Writer pool has MaxOpenConns=1. Concurrent writes should serialize, not error.
 	var wg sync.WaitGroup
@@ -257,7 +257,7 @@ func TestMixedReadWriteFunction(t *testing.T) {
 	d := testDB(t)
 
 	// RegisterAgent reads (check existing) then writes (insert) — tests mixed path
-	agent1, isRespawn1, err := d.RegisterAgent("default", "bot-a", "tester", "", nil, nil, false, nil, "[]", 0)
+	agent1, isRespawn1, err := d.RegisterAgent("default", "bot-a", "tester", "", nil, nil, false, nil, "[]", 0, RegisterOptions{})
 	if err != nil {
 		t.Fatalf("register agent: %v", err)
 	}
@@ -269,7 +269,7 @@ func TestMixedReadWriteFunction(t *testing.T) {
 	}
 
 	// Re-register same agent — should read existing via writer, then update
-	agent2, isRespawn2, err := d.RegisterAgent("default", "bot-a", "updated", "", nil, nil, false, nil, "[]", 0)
+	agent2, isRespawn2, err := d.RegisterAgent("default", "bot-a", "updated", "", nil, nil, false, nil, "[]", 0, RegisterOptions{})
 	if err != nil {
 		t.Fatalf("re-register agent: %v", err)
 	}
@@ -323,7 +323,7 @@ func TestCloseCheckpoint(t *testing.T) {
 	d := &DB{conn: writer, reader: reader, path: dbPath}
 
 	// Insert data to create WAL entries
-	_, _, _ = d.RegisterAgent("default", "bot-a", "test", "", nil, nil, false, nil, "[]", 0)
+	_, _, _ = d.RegisterAgent("default", "bot-a", "test", "", nil, nil, false, nil, "[]", 0, RegisterOptions{})
 	for i := 0; i < 50; i++ {
 		_, _ = d.InsertMessage("default", "bot-a", "bot-b", "notification", "test", fmt.Sprintf("msg-%d", i), "{}", "P2", 3600, nil, nil)
 	}
@@ -344,10 +344,130 @@ func TestCloseCheckpoint(t *testing.T) {
 	}
 }
 
+func strptr(s string) *string { return &s }
+
+// TestRegisterAgentPreservesProfileSlugOnOmit reproduces the production bug:
+// orchestrator registers an agent WITH profile_slug, then the agent's own
+// in-pane /relay register re-registers WITHOUT profile_slug (per skill/relay.md).
+// The slug must survive — NULLing it hides the agent's dispatched/pending tasks.
+func TestRegisterAgentPreservesProfileSlugOnOmit(t *testing.T) {
+	d := testDB(t)
+
+	// Orchestrator registers with a profile slug.
+	_, _, err := d.RegisterAgent("default", "bot-a", "dev", "", nil, strptr("backend"), false, nil, "[]", 0, RegisterOptions{
+		ProfileSlugSet: true,
+	})
+	if err != nil {
+		t.Fatalf("initial register: %v", err)
+	}
+
+	// Agent self-registers WITHOUT profile_slug (omitted → nil, not "set").
+	agent, isRespawn, err := d.RegisterAgent("default", "bot-a", "dev", "", nil, nil, false, nil, "[]", 0, RegisterOptions{})
+	if err != nil {
+		t.Fatalf("re-register: %v", err)
+	}
+	if !isRespawn {
+		t.Fatal("expected respawn on re-register")
+	}
+	if agent.ProfileSlug == nil || *agent.ProfileSlug != "backend" {
+		t.Fatalf("profile_slug must survive omitted re-register, got %v", agent.ProfileSlug)
+	}
+
+	// Verify persisted (not just the returned struct).
+	got, _ := d.GetAgent("default", "bot-a")
+	if got.ProfileSlug == nil || *got.ProfileSlug != "backend" {
+		t.Fatalf("persisted profile_slug must survive, got %v", got.ProfileSlug)
+	}
+}
+
+// TestRegisterAgentPreservesReportsToOnOmit ensures org hierarchy survives respawn.
+func TestRegisterAgentPreservesReportsToOnOmit(t *testing.T) {
+	d := testDB(t)
+
+	_, _, _ = d.RegisterAgent("default", "lead", "lead", "", nil, nil, false, nil, "[]", 0, RegisterOptions{})
+	_, _, err := d.RegisterAgent("default", "bot-a", "dev", "", strptr("lead"), nil, false, nil, "[]", 0, RegisterOptions{
+		ReportsToSet: true,
+	})
+	if err != nil {
+		t.Fatalf("initial register: %v", err)
+	}
+
+	agent, _, err := d.RegisterAgent("default", "bot-a", "dev", "", nil, nil, false, nil, "[]", 0, RegisterOptions{})
+	if err != nil {
+		t.Fatalf("re-register: %v", err)
+	}
+	if agent.ReportsTo == nil || *agent.ReportsTo != "lead" {
+		t.Fatalf("reports_to must survive omitted re-register, got %v", agent.ReportsTo)
+	}
+}
+
+// TestRegisterAgentPreservesIsExecutiveOnOmit ensures executive flag survives respawn.
+func TestRegisterAgentPreservesIsExecutiveOnOmit(t *testing.T) {
+	d := testDB(t)
+
+	_, _, err := d.RegisterAgent("default", "cto", "cto", "", nil, nil, true, nil, "[]", 0, RegisterOptions{
+		IsExecutiveSet: true,
+	})
+	if err != nil {
+		t.Fatalf("initial register: %v", err)
+	}
+
+	agent, _, err := d.RegisterAgent("default", "cto", "cto", "", nil, nil, false, nil, "[]", 0, RegisterOptions{})
+	if err != nil {
+		t.Fatalf("re-register: %v", err)
+	}
+	if !agent.IsExecutive {
+		t.Fatal("is_executive must survive omitted re-register")
+	}
+}
+
+// TestRegisterAgentPreservesSessionIDOnOmit ensures activity-tracking session survives respawn.
+func TestRegisterAgentPreservesSessionIDOnOmit(t *testing.T) {
+	d := testDB(t)
+
+	_, _, _ = d.RegisterAgent("default", "bot-a", "dev", "", nil, nil, false, strptr("sess-123"), "[]", 0, RegisterOptions{
+		SessionIDSet: true,
+	})
+	agent, _, err := d.RegisterAgent("default", "bot-a", "dev", "", nil, nil, false, nil, "[]", 0, RegisterOptions{})
+	if err != nil {
+		t.Fatalf("re-register: %v", err)
+	}
+	if agent.SessionID == nil || *agent.SessionID != "sess-123" {
+		t.Fatalf("session_id must survive omitted re-register, got %v", agent.SessionID)
+	}
+}
+
+// TestRegisterAgentExplicitFieldsStillUpdate ensures preserve-on-omit does NOT
+// block legitimate updates: when a field IS provided, it must overwrite.
+func TestRegisterAgentExplicitFieldsStillUpdate(t *testing.T) {
+	d := testDB(t)
+
+	_, _, _ = d.RegisterAgent("default", "bot-a", "dev", "old", nil, strptr("backend"), false, nil, "[]", 0, RegisterOptions{
+		ProfileSlugSet: true,
+	})
+
+	// Re-register with a DIFFERENT profile slug (explicitly set) — must update.
+	agent, _, err := d.RegisterAgent("default", "bot-a", "dev2", "new", nil, strptr("frontend"), false, nil, "[]", 0, RegisterOptions{
+		ProfileSlugSet: true,
+	})
+	if err != nil {
+		t.Fatalf("re-register: %v", err)
+	}
+	if agent.ProfileSlug == nil || *agent.ProfileSlug != "frontend" {
+		t.Fatalf("explicit profile_slug must update, got %v", agent.ProfileSlug)
+	}
+	if agent.Role != "dev2" {
+		t.Fatalf("role must update, got %s", agent.Role)
+	}
+	if agent.Description != "new" {
+		t.Fatalf("description must update, got %s", agent.Description)
+	}
+}
+
 func TestHeavyLoad(t *testing.T) {
 	d := testDB(t)
 
-	_, _, _ = d.RegisterAgent("default", "bot-a", "test", "", nil, nil, false, nil, "[]", 0)
+	_, _, _ = d.RegisterAgent("default", "bot-a", "test", "", nil, nil, false, nil, "[]", 0, RegisterOptions{})
 
 	var wg sync.WaitGroup
 	var writeErrors, readErrors atomic.Int32

--- a/internal/relay/api_test.go
+++ b/internal/relay/api_test.go
@@ -76,7 +76,7 @@ func TestAPIGetProjects(t *testing.T) {
 	r := testRelay(t)
 
 	// Create a project by registering an agent
-	_, _, _ = r.DB.RegisterAgent("test-proj", "bot-a", "dev", "", nil, nil, false, nil, "[]", 0)
+	_, _, _ = r.DB.RegisterAgent("test-proj", "bot-a", "dev", "", nil, nil, false, nil, "[]", 0, db.RegisterOptions{})
 
 	w := doAPI(r, "GET", "/projects", "")
 	if w.Code != http.StatusOK {
@@ -90,7 +90,7 @@ func TestAPIGetProjects(t *testing.T) {
 
 func TestAPIGetProject(t *testing.T) {
 	r := testRelay(t)
-	_, _, _ = r.DB.RegisterAgent("my-proj", "bot-a", "dev", "", nil, nil, false, nil, "[]", 0)
+	_, _, _ = r.DB.RegisterAgent("my-proj", "bot-a", "dev", "", nil, nil, false, nil, "[]", 0, db.RegisterOptions{})
 
 	w := doAPI(r, "GET", "/projects/my-proj", "")
 	if w.Code != http.StatusOK {
@@ -112,7 +112,7 @@ func TestAPIGetProjectNotFound(t *testing.T) {
 
 func TestAPIPatchProject(t *testing.T) {
 	r := testRelay(t)
-	_, _, _ = r.DB.RegisterAgent("my-proj", "bot-a", "dev", "", nil, nil, false, nil, "[]", 0)
+	_, _, _ = r.DB.RegisterAgent("my-proj", "bot-a", "dev", "", nil, nil, false, nil, "[]", 0, db.RegisterOptions{})
 
 	w := doAPI(r, "PATCH", "/projects/my-proj", `{"planet_type":"lava/1"}`)
 	if w.Code != http.StatusOK {
@@ -122,7 +122,7 @@ func TestAPIPatchProject(t *testing.T) {
 
 func TestAPIPatchProjectMissingPlanetType(t *testing.T) {
 	r := testRelay(t)
-	_, _, _ = r.DB.RegisterAgent("my-proj", "bot-a", "dev", "", nil, nil, false, nil, "[]", 0)
+	_, _, _ = r.DB.RegisterAgent("my-proj", "bot-a", "dev", "", nil, nil, false, nil, "[]", 0, db.RegisterOptions{})
 
 	w := doAPI(r, "PATCH", "/projects/my-proj", `{}`)
 	if w.Code != http.StatusBadRequest {
@@ -163,8 +163,8 @@ func TestAPISettings(t *testing.T) {
 
 func TestAPIGetAgents(t *testing.T) {
 	r := testRelay(t)
-	_, _, _ = r.DB.RegisterAgent("p1", "bot-a", "dev", "", nil, nil, false, nil, "[]", 0)
-	_, _, _ = r.DB.RegisterAgent("p1", "bot-b", "qa", "", nil, nil, false, nil, "[]", 0)
+	_, _, _ = r.DB.RegisterAgent("p1", "bot-a", "dev", "", nil, nil, false, nil, "[]", 0, db.RegisterOptions{})
+	_, _, _ = r.DB.RegisterAgent("p1", "bot-b", "qa", "", nil, nil, false, nil, "[]", 0, db.RegisterOptions{})
 
 	w := doAPI(r, "GET", "/agents?project=p1", "")
 	if w.Code != http.StatusOK {
@@ -178,8 +178,8 @@ func TestAPIGetAgents(t *testing.T) {
 
 func TestAPIGetAllAgents(t *testing.T) {
 	r := testRelay(t)
-	_, _, _ = r.DB.RegisterAgent("p1", "bot-a", "dev", "", nil, nil, false, nil, "[]", 0)
-	_, _, _ = r.DB.RegisterAgent("p2", "bot-b", "qa", "", nil, nil, false, nil, "[]", 0)
+	_, _, _ = r.DB.RegisterAgent("p1", "bot-a", "dev", "", nil, nil, false, nil, "[]", 0, db.RegisterOptions{})
+	_, _, _ = r.DB.RegisterAgent("p2", "bot-b", "qa", "", nil, nil, false, nil, "[]", 0, db.RegisterOptions{})
 
 	w := doAPI(r, "GET", "/agents/all", "")
 	if w.Code != http.StatusOK {
@@ -194,8 +194,8 @@ func TestAPIGetAllAgents(t *testing.T) {
 func TestAPIGetOrgTree(t *testing.T) {
 	r := testRelay(t)
 	mgr := "manager"
-	_, _, _ = r.DB.RegisterAgent("p1", "manager", "lead", "", nil, nil, false, nil, "[]", 0)
-	_, _, _ = r.DB.RegisterAgent("p1", "dev-1", "dev", "", &mgr, nil, false, nil, "[]", 0)
+	_, _, _ = r.DB.RegisterAgent("p1", "manager", "lead", "", nil, nil, false, nil, "[]", 0, db.RegisterOptions{})
+	_, _, _ = r.DB.RegisterAgent("p1", "dev-1", "dev", "", &mgr, nil, false, nil, "[]", 0, db.RegisterOptions{})
 
 	w := doAPI(r, "GET", "/org?project=p1", "")
 	if w.Code != http.StatusOK {
@@ -216,7 +216,7 @@ func TestAPIGetOrgTree(t *testing.T) {
 
 func TestAPIGetAllMessages(t *testing.T) {
 	r := testRelay(t)
-	_, _, _ = r.DB.RegisterAgent("p1", "bot-a", "dev", "", nil, nil, false, nil, "[]", 0)
+	_, _, _ = r.DB.RegisterAgent("p1", "bot-a", "dev", "", nil, nil, false, nil, "[]", 0, db.RegisterOptions{})
 	_, _ = r.DB.InsertMessage("p1", "bot-a", "bot-b", "notification", "test", "hello", "{}", "P2", 3600, nil, nil)
 
 	w := doAPI(r, "GET", "/messages/all?project=p1", "")
@@ -231,8 +231,8 @@ func TestAPIGetAllMessages(t *testing.T) {
 
 func TestAPIGetAllMessagesAllProjects(t *testing.T) {
 	r := testRelay(t)
-	_, _, _ = r.DB.RegisterAgent("p1", "bot-a", "dev", "", nil, nil, false, nil, "[]", 0)
-	_, _, _ = r.DB.RegisterAgent("p2", "bot-b", "qa", "", nil, nil, false, nil, "[]", 0)
+	_, _, _ = r.DB.RegisterAgent("p1", "bot-a", "dev", "", nil, nil, false, nil, "[]", 0, db.RegisterOptions{})
+	_, _, _ = r.DB.RegisterAgent("p2", "bot-b", "qa", "", nil, nil, false, nil, "[]", 0, db.RegisterOptions{})
 	_, _ = r.DB.InsertMessage("p1", "bot-a", "bot-b", "notification", "test", "hello", "{}", "P2", 3600, nil, nil)
 	_, _ = r.DB.InsertMessage("p2", "bot-b", "bot-a", "notification", "test", "hey", "{}", "P2", 3600, nil, nil)
 
@@ -248,7 +248,7 @@ func TestAPIGetAllMessagesAllProjects(t *testing.T) {
 
 func TestAPIPostUserResponse(t *testing.T) {
 	r := testRelay(t)
-	_, _, _ = r.DB.RegisterAgent("p1", "bot-a", "dev", "", nil, nil, false, nil, "[]", 0)
+	_, _, _ = r.DB.RegisterAgent("p1", "bot-a", "dev", "", nil, nil, false, nil, "[]", 0, db.RegisterOptions{})
 
 	w := doAPI(r, "POST", "/user-response", `{"project":"p1","to":"bot-a","content":"yes"}`)
 	if w.Code != http.StatusOK {
@@ -275,8 +275,8 @@ func TestAPIPostUserResponseMissingFields(t *testing.T) {
 
 func TestAPIGetConversations(t *testing.T) {
 	r := testRelay(t)
-	_, _, _ = r.DB.RegisterAgent("p1", "bot-a", "dev", "", nil, nil, false, nil, "[]", 0)
-	_, _, _ = r.DB.RegisterAgent("p1", "bot-b", "qa", "", nil, nil, false, nil, "[]", 0)
+	_, _, _ = r.DB.RegisterAgent("p1", "bot-a", "dev", "", nil, nil, false, nil, "[]", 0, db.RegisterOptions{})
+	_, _, _ = r.DB.RegisterAgent("p1", "bot-b", "qa", "", nil, nil, false, nil, "[]", 0, db.RegisterOptions{})
 	_, _ = r.DB.CreateConversation("p1", "test conv", "bot-a", []string{"bot-a", "bot-b"})
 
 	w := doAPI(r, "GET", "/conversations?project=p1", "")
@@ -291,8 +291,8 @@ func TestAPIGetConversations(t *testing.T) {
 
 func TestAPIGetConversationMessages(t *testing.T) {
 	r := testRelay(t)
-	_, _, _ = r.DB.RegisterAgent("p1", "bot-a", "dev", "", nil, nil, false, nil, "[]", 0)
-	_, _, _ = r.DB.RegisterAgent("p1", "bot-b", "qa", "", nil, nil, false, nil, "[]", 0)
+	_, _, _ = r.DB.RegisterAgent("p1", "bot-a", "dev", "", nil, nil, false, nil, "[]", 0, db.RegisterOptions{})
+	_, _, _ = r.DB.RegisterAgent("p1", "bot-b", "qa", "", nil, nil, false, nil, "[]", 0, db.RegisterOptions{})
 	conv, _ := r.DB.CreateConversation("p1", "test", "bot-a", []string{"bot-a", "bot-b"})
 	_, _ = r.DB.InsertMessage("p1", "bot-a", "", "notification", "test", "hello", "{}", "P2", 3600, nil, &conv.ID)
 
@@ -384,7 +384,7 @@ func TestAPISearchMemoriesMissingQuery(t *testing.T) {
 
 func TestAPITaskCRUD(t *testing.T) {
 	r := testRelay(t)
-	_, _, _ = r.DB.RegisterAgent("p1", "bot-a", "dev", "", nil, nil, false, nil, "[]", 0)
+	_, _, _ = r.DB.RegisterAgent("p1", "bot-a", "dev", "", nil, nil, false, nil, "[]", 0, db.RegisterOptions{})
 
 	// Dispatch
 	w := doAPI(r, "POST", "/tasks", `{"project":"p1","dispatched_by":"bot-a","profile":"dev","title":"Fix bug","description":"fix it"}`)
@@ -420,7 +420,7 @@ func TestAPITaskCRUD(t *testing.T) {
 
 func TestAPITaskTransition(t *testing.T) {
 	r := testRelay(t)
-	_, _, _ = r.DB.RegisterAgent("p1", "bot-a", "dev", "", nil, nil, false, nil, "[]", 0)
+	_, _, _ = r.DB.RegisterAgent("p1", "bot-a", "dev", "", nil, nil, false, nil, "[]", 0, db.RegisterOptions{})
 
 	task, _ := r.DB.DispatchTask("p1", "dev", "bot-a", "task1", "", "P2", nil, nil, nil)
 
@@ -457,7 +457,7 @@ func TestAPITaskTransition(t *testing.T) {
 
 func TestAPIGetAllTasks(t *testing.T) {
 	r := testRelay(t)
-	_, _, _ = r.DB.RegisterAgent("p1", "bot-a", "dev", "", nil, nil, false, nil, "[]", 0)
+	_, _, _ = r.DB.RegisterAgent("p1", "bot-a", "dev", "", nil, nil, false, nil, "[]", 0, db.RegisterOptions{})
 	_, _ = r.DB.DispatchTask("p1", "dev", "bot-a", "task1", "", "P2", nil, nil, nil)
 	_, _ = r.DB.DispatchTask("p1", "dev", "bot-a", "task2", "", "P1", nil, nil, nil)
 
@@ -603,7 +603,7 @@ func TestAPIGetAllTeams(t *testing.T) {
 func TestAPIGetTeamMembers(t *testing.T) {
 	r := testRelay(t)
 	team, _ := r.DB.CreateTeam("Backend", "backend", "p1", "", "regular", nil, nil)
-	_, _, _ = r.DB.RegisterAgent("p1", "bot-a", "dev", "", nil, nil, false, nil, "[]", 0)
+	_, _, _ = r.DB.RegisterAgent("p1", "bot-a", "dev", "", nil, nil, false, nil, "[]", 0, db.RegisterOptions{})
 	_ = r.DB.AddTeamMember(team.ID, "bot-a", "p1", "lead")
 
 	w := doAPI(r, "GET", "/teams/backend/members?project=p1", "")
@@ -616,8 +616,8 @@ func TestAPIGetTeamMembers(t *testing.T) {
 
 func TestAPIGetAllConversations(t *testing.T) {
 	r := testRelay(t)
-	_, _, _ = r.DB.RegisterAgent("p1", "bot-a", "dev", "", nil, nil, false, nil, "[]", 0)
-	_, _, _ = r.DB.RegisterAgent("p2", "bot-b", "qa", "", nil, nil, false, nil, "[]", 0)
+	_, _, _ = r.DB.RegisterAgent("p1", "bot-a", "dev", "", nil, nil, false, nil, "[]", 0, db.RegisterOptions{})
+	_, _, _ = r.DB.RegisterAgent("p2", "bot-b", "qa", "", nil, nil, false, nil, "[]", 0, db.RegisterOptions{})
 	_, _ = r.DB.CreateConversation("p1", "conv1", "bot-a", []string{"bot-a"})
 	_, _ = r.DB.CreateConversation("p2", "conv2", "bot-b", []string{"bot-b"})
 
@@ -635,7 +635,7 @@ func TestAPIGetAllConversations(t *testing.T) {
 
 func TestAPIGetLatestMessages(t *testing.T) {
 	r := testRelay(t)
-	_, _, _ = r.DB.RegisterAgent("p1", "bot-a", "dev", "", nil, nil, false, nil, "[]", 0)
+	_, _, _ = r.DB.RegisterAgent("p1", "bot-a", "dev", "", nil, nil, false, nil, "[]", 0, db.RegisterOptions{})
 	_, _ = r.DB.InsertMessage("p1", "bot-a", "bot-b", "notification", "test", "recent msg", "{}", "P2", 3600, nil, nil)
 
 	w := doAPI(r, "GET", "/messages/latest?project=p1", "")
@@ -650,7 +650,7 @@ func TestAPIGetLatestMessages(t *testing.T) {
 
 func TestAPIGetLatestMessagesAllProjects(t *testing.T) {
 	r := testRelay(t)
-	_, _, _ = r.DB.RegisterAgent("p1", "bot-a", "dev", "", nil, nil, false, nil, "[]", 0)
+	_, _, _ = r.DB.RegisterAgent("p1", "bot-a", "dev", "", nil, nil, false, nil, "[]", 0, db.RegisterOptions{})
 	_, _ = r.DB.InsertMessage("p1", "bot-a", "bot-b", "notification", "test", "msg1", "{}", "P2", 3600, nil, nil)
 
 	w := doAPI(r, "GET", "/messages/latest-all", "")
@@ -663,7 +663,7 @@ func TestAPIGetLatestMessagesAllProjects(t *testing.T) {
 
 func TestAPIGetLatestTasks(t *testing.T) {
 	r := testRelay(t)
-	_, _, _ = r.DB.RegisterAgent("p1", "bot-a", "dev", "", nil, nil, false, nil, "[]", 0)
+	_, _, _ = r.DB.RegisterAgent("p1", "bot-a", "dev", "", nil, nil, false, nil, "[]", 0, db.RegisterOptions{})
 	_, _ = r.DB.DispatchTask("p1", "dev", "bot-a", "recent task", "", "P2", nil, nil, nil)
 
 	w := doAPI(r, "GET", "/tasks/latest?project=p1", "")
@@ -674,7 +674,7 @@ func TestAPIGetLatestTasks(t *testing.T) {
 
 func TestAPIUpdateTask(t *testing.T) {
 	r := testRelay(t)
-	_, _, _ = r.DB.RegisterAgent("p1", "bot-a", "dev", "", nil, nil, false, nil, "[]", 0)
+	_, _, _ = r.DB.RegisterAgent("p1", "bot-a", "dev", "", nil, nil, false, nil, "[]", 0, db.RegisterOptions{})
 	task, _ := r.DB.DispatchTask("p1", "dev", "bot-a", "old title", "", "P2", nil, nil, nil)
 
 	w := doAPI(r, "PUT", "/tasks/"+task.ID, `{"project":"p1","title":"new title"}`)
@@ -689,7 +689,7 @@ func TestAPIUpdateTask(t *testing.T) {
 
 func TestAPIDeleteTask(t *testing.T) {
 	r := testRelay(t)
-	_, _, _ = r.DB.RegisterAgent("p1", "bot-a", "dev", "", nil, nil, false, nil, "[]", 0)
+	_, _, _ = r.DB.RegisterAgent("p1", "bot-a", "dev", "", nil, nil, false, nil, "[]", 0, db.RegisterOptions{})
 	task, _ := r.DB.DispatchTask("p1", "dev", "bot-a", "to delete", "", "P2", nil, nil, nil)
 
 	w := doAPI(r, "DELETE", "/tasks/"+task.ID+"?project=p1", "")
@@ -1240,7 +1240,7 @@ func TestAPIQuotaCRUD(t *testing.T) {
 
 func TestAPIQuotaUsageTracking(t *testing.T) {
 	r := testRelay(t)
-	_, _, _ = r.DB.RegisterAgent("p1", "bot-a", "dev", "", nil, nil, false, nil, "[]", 0)
+	_, _, _ = r.DB.RegisterAgent("p1", "bot-a", "dev", "", nil, nil, false, nil, "[]", 0, db.RegisterOptions{})
 
 	// Set quota
 	_ = r.DB.SetAgentQuota("p1", "bot-a", 0, 100, 50, 0)
@@ -1297,7 +1297,7 @@ func TestAPIDiscover(t *testing.T) {
 	profile, _ := r.DB.RegisterProfile("p1", "qa-lead", "QA Lead", "tester", "", "[]", "[]", "[]")
 	_ = r.DB.LinkProfileSkill(profile.ID, skill.ID, "expert")
 	slug := "qa-lead"
-	_, _, _ = r.DB.RegisterAgent("p1", "qa-bot", "tester", "", nil, &slug, false, nil, "[]", 0)
+	_, _, _ = r.DB.RegisterAgent("p1", "qa-bot", "tester", "", nil, &slug, false, nil, "[]", 0, db.RegisterOptions{})
 
 	w := doAPI(r, "GET", "/discover?project=p1&skill=testing", "")
 	if w.Code != http.StatusOK {
@@ -1415,8 +1415,8 @@ func TestAPIElevationCanMessage(t *testing.T) {
 
 	// Setup: teams configured, bot-a NOT in admin team
 	_, _ = r.DB.CreateTeam("devs", "devs", "p1", "", "regular", nil, nil)
-	_, _, _ = r.DB.RegisterAgent("p1", "bot-a", "dev", "", nil, nil, false, nil, "[]", 0)
-	_, _, _ = r.DB.RegisterAgent("p1", "bot-b", "dev", "", nil, nil, false, nil, "[]", 0)
+	_, _, _ = r.DB.RegisterAgent("p1", "bot-a", "dev", "", nil, nil, false, nil, "[]", 0, db.RegisterOptions{})
+	_, _, _ = r.DB.RegisterAgent("p1", "bot-b", "dev", "", nil, nil, false, nil, "[]", 0, db.RegisterOptions{})
 
 	// Without elevation: should NOT be able to message bot-b (different team)
 	allowed, _ := r.DB.CanMessage("p1", "bot-a", "bot-b")

--- a/internal/relay/handlers.go
+++ b/internal/relay/handlers.go
@@ -181,10 +181,30 @@ func (h *Handlers) HandleRegisterAgent(ctx context.Context, req mcp.CallToolRequ
 	interestTags := req.GetString("interest_tags", "[]")
 	maxContextBytes := req.GetInt("max_context_bytes", 16384)
 
-	agent, isRespawn, err := h.db.RegisterAgent(project, name, role, description, reportsTo, profileSlug, isExecutive, sessionID, interestTags, maxContextBytes)
+	// Detect which identity fields were actually provided. GetString/GetBool conflate an
+	// omitted param with an explicitly-empty one, so presence is read from the raw args.
+	// On a respawn, omitted fields are preserved (not clobbered) by the DB layer.
+	args := req.GetArguments()
+	_, reportsToSet := args["reports_to"]
+	_, profileSlugSet := args["profile_slug"]
+	_, isExecutiveSet := args["is_executive"]
+	_, sessionIDSet := args["session_id"]
+	opts := db.RegisterOptions{
+		ReportsToSet:   reportsToSet,
+		ProfileSlugSet: profileSlugSet,
+		IsExecutiveSet: isExecutiveSet,
+		SessionIDSet:   sessionIDSet,
+	}
+
+	agent, isRespawn, err := h.db.RegisterAgent(project, name, role, description, reportsTo, profileSlug, isExecutive, sessionID, interestTags, maxContextBytes, opts)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("failed to register agent: %v", err)), nil
 	}
+
+	// Use the effective (post-merge) executive flag and profile slug so a respawn that
+	// omits these still drives the leadership-team side effect and session_context.
+	isExecutive = agent.IsExecutive
+	profileSlug = agent.ProfileSlug
 
 	// Auto-create admin team + add executive agent (fixes broadcast permission UX)
 	var autoAdminTeam *string

--- a/internal/relay/handlers_test.go
+++ b/internal/relay/handlers_test.go
@@ -108,6 +108,93 @@ func TestRegisterAgentRespawn(t *testing.T) {
 	}
 }
 
+// TestRegisterAgentRespawnPreservesProfileSlug reproduces the production bug end-to-end:
+// the orchestrator registers an agent WITH profile_slug, then the agent's own in-pane
+// /relay register (per skill/relay.md — never passes profile_slug) re-registers without it.
+// The slug must survive so list_tasks / session_context can route the agent's tasks.
+func TestRegisterAgentRespawnPreservesProfileSlug(t *testing.T) {
+	h := testHandlers(t)
+
+	// Orchestrator registers WITH profile_slug.
+	_, _ = h.HandleRegisterAgent(ctx, call(map[string]any{
+		"project":      "test-proj",
+		"name":         "bot-a",
+		"role":         "developer",
+		"profile_slug": "backend",
+	}))
+
+	// Agent self-registers WITHOUT profile_slug (key omitted entirely).
+	res, _ := h.HandleRegisterAgent(ctx, call(map[string]any{
+		"project": "test-proj",
+		"name":    "bot-a",
+		"role":    "developer",
+	}))
+	data := parseJSON(t, res)
+	agent := data["agent"].(map[string]any)
+	if agent["profile_slug"] != "backend" {
+		t.Fatalf("profile_slug must survive omitted re-register, got %v", agent["profile_slug"])
+	}
+}
+
+// TestRegisterAgentRespawnPreservesReportsTo ensures org hierarchy survives a respawn
+// that omits reports_to.
+func TestRegisterAgentRespawnPreservesReportsTo(t *testing.T) {
+	h := testHandlers(t)
+
+	_, _ = h.HandleRegisterAgent(ctx, call(map[string]any{
+		"project": "test-proj", "name": "lead", "role": "lead",
+	}))
+	_, _ = h.HandleRegisterAgent(ctx, call(map[string]any{
+		"project": "test-proj", "name": "bot-a", "role": "dev", "reports_to": "lead",
+	}))
+
+	res, _ := h.HandleRegisterAgent(ctx, call(map[string]any{
+		"project": "test-proj", "name": "bot-a", "role": "dev",
+	}))
+	data := parseJSON(t, res)
+	agent := data["agent"].(map[string]any)
+	if agent["reports_to"] != "lead" {
+		t.Fatalf("reports_to must survive omitted re-register, got %v", agent["reports_to"])
+	}
+}
+
+// TestRegisterAgentRespawnPreservesIsExecutive ensures the executive flag (and its
+// leadership-team membership) survives a respawn that omits is_executive.
+func TestRegisterAgentRespawnPreservesIsExecutive(t *testing.T) {
+	h := testHandlers(t)
+
+	_, _ = h.HandleRegisterAgent(ctx, call(map[string]any{
+		"project": "test-proj", "name": "cto", "role": "lead", "is_executive": true,
+	}))
+
+	res, _ := h.HandleRegisterAgent(ctx, call(map[string]any{
+		"project": "test-proj", "name": "cto", "role": "lead",
+	}))
+	data := parseJSON(t, res)
+	agent := data["agent"].(map[string]any)
+	if agent["is_executive"] != true {
+		t.Fatalf("is_executive must survive omitted re-register, got %v", agent["is_executive"])
+	}
+}
+
+// TestRegisterAgentExplicitSlugStillUpdates ensures preserve-on-omit does not block a
+// legitimate slug change when profile_slug IS provided on re-register.
+func TestRegisterAgentExplicitSlugStillUpdates(t *testing.T) {
+	h := testHandlers(t)
+
+	_, _ = h.HandleRegisterAgent(ctx, call(map[string]any{
+		"project": "test-proj", "name": "bot-a", "role": "dev", "profile_slug": "backend",
+	}))
+	res, _ := h.HandleRegisterAgent(ctx, call(map[string]any{
+		"project": "test-proj", "name": "bot-a", "role": "dev", "profile_slug": "frontend",
+	}))
+	data := parseJSON(t, res)
+	agent := data["agent"].(map[string]any)
+	if agent["profile_slug"] != "frontend" {
+		t.Fatalf("explicit profile_slug must update, got %v", agent["profile_slug"])
+	}
+}
+
 func TestRegisterAgentMissingName(t *testing.T) {
 	h := testHandlers(t)
 	res, _ := h.HandleRegisterAgent(ctx, call(map[string]any{

--- a/internal/relay/tools.go
+++ b/internal/relay/tools.go
@@ -21,7 +21,7 @@ func whoamiTool() mcp.Tool {
 func registerAgentTool() mcp.Tool {
 	return mcp.NewTool(
 		"register_agent",
-		mcp.WithDescription("Register an agent with the relay. Call this once per agent at startup to announce their presence. Returns session_context with profile, tasks, unread messages, and conversations.\n\nIf is_executive=true, an 'admin' team ('leadership') is auto-created and the agent is added to it, enabling broadcast messages (send_message to='*')."),
+		mcp.WithDescription("Register an agent with the relay. Call this once per agent at startup to announce their presence. Returns session_context with profile, tasks, unread messages, and conversations.\n\nRe-registering the same name+project is a respawn: role, description, interest_tags and max_context_bytes are updated, while identity fields you OMIT (reports_to, profile_slug, is_executive, session_id) are PRESERVED from the existing registration rather than cleared. This means a bare re-register won't drop a profile_slug set by your orchestrator. To clear these, use deactivate_agent / delete_agent / remove_team_member.\n\nIf is_executive=true (or already set), an 'admin' team ('leadership') is auto-created and the agent is added to it, enabling broadcast messages (send_message to='*')."),
 		projectParam,
 		mcp.WithString("name", mcp.Description("Unique agent name (e.g. 'lead', 'backend', 'frontend'). Re-registering the same name updates the agent. To rename, register the new name and call deactivate_agent on the old one."), mcp.Required()),
 		mcp.WithString("role", mcp.Description("Agent role description (e.g. 'FastAPI backend developer')")),

--- a/skill/relay.md
+++ b/skill/relay.md
@@ -28,6 +28,8 @@ register_agent(name: "backend", project: "my-app", role: "Go developer", reports
 send_message(as: "backend", project: "my-app", to: "frontend", subject: "...", content: "...")
 ```
 
+Re-registering the same name+project is a respawn: it updates `role`/`description`, but identity fields you **omit** (`profile_slug`, `reports_to`, `is_executive`, `session_id`) are **preserved**, not cleared. So a bare re-register won't drop a `profile_slug` set by your orchestrator. To clear them, use `deactivate_agent` / `delete_agent` / `remove_team_member`.
+
 ## Commands
 
 ### Messaging


### PR DESCRIPTION
Fixes #23.

## Problem

`register_agent` on an existing `name`+`project` does a full-replace UPDATE, so identity fields **omitted** on a re-register get overwritten with NULL/false instead of being preserved. When an orchestrator registers an agent with a `profile_slug` and the agent's own in-pane `/relay register` (which per `skill/relay.md` never passes `profile_slug`) re-registers, the slug is NULLed and `GetAgentTasks`' pending subselect (`profile_slug IS NOT NULL`) silently hides the agent's profile-routed tasks. No error surfaces — task routing just stops. `reports_to`, `is_executive` and `session_id` are clobbered the same way.

Root cause: the MCP layer conflates an omitted optional param with an explicitly-empty one (`GetString → ""`, `GetBool → false`), so the respawn UPDATE can't distinguish "leave it" from "clear it".

## Fix

Detect actual field presence at the handler via `req.GetArguments()`, thread `RegisterOptions` presence flags into `db.RegisterAgent`, and on respawn preserve the existing value for any identity field that was not provided. The handler also drives the leadership-team side effect and `session_context` off the effective (post-merge) `is_executive`/`profile_slug`.

Per-field behavior on re-register when **omitted**:

| Field | Behavior | Why |
|---|---|---|
| `profile_slug` | preserve | self-register omits it; NULLing breaks routing |
| `reports_to` | preserve | keep org hierarchy across respawns |
| `is_executive` | preserve | no demote-via-register path; keep leadership |
| `session_id` | preserve | keep hook activity tracking |
| `role` / `description` / `interest_tags` / `max_context_bytes` | update | respawn legitimately refreshes these |

Clearing an identity field stays the job of the dedicated flows (`deactivate_agent` / `delete_agent` / `remove_team_member`), not re-registration. No production caller relied on the clobbering.

## Tests

Strict TDD — failing tests first (DB + handler layers) reproducing the `profile_slug`/`reports_to`/`is_executive`/`session_id` NULLing, plus explicit-set-still-updates guards. `skill/relay.md` and the `register_agent` tool description updated to document preserve-on-omit. `go test -tags fts5 ./...` and `go vet -tags fts5 ./...` green.