### PR TITLE
perf+fix: token efficiency (discovery default, Def.7 ceiling, lean thread/team inbox) + EventBus race

### DIFF
--- a/internal/relay/context.go
+++ b/internal/relay/context.go
@@ -13,14 +13,19 @@ const toolsModeKey contextKey = "tools_mode"
 
 // Tools exposure modes (?tools= query parameter).
 const (
-	ToolsModeFull      = "full"      // default: every tool schema served on tools/list
-	ToolsModeDiscovery = "discovery" // progressive disclosure: only discover_tools + call_tool
+	ToolsModeFull      = "full"      // opt-in: every tool schema served on tools/list (~10k tokens)
+	ToolsModeDiscovery = "discovery" // default: progressive disclosure, only discover_tools + call_tool (~430 tokens)
 )
 
 // HTTPContextFunc extracts the project from the ?project= query parameter
 // and the optional ?agent= fallback, injecting both into the request context.
 // Agent identity is primarily set via register_agent + the "as" param on tool calls.
-// ?tools=discovery opts the connection into progressive tool disclosure.
+// Progressive tool disclosure (discover_tools + call_tool) is the default — it
+// cuts the tools/list init payload from ~10k tokens to ~430. Pass ?tools=full to
+// serve every tool schema on tools/list for vanilla list-driven MCP clients.
+// Note: dispatch is unaffected by the mode — every tool stays callable by name
+// in either mode (see toolsModeFilter), so clients that invoke tools directly
+// keep working under the default.
 func HTTPContextFunc(ctx context.Context, r *http.Request) context.Context {
 	agent := r.URL.Query().Get("agent")
 	if agent == "" {
@@ -30,8 +35,8 @@ func HTTPContextFunc(ctx context.Context, r *http.Request) context.Context {
 	if project == "" {
 		project = "default"
 	}
-	if r.URL.Query().Get("tools") == ToolsModeDiscovery {
-		ctx = context.WithValue(ctx, toolsModeKey, ToolsModeDiscovery)
+	if r.URL.Query().Get("tools") == ToolsModeFull {
+		ctx = context.WithValue(ctx, toolsModeKey, ToolsModeFull)
 	}
 	ctx = context.WithValue(ctx, agentNameKey, agent)
 	return context.WithValue(ctx, projectKey, project)
@@ -54,9 +59,10 @@ func ProjectFromContext(ctx context.Context) string {
 }
 
 // ToolsModeFromContext retrieves the tool exposure mode from the context.
+// Defaults to discovery (progressive disclosure) when unset.
 func ToolsModeFromContext(ctx context.Context) string {
 	if v, ok := ctx.Value(toolsModeKey).(string); ok {
 		return v
 	}
-	return ToolsModeFull
+	return ToolsModeDiscovery
 }

--- a/internal/relay/events.go
+++ b/internal/relay/events.go
@@ -83,15 +83,22 @@ func (b *EventBus) Emit(evt MCPEvent) {
 	if len(b.history) > eventHistorySize {
 		b.history = b.history[len(b.history)-eventHistorySize:]
 	}
-	subs := b.subs
 	b.mu.Unlock()
 
-	for ch := range subs {
+	// Fan out under the read lock. Holding RLock for the whole loop is what makes
+	// this safe: iterating b.subs is synchronized against Subscribe/Unsubscribe
+	// (which take the full Lock), so we cannot hit "concurrent map iteration and
+	// map write", and Unsubscribe cannot close(ch) mid-send (it blocks on Lock
+	// until we release RLock). Sends are non-blocking, so holding RLock can't
+	// deadlock and slow subscribers are dropped via the default case.
+	b.mu.RLock()
+	for ch := range b.subs {
 		select {
 		case ch <- evt:
 		default: // drop if slow
 		}
 	}
+	b.mu.RUnlock()
 }
 
 // Recent returns up to limit most-recent events (newest first) optionally

--- a/internal/relay/events_test.go
+++ b/internal/relay/events_test.go
@@ -1,0 +1,55 @@
+package relay
+
+import (
+	"sync"
+	"testing"
+)
+
+// TestEventBus_ConcurrentEmitSubscribe stresses the bus the way the SSE
+// handlers do: goroutines Emit while subscribers connect and disconnect.
+// Before the fix, Emit iterated b.subs after releasing the lock, which the race
+// detector flags as "concurrent map iteration and map write" and which can
+// panic with "send on closed channel" when Unsubscribe closes mid-fan-out.
+// Run with -race to be meaningful.
+func TestEventBus_ConcurrentEmitSubscribe(t *testing.T) {
+	bus := NewEventBus()
+	stop := make(chan struct{})
+
+	// Emitters run until stopped.
+	var emitters sync.WaitGroup
+	for i := 0; i < 4; i++ {
+		emitters.Add(1)
+		go func() {
+			defer emitters.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					bus.Emit(MCPEvent{Type: "task.done", Project: "p1"})
+				}
+			}
+		}()
+	}
+
+	// Subscribers churn: connect, maybe drain one event, disconnect.
+	var subs sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		subs.Add(1)
+		go func() {
+			defer subs.Done()
+			for j := 0; j < 300; j++ {
+				ch := bus.Subscribe()
+				select {
+				case <-ch:
+				default:
+				}
+				bus.Unsubscribe(ch)
+			}
+		}()
+	}
+
+	subs.Wait() // let all the connect/disconnect churn race against Emit
+	close(stop) // then stop the emitters
+	emitters.Wait()
+}

--- a/internal/relay/handlers.go
+++ b/internal/relay/handlers.go
@@ -684,15 +684,23 @@ func (h *Handlers) HandleGetThread(ctx context.Context, req mcp.CallToolRequest)
 		return mcp.NewToolResultError(fmt.Sprintf("failed to get thread: %v", err)), nil
 	}
 
+	// Thread can hold up to 200 messages; injecting every full body unbounded
+	// could dump 100k+ tokens into context. Preview-truncate (like get_inbox)
+	// unless full_content=true; default to a compact markdown table.
+	fullContent := req.GetBool("full_content", false)
 	formatted := make([]map[string]any, len(messages))
 	for i, m := range messages {
+		content := m.Content
+		if !fullContent && len(content) > msgContentPreview {
+			content = content[:msgContentPreview] + "..."
+		}
 		entry := map[string]any{
 			"id":         m.ID,
 			"from":       m.From,
 			"to":         m.To,
 			"type":       m.Type,
 			"subject":    m.Subject,
-			"content":    m.Content,
+			"content":    content,
 			"created_at": m.CreatedAt,
 			"priority":   m.Priority,
 		}
@@ -702,10 +710,21 @@ func (h *Handlers) HandleGetThread(ctx context.Context, req mcp.CallToolRequest)
 		if m.ConversationID != nil {
 			entry["conversation_id"] = *m.ConversationID
 		}
-		if m.Metadata != "" && m.Metadata != "{}" {
+		// metadata is heavy and rarely needed; only include with full_content.
+		if fullContent && m.Metadata != "" && m.Metadata != "{}" {
 			entry["metadata"] = m.Metadata
 		}
 		formatted[i] = entry
+	}
+
+	if f := req.GetString("format", "md"); f == "md" || f == "table" {
+		rows := make([][]string, len(messages))
+		for i, m := range messages {
+			content, _ := formatted[i]["content"].(string)
+			rows[i] = []string{m.ID, m.From, m.To, m.Type, m.Priority, m.CreatedAt, m.Subject, content}
+		}
+		table := renderTable([]string{"id", "from", "to", "type", "priority", "created_at", "subject", "content"}, rows)
+		return h.resultTextTracked(resolveProject(ctx, req), "", "get_thread", fmt.Sprintf("%d messages in thread\n%s", len(messages), table))
 	}
 
 	return h.resultJSONTracked(resolveProject(ctx, req), "", "get_thread", map[string]any{
@@ -2948,10 +2967,43 @@ func (h *Handlers) HandleGetTeamInbox(ctx context.Context, req mcp.CallToolReque
 		msgs = []models.Message{}
 	}
 
+	// Team inboxes carry verbose alert/digest bodies (~4k chars each); preview-
+	// truncate unless full_content=true and default to a compact markdown table
+	// so a busy team inbox can't blow up context. (Previously dumped raw
+	// models.Message structs — all fields, full content.)
+	fullContent := req.GetBool("full_content", false)
+	formatted := make([]map[string]any, len(msgs))
+	for i, m := range msgs {
+		content := m.Content
+		if !fullContent && len(content) > msgContentPreview {
+			content = content[:msgContentPreview] + "..."
+		}
+		formatted[i] = map[string]any{
+			"id":         m.ID,
+			"from":       m.From,
+			"to":         m.To,
+			"type":       m.Type,
+			"subject":    m.Subject,
+			"content":    content,
+			"created_at": m.CreatedAt,
+			"priority":   m.Priority,
+		}
+	}
+
+	if f := req.GetString("format", "md"); f == "md" || f == "table" {
+		rows := make([][]string, len(msgs))
+		for i, m := range msgs {
+			content, _ := formatted[i]["content"].(string)
+			rows[i] = []string{m.ID, m.From, m.To, m.Type, m.Priority, m.CreatedAt, m.Subject, content}
+		}
+		table := renderTable([]string{"id", "from", "to", "type", "priority", "created_at", "subject", "content"}, rows)
+		return h.resultTextTracked(project, "", "get_team_inbox", fmt.Sprintf("%d messages for team %s\n%s", len(msgs), teamSlug, table))
+	}
+
 	return h.resultJSONTracked(project, "", "get_team_inbox", map[string]any{
 		"team":     teamSlug,
 		"count":    len(msgs),
-		"messages": msgs,
+		"messages": formatted,
 	})
 }
 

--- a/internal/relay/handlers_test.go
+++ b/internal/relay/handlers_test.go
@@ -378,8 +378,8 @@ func TestGetThread(t *testing.T) {
 		"project": "p1", "as": "bot-b", "to": "bot-a", "content": "reply", "reply_to": msg1ID,
 	}))
 
-	// Get thread
-	threadRes, _ := h.HandleGetThread(ctx, call(map[string]any{"message_id": msg1ID}))
+	// Get thread (json format — default is now a markdown table)
+	threadRes, _ := h.HandleGetThread(ctx, call(map[string]any{"message_id": msg1ID, "format": "json"}))
 	thread := parseJSON(t, threadRes)
 	if thread["count"].(float64) != 2 {
 		t.Errorf("expected 2 messages in thread, got %v", thread["count"])
@@ -1027,9 +1027,9 @@ func TestTeamInbox(t *testing.T) {
 		"project": "p1", "as": "bot-a", "to": "team:dev", "content": "team message",
 	}))
 
