### PR TITLE
fix: bound graceful shutdown (C2) + detector lock-during-send (C3)

### DIFF
--- a/internal/ingest/detector.go
+++ b/internal/ingest/detector.go
@@ -183,9 +183,13 @@ func (d *Detector) run(ctx context.Context) {
 }
 
 func (d *Detector) tick(now time.Time) {
+	// Collect channel events while holding the lock, but emit them only after
+	// releasing it: sending on d.out while holding d.mu means a stalled consumer
+	// (buffer full) would block tick with the lock held, head-of-line-blocking
+	// every RecordEvent/GetSessions. broadcast() stays under the lock because it
+	// reads d.sessions via getSessionsLocked.
+	var pending []AgentEvent
 	d.mu.Lock()
-	defer d.mu.Unlock()
-
 	for sid, s := range d.sessions {
 		elapsed := now.Sub(s.lastEvent)
 
@@ -201,12 +205,12 @@ func (d *Detector) tick(now time.Time) {
 			if s.state != "exited" {
 				s.state = "exited"
 				s.activity = ActivityIdle
-				d.out <- AgentEvent{
+				pending = append(pending, AgentEvent{
 					Type:      EventAgentExit,
 					SessionID: sid,
 					Activity:  ActivityIdle,
 					Timestamp: now,
-				}
+				})
 			}
 			delete(d.sessions, sid)
 			continue
@@ -216,12 +220,12 @@ func (d *Detector) tick(now time.Time) {
 			s.idleSent = true
 			s.state = "idle"
 			s.activity = ActivityIdle
-			d.out <- AgentEvent{
+			pending = append(pending, AgentEvent{
 				Type:      EventIdle,
 				SessionID: sid,
 				Activity:  ActivityIdle,
 				Timestamp: now,
-			}
+			})
 			continue
 		}
 
@@ -229,14 +233,19 @@ func (d *Detector) tick(now time.Time) {
 			s.waitSent = true
 			s.state = "waiting"
 			s.activity = ActivityWaiting
-			d.out <- AgentEvent{
+			pending = append(pending, AgentEvent{
 				Type:      EventWaiting,
 				SessionID: sid,
 				Activity:  ActivityWaiting,
 				Timestamp: now,
-			}
+			})
 		}
 	}
 
 	d.broadcast()
+	d.mu.Unlock()
+
+	for _, ev := range pending {
+		d.out <- ev
+	}
 }

--- a/internal/ingest/detector_test.go
+++ b/internal/ingest/detector_test.go
@@ -1,0 +1,55 @@
+package ingest
+
+import (
+	"testing"
+	"time"
+)
+
+// TestDetector_TickEmitsWithoutHoldingLock is a regression test for C3: tick
+// must not hold d.mu while sending on d.out. If it does, a stalled consumer
+// (full/unbuffered channel) blocks tick with the lock held, head-of-line
+// blocking every RecordEvent/GetSessions. We make d.out unbuffered so tick's
+// emit blocks, then assert RecordEvent + GetSessions still proceed.
+func TestDetector_TickEmitsWithoutHoldingLock(t *testing.T) {
+	out := make(chan AgentEvent) // unbuffered: tick's send blocks until drained
+	d := newDetector(out)
+
+	// Session old enough to trigger an idle event on the next tick.
+	d.RecordEvent(AgentEvent{
+		SessionID: "s1",
+		Type:      EventToolEnd,
+		Timestamp: time.Now().Add(-idleThreshold - time.Second),
+	})
+
+	tickDone := make(chan struct{})
+	go func() {
+		d.tick(time.Now())
+		close(tickDone)
+	}()
+
+	// While tick is blocked emitting on the unbuffered channel, d.mu must be
+	// free — these must not hang.
+	lockFree := make(chan struct{})
+	go func() {
+		d.RecordEvent(AgentEvent{SessionID: "s2", Type: EventToolEnd, Timestamp: time.Now()})
+		_ = d.GetSessions()
+		close(lockFree)
+	}()
+
+	select {
+	case <-lockFree:
+	case <-time.After(2 * time.Second):
+		t.Fatal("RecordEvent/GetSessions blocked while tick emitted — lock held during channel send (C3 regression)")
+	}
+
+	// Drain the event tick is emitting so it can finish.
+	select {
+	case ev := <-out:
+		if ev.Type != EventIdle {
+			t.Fatalf("expected idle event, got %s", ev.Type)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("expected an idle event from tick")
+	}
+	<-tickDone
+}

--- a/internal/relay/api.go
+++ b/internal/relay/api.go
@@ -976,6 +976,8 @@ func (r *Relay) apiStreamActivity(w http.ResponseWriter, req *http.Request) {
 		select {
 		case <-req.Context().Done():
 			return
+		case <-r.shutdownCtx.Done():
+			return
 		case snap, ok := <-ch:
 			if !ok {
 				return
@@ -1005,6 +1007,8 @@ func (r *Relay) apiStreamEvents(w http.ResponseWriter, req *http.Request) {
 	for {
 		select {
 		case <-req.Context().Done():
+			return
+		case <-r.shutdownCtx.Done():
 			return
 		case evt, ok := <-ch:
 			if !ok {

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -40,6 +40,11 @@ type Relay struct {
 	Version    string
 	httpServer *http.Server
 	StartedAt  time.Time
+	// shutdownCtx is cancelled by Shutdown so long-lived handlers (SSE streams)
+	// unblock and return — otherwise http.Server.Shutdown waits forever on them
+	// (their only other exit is the client closing the request).
+	shutdownCtx    context.Context
+	shutdownCancel context.CancelFunc
 }
 
 // New creates a fully wired Relay with all tools registered.
@@ -73,6 +78,7 @@ func New(database *db.DB, ingester *ingest.Ingester, cfg config.Config) *Relay {
 	// Initialize notifications subsystem (rules evaluator + digest scheduler).
 	// Seeds default rules on first run.
 	notifier := NewNotifier(database, registry, events)
+	shutdownCtx, shutdownCancel := context.WithCancel(context.Background())
 	handlers.SetNotifier(notifier)
 
 	// The Linear connector is wired after construction via ReconfigureLinear()
@@ -93,17 +99,19 @@ func New(database *db.DB, ingester *ingest.Ingester, cfg config.Config) *Relay {
 	)
 
 	return &Relay{
-		MCPServer: mcpSrv,
-		HTTP:      httpSrv,
-		DB:        database,
-		Registry:  registry,
-		Ingester:  ingester,
-		Events:    events,
-		Handlers:  handlers,
-		Notifier:  notifier,
-		taskConn:  connector.Noop{},
-		Config:    cfg,
-		StartedAt: time.Now().UTC(),
+		MCPServer:      mcpSrv,
+		HTTP:           httpSrv,
+		DB:             database,
+		Registry:       registry,
+		Ingester:       ingester,
+		Events:         events,
+		Handlers:       handlers,
+		Notifier:       notifier,
+		taskConn:       connector.Noop{},
+		Config:         cfg,
+		StartedAt:      time.Now().UTC(),
+		shutdownCtx:    shutdownCtx,
+		shutdownCancel: shutdownCancel,
 	}
 }
 
@@ -142,8 +150,13 @@ func (r *Relay) buildMiddlewareChain(handler http.Handler) http.Handler {
 	return handler
 }
 
-// Shutdown gracefully stops the HTTP server.
+// Shutdown gracefully stops the HTTP server. It first cancels shutdownCtx so
+// long-lived SSE handlers unblock and return, then waits for in-flight handlers
+// via http.Server.Shutdown (bounded by the caller's ctx).
 func (r *Relay) Shutdown(ctx context.Context) error {
+	if r.shutdownCancel != nil {
+		r.shutdownCancel()
+	}
 	if r.httpServer != nil {
 		return r.httpServer.Shutdown(ctx)
 	}

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	"agent-relay/internal/cli"
 	"agent-relay/internal/config"
@@ -124,7 +125,11 @@ func startServer() {
 	<-ctx.Done()
 	close(cleanupDone)
 	log.Println("shutting down...")
-	if err := r.Shutdown(context.Background()); err != nil {
+	// Bound the shutdown: Shutdown cancels SSE streams so they unblock, but cap
+	// the wait so a stuck handler can't hang the process forever.
+	shutdownCtx, cancelShutdown := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancelShutdown()
+	if err := r.Shutdown(shutdownCtx); err != nil {
 		log.Printf("shutdown error: %v", err)
 	}
 }


### PR DESCRIPTION
Two concurrency/ops correctness fixes from the audit (code-quality C2 + C3). Not security/CI/DB (those stay P3).

## C2 — graceful shutdown could hang forever *(Medium)*
`http.Server.Shutdown` waits for in-flight handlers; the SSE handlers (`apiStreamActivity`/`apiStreamEvents`) only return on the client closing the request, so SIGINT/SIGTERM with any SSE client connected blocked the process indefinitely (needed external SIGKILL).

**Fix:** `Relay.shutdownCtx`, cancelled at the top of `Shutdown()` → SSE loops unblock via a new `select` case. `main` now bounds shutdown with a 10s timeout context.

## C3 — detector held its lock while emitting events *(Low, latent)*
`Detector.tick` sent on `d.out` three times while holding `d.mu`. Buffered, so latent: a stalled consumer filling the buffer would block `tick` with the lock held, head-of-line-blocking every `RecordEvent`/`GetSessions`.

**Fix:** collect events under the lock, keep `broadcast()` under the lock (it reads `d.sessions` via `getSessionsLocked`), release, then emit on `d.out`. Adds a `-race` regression test proving the lock is free while `tick` emits on an unbuffered channel (also the first test for `internal/ingest`, previously 0% cov).

## Verification
- `go build`, `go vet` clean
- `go test ./... -race` green
- New `-race` test `TestDetector_TickEmitsWithoutHoldingLock`

🤖 Generated with [Claude Code](https://claude.com/claude-code)