### PR TITLE
chore(ci): .gitattributes + pin golangci + harden release create

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,28 @@
+# Normalize line endings: store everything as LF in the repo, check out LF.
+# Stops CRLF from leaking into commits / poisoning gofmt + golangci diffs on
+# machines with core.autocrlf=true.
+* text=auto eol=lf
+
+*.go   text eol=lf
+*.sh   text eol=lf
+*.mod  text eol=lf
+*.sum  text eol=lf
+*.md   text eol=lf
+*.yml  text eol=lf
+*.yaml text eol=lf
+*.json text eol=lf
+*.js   text eol=lf
+*.css  text eol=lf
+*.html text eol=lf
+
+# Windows scripts want CRLF.
+*.ps1 text eol=crlf
+
+# Binary assets — never normalize.
+*.png binary
+*.gif binary
+*.jpg binary
+*.jpeg binary
+*.ico binary
+*.woff binary
+*.woff2 binary

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,5 +19,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v7
         with:
-          version: latest
+          # Pinned for reproducible lint — a floating "latest" can turn main red
+          # with no code change when a new golangci release lands.
+          version: v2.12.2
           args: --timeout=5m

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,12 +96,15 @@ jobs:
         run: |
           VERSION="${GITHUB_REF_NAME}"
 
-          # Create release if it doesn't exist, then upload assets
-          gh release create "$VERSION" \
-            --title "$VERSION" \
-            --generate-notes \
-            --latest \
-            2>/dev/null || true
+          # Create the release only if it doesn't already exist (idempotent on
+          # re-run). Don't blanket-swallow errors — a real failure (auth, rate
+          # limit) should surface instead of silently continuing.
+          if ! gh release view "$VERSION" >/dev/null 2>&1; then
+            gh release create "$VERSION" \
+              --title "$VERSION" \
+              --generate-notes \
+              --latest
+          fi
 
           gh release upload "$VERSION" \
             artifacts/agent-relay-*.tar.gz \


### PR DESCRIPTION
CI/CD audit items G + I-partial. Low-risk hygiene.

- **.gitattributes** — `* text=auto eol=lf` (+ `*.ps1 crlf`, binaries). Kills the CRLF churn that's been biting every PR on this autocrlf machine. `git add --renormalize .` touched 0 files (repo already LF) → preventive only.
- **pin golangci-lint** v2.12.2 (was `latest`) — reproducible lint; a floating version can redden main with no code change (it did, on the v1.0.0 merge).
- **harden release.yml** — replace `gh release create … || true` with an explicit `gh release view` existence check so real errors surface.

Note: `.gitignore` already covers binaries/db/scratch — no committed cruft to remove.

🤖 Generated with [Claude Code](https://claude.com/claude-code)