-	// Get team inbox
+	// Get team inbox (json format — default is now a markdown table)
 	inboxRes, _ := h.HandleGetTeamInbox(ctx, call(map[string]any{
-		"project": "p1", "team": "dev",
+		"project": "p1", "team": "dev", "format": "json",
 	}))
 	data := parseJSON(t, inboxRes)
 	if data["count"].(float64) != 1 {

--- a/internal/relay/project.go
+++ b/internal/relay/project.go
@@ -29,6 +29,16 @@ const sessionUnreadBudget = 6000
 // (see handlers.go). Full bodies are fetched via get_inbox(full_content=true).
 const msgContentPreview = 300
 
+// budgetHardMultiplier caps the absolute size of a projection at this multiple
+// of its soft byte budget. P0 messages/tasks and constraints-layer memories
+// bypass the SOFT budget (they must surface even when it's blown), but they
+// still obey this HARD ceiling — so a flood of P0 items (priority is
+// caller-settable on send_message) from one agent cannot inflate every peer's
+// boot payload without bound. Keeps the paper's invariant |M_boot| ≤ B_max real,
+// with B_max = soft budget × budgetHardMultiplier. Items beyond the ceiling are
+// dropped and surface via the *_omitted counters in session_context.
+const budgetHardMultiplier = 2
+
 // memValuePreview bounds a single memory's value preview in session_context.
 // Full values are fetched via get_memory(key).
 const memValuePreview = 400
@@ -143,9 +153,18 @@ func projectMessages(msgs []models.Message, maxBytes int) []MessageSummary {
 
 	var out []MessageSummary
 	used := 0
+	hardCeil := 0
+	if maxBytes > 0 {
+		hardCeil = maxBytes * budgetHardMultiplier
+	}
 	for _, m := range sorted {
 		s := summarizeMessage(m)
 		b := messageSummaryBytes(s)
+		// Hard ceiling caps the bypass flood; the first (most-important) P0
+		// item always surfaces even under a tiny budget.
+		if hardCeil > 0 && used+b > hardCeil && len(out) > 0 {
+			continue
+		}
 		if m.Priority == "P0" {
 			out = append(out, s)
 			used += b
@@ -255,10 +274,19 @@ func projectTasks(tasks []models.Task, maxBytes int) []TaskSummary {
 
 	var out []TaskSummary
 	used := 0
+	hardCeil := 0
+	if maxBytes > 0 {
+		hardCeil = maxBytes * budgetHardMultiplier
+	}
 	for _, t := range sorted {
 		s := summarizeTask(t)
 		b := taskSummaryBytes(s)
-		// P0 always bypasses the budget
+		// Hard ceiling caps the bypass flood; the first (most-important) P0
+		// item always surfaces even under a tiny budget.
+		if hardCeil > 0 && used+b > hardCeil && len(out) > 0 {
+			continue
+		}
+		// P0 bypasses the soft budget
 		if t.Priority == "P0" {
 			out = append(out, s)
 			used += b
@@ -319,9 +347,18 @@ func projectMemories(mems []models.Memory, maxBytes int) []MemorySummary {
 	}
 	var out []MemorySummary
 	used := 0
+	hardCeil := 0
+	if maxBytes > 0 {
+		hardCeil = maxBytes * budgetHardMultiplier
+	}
 	for _, m := range mems {
 		s := summarizeMemory(m)
 		b := memorySummaryBytes(s)
+		// Hard ceiling caps the bypass flood; the first (most-important)
+		// constraints memory always surfaces even under a tiny budget.
+		if hardCeil > 0 && used+b > hardCeil && len(out) > 0 {
+			continue
+		}
 		if m.Layer == "constraints" {
 			out = append(out, s)
 			used += b

--- a/internal/relay/project_test.go
+++ b/internal/relay/project_test.go
@@ -239,3 +239,59 @@ func TestProjectMemories_BudgetBound(t *testing.T) {
 		t.Fatalf("budget exceeded: %d > %d", used, sessionMemoryBudget)
 	}
 }
+
+// TestProjectMessages_P0FloodObeysHardCeiling verifies the Def.7 hard ceiling:
+// P0 messages bypass the soft budget but a flood cannot exceed
+// soft*budgetHardMultiplier, so one agent can't inflate a peer's boot payload
+// without bound. The single most-important P0 still always surfaces.
+func TestProjectMessages_P0FloodObeysHardCeiling(t *testing.T) {
+	var msgs []models.Message
+	for i := 0; i < 200; i++ {
+		msgs = append(msgs, models.Message{
+			ID: "m", From: "attacker", Priority: "P0",
+			Content: strings.Repeat("x", 400),
+		})
+	}
+	const soft = 6000
+	out := projectMessages(msgs, soft)
+
+	total := 0
+	for _, s := range out {
+		total += messageSummaryBytes(s)
+	}
+	hardCeil := soft * budgetHardMultiplier
+	// Allow one item of slack: the first item is always admitted even if it
+	// alone would exceed the ceiling.
+	if total > hardCeil+700 {
+		t.Fatalf("P0 flood exceeded hard ceiling: %d > %d", total, hardCeil)
+	}
+	if len(out) >= len(msgs) {
+		t.Fatalf("expected the hard ceiling to drop most of the %d P0 messages, kept %d", len(msgs), len(out))
+	}
+	if len(out) == 0 {
+		t.Fatal("at least the most-important P0 must surface")
+	}
+}
+
+// TestProjectTasks_P0FloodObeysHardCeiling mirrors the message test for tasks.
+func TestProjectTasks_P0FloodObeysHardCeiling(t *testing.T) {
+	var tasks []models.Task
+	for i := 0; i < 200; i++ {
+		tasks = append(tasks, models.Task{
+			ID: "t", Title: "crit", Priority: "P0", Status: "pending",
+			Description: strings.Repeat("x", 400),
+		})
+	}
+	const soft = 8000
+	out := projectTasks(tasks, soft)
+	total := 0
+	for _, s := range out {
+		total += taskSummaryBytes(s)
+	}
+	if total > soft*budgetHardMultiplier+700 {
+		t.Fatalf("P0 task flood exceeded hard ceiling: %d", total)
+	}
+	if len(out) >= len(tasks) || len(out) == 0 {
+		t.Fatalf("hard ceiling should bound P0 tasks, kept %d of %d", len(out), len(tasks))
+	}
+}

--- a/internal/relay/tools.go
+++ b/internal/relay/tools.go
@@ -10,6 +10,10 @@ var asParam = mcp.WithString("as", mcp.Description("Act as this agent (overrides
 // so agents can switch projects without changing the MCP connection.
 var projectParam = mcp.WithString("project", mcp.Description("Project namespace (overrides the connection URL default)."))
 
+// formatParam is the shared output-format selector for list/get tools that can
+// render either a compact markdown table (default, ~half the tokens) or JSON.
+var formatParam = mcp.WithString("format", mcp.Description("'md' (default, markdown table — ~half the tokens) or 'json'"), mcp.Enum("md", "json"))
+
 func whoamiTool() mcp.Tool {
 	return mcp.NewTool(
 		"whoami",
@@ -74,7 +78,7 @@ func getInboxTool() mcp.Tool {
 		mcp.WithString("from", mcp.Description("Filter by sender")),
 		mcp.WithString("since", mcp.Description("Only messages after this ISO timestamp")),
 		mcp.WithBoolean("exclude_broadcasts", mcp.Description("Exclude broadcasts (default false)")),
-		mcp.WithString("format", mcp.Description("'md' (default, markdown table — ~half the tokens) or 'json'"), mcp.Enum("md", "json")),
+		formatParam,
 	)
 }
 
@@ -89,9 +93,11 @@ func ackDeliveryTool() mcp.Tool {
 func getThreadTool() mcp.Tool {
 	return mcp.NewTool(
 		"get_thread",
-		mcp.WithDescription("Get the full message thread containing the given message."),
+		mcp.WithDescription("Get the message thread containing the given message (up to 200 messages). Content is preview-truncated by default; pass full_content=true for untruncated bodies."),
 		projectParam,
 		mcp.WithString("message_id", mcp.Description("Any message ID in the thread"), mcp.Required()),
+		mcp.WithBoolean("full_content", mcp.Description("Full content instead of 300-char truncation (default false)")),
+		formatParam,
 	)
 }
 
@@ -100,7 +106,7 @@ func listAgentsTool() mcp.Tool {
 		"list_agents",
 		mcp.WithDescription("List registered agents and their status."),
 		projectParam,
-		mcp.WithString("format", mcp.Description("'md' (default, markdown table — ~half the tokens) or 'json'"), mcp.Enum("md", "json")),
+		formatParam,
 	)
 }
 
@@ -256,7 +262,7 @@ func listMemoriesTool() mcp.Tool {
 		mcp.WithArray("tags", mcp.Description("Filter by tags"), mcp.WithStringItems()),
 		mcp.WithString("agent", mcp.Description("Filter by author")),
 		mcp.WithNumber("limit", mcp.Description("Max results (default 50)")),
-		mcp.WithString("format", mcp.Description("'md' (default, markdown table — ~half the tokens) or 'json'"), mcp.Enum("md", "json")),
+		formatParam,
 	)
 }
 
@@ -452,7 +458,7 @@ func listTasksTool() mcp.Tool {
 		mcp.WithString("board_id", mcp.Description("Filter by board")),
 		mcp.WithNumber("limit", mcp.Description("Max results (default 50)")),
 		mcp.WithBoolean("include_archived", mcp.Description("Include archived (default false)")),
-		mcp.WithString("format", mcp.Description("'md' (default, markdown table — ~half the tokens) or 'json'"), mcp.Enum("md", "json")),
+		formatParam,
 	)
 }
 
@@ -742,11 +748,13 @@ func removeTeamMemberTool() mcp.Tool {
 func getTeamInboxTool() mcp.Tool {
 	return mcp.NewTool(
 		"get_team_inbox",
-		mcp.WithDescription("Get messages sent to a team (to='team:slug')."),
+		mcp.WithDescription("Get messages sent to a team (to='team:slug'). Content is preview-truncated by default; pass full_content=true for untruncated bodies."),
 		asParam,
 		projectParam,
 		mcp.WithString("team", mcp.Description("Team slug"), mcp.Required()),
 		mcp.WithNumber("limit", mcp.Description("Max messages (default 50)")),
+		mcp.WithBoolean("full_content", mcp.Description("Full content instead of 300-char truncation (default false)")),
+		formatParam,
 	)
 }
 

--- a/internal/relay/toolset_test.go
+++ b/internal/relay/toolset_test.go
@@ -76,13 +76,15 @@ func TestToolsModeFilter(t *testing.T) {
 	}
 	all = append(all, discoverToolsTool(), callToolTool())
 
-	fullCtx := context.Background()
+	// Full mode is now opt-in: it must be explicitly requested.
+	fullCtx := context.WithValue(context.Background(), toolsModeKey, ToolsModeFull)
 	full := toolsModeFilter(fullCtx, all)
 	if len(full) != len(all)-2 {
 		t.Errorf("full mode: %d tools, want %d (discovery pair hidden)", len(full), len(all)-2)
 	}
 
-	discCtx := context.WithValue(context.Background(), toolsModeKey, ToolsModeDiscovery)
+	// Discovery is the default: a bare context resolves to discovery.
+	discCtx := context.Background()
 	disc := toolsModeFilter(discCtx, all)
 	if len(disc) != 2 {
 		t.Errorf("discovery mode: %d tools, want 2", len(disc))
@@ -90,16 +92,25 @@ func TestToolsModeFilter(t *testing.T) {
 }
 
 func TestHTTPContextFuncToolsMode(t *testing.T) {
-	req := &http.Request{URL: &url.URL{RawQuery: "project=p1&tools=discovery"}}
+	// Explicit full opts out of the discovery default.
+	req := &http.Request{URL: &url.URL{RawQuery: "project=p1&tools=full"}}
 	ctx := HTTPContextFunc(context.Background(), req)
-	if ToolsModeFromContext(ctx) != ToolsModeDiscovery {
-		t.Error("tools=discovery not propagated")
+	if ToolsModeFromContext(ctx) != ToolsModeFull {
+		t.Error("tools=full not propagated")
 	}
 
+	// No tools param → discovery (the default).
 	req = &http.Request{URL: &url.URL{RawQuery: "project=p1"}}
 	ctx = HTTPContextFunc(context.Background(), req)
-	if ToolsModeFromContext(ctx) != ToolsModeFull {
-		t.Error("default mode should be full")
+	if ToolsModeFromContext(ctx) != ToolsModeDiscovery {
+		t.Error("default mode should be discovery")
+	}
+
+	// Explicit discovery is also honored.
+	req = &http.Request{URL: &url.URL{RawQuery: "project=p1&tools=discovery"}}
+	ctx = HTTPContextFunc(context.Background(), req)
+	if ToolsModeFromContext(ctx) != ToolsModeDiscovery {
+		t.Error("tools=discovery not propagated")
 	}
 }
 


### PR DESCRIPTION
Implements the **token-efficiency P0/P1** findings from the audit plus the **process-fatal EventBus race** (code-quality C1). Security / CI / DB findings are intentionally deferred (owner triaged them to P3).

## Changes

### 1. EventBus.Emit data race → process crash *(fix)*
`Emit` iterated `b.subs` after releasing the lock → Go's fatal `concurrent map iteration and map write` whenever an SSE client connected/disconnected during an emit, plus a `send on closed channel` window vs `Unsubscribe`. Now fans out under `RLock` (synchronized against Subscribe/Unsubscribe, can't close mid-send; sends stay non-blocking). Adds a `-race` churn test.

### 2. Discovery tool mode default-on → **~9,718 tokens/boot saved** *(perf)*
Progressive disclosure was opt-in, so every default connection paid the full `tools/list`: **~40.6KB / ~10,146 tok**. Flipped to discovery default (**~1.7KB / ~428 tok**); `?tools=full` opts back in. Dispatch is unaffected by mode — every tool stays callable by name — so direct-call clients keep working.

### 3. Def.7 hard ceiling on P0/constraints bypass *(fix)*
P0 messages/tasks + constraints memories bypassed the soft budget with no outer cap (priority is caller-settable). Any agent could flood 50 P0 msgs and add ~6,000 tok to a peer's every boot — a cross-agent context-amplification vector. Added `budgetHardMultiplier` (×2): bypass items now obey a hard ceiling, the single most-important item still always surfaces, overflow reported via existing `*_omitted` counters.

### 4. Lean `get_thread` / `get_team_inbox` *(perf)*
`get_thread` injected up to 200 full message bodies (100k+ tok); `get_team_inbox` dumped raw structs. Both now preview-truncate (300 chars unless `full_content=true`) and default to a markdown table, matching `get_inbox`. Hoisted the duplicated `format` param to a shared `formatParam`.

## Verification
- `go build ./...`, `go vet ./...` clean
- `go test ./... -race` — all green
- Token tests: init **96%** saved (10,146→428 tok); table-vs-json 17–52% saved
- New tests: EventBus `-race` churn, Def.7 hard-ceiling (messages + tasks)

## Compatibility note
Flipping discovery-default changes what bare (no `?tools=`) MCP connections see on `tools/list` (2 tools vs 58). Clients that browse via `tools/list` should call `discover_tools` first or connect with `?tools=full`. Tools invoked by name are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)