### PR TITLE
fix(db): RELAY_DB path override (footgun) + atomic message fan-out

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -17,18 +17,30 @@ type DB struct {
 	path   string
 }
 
-func New() (*DB, error) {
+// resolveDBPath returns the database file path. RELAY_DB overrides the default
+// (~/.agent-relay/relay.db) — set it in dev / CI / tests so a local `agent-relay`
+// run never opens (and migrates) the production database. This is the guard
+// against the footgun where a dev `agent-relay send` mutates prod.
+func resolveDBPath() (string, error) {
+	if p := os.Getenv("RELAY_DB"); p != "" {
+		return p, nil
+	}
 	home, err := os.UserHomeDir()
 	if err != nil {
-		return nil, fmt.Errorf("get home dir: %w", err)
+		return "", fmt.Errorf("get home dir: %w", err)
+	}
+	return filepath.Join(home, ".agent-relay", "relay.db"), nil
+}
+
+func New() (*DB, error) {
+	dbPath, err := resolveDBPath()
+	if err != nil {
+		return nil, err
 	}
 
-	dbDir := filepath.Join(home, ".agent-relay")
-	if err := os.MkdirAll(dbDir, 0700); err != nil {
+	if err := os.MkdirAll(filepath.Dir(dbPath), 0700); err != nil {
 		return nil, fmt.Errorf("create db dir: %w", err)
 	}
-
-	dbPath := filepath.Join(dbDir, "relay.db")
 
 	// Writer pool: single connection serializes writes at Go level (SQLite only allows 1 writer).
 	writer, err := sql.Open("sqlite3", dbPath+"?_journal_mode=WAL&_busy_timeout=10000&_synchronous=NORMAL&_cache_size=-20000&_foreign_keys=ON&_txlock=immediate")
@@ -97,13 +109,10 @@ func (d *DB) GetHealthStats() map[string]int64 {
 	return stats
 }
 
-// DBPath returns the default database path without opening it.
+// DBPath returns the database path (RELAY_DB override or default) without
+// opening it.
 func DBPath() (string, error) {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(home, ".agent-relay", "relay.db"), nil
+	return resolveDBPath()
 }
 
 // NewReadOnly opens the database in read-only mode for CLI queries.

--- a/internal/db/db_path_atomic_test.go
+++ b/internal/db/db_path_atomic_test.go
@@ -1,0 +1,61 @@
+package db
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestResolveDBPath_RespectsRelayDBEnv(t *testing.T) {
+	t.Setenv("RELAY_DB", "/custom/relay-dev.db")
+	got, err := resolveDBPath()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "/custom/relay-dev.db" {
+		t.Fatalf("RELAY_DB override ignored: got %q", got)
+	}
+}
+
+func TestResolveDBPath_DefaultWhenUnset(t *testing.T) {
+	t.Setenv("RELAY_DB", "")
+	got, err := resolveDBPath()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasSuffix(filepath.ToSlash(got), ".agent-relay/relay.db") {
+		t.Fatalf("default path wrong: %q", got)
+	}
+}
+
+// TestInsertMessageWithDeliveries_Atomic verifies the message and its delivery
+// rows land together and the recipient can read the message from their inbox.
+func TestInsertMessageWithDeliveries_Atomic(t *testing.T) {
+	d, err := NewTestDB(filepath.Join(t.TempDir(), "t.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = d.Close() }()
+
+	msg, err := d.InsertMessageWithDeliveries("p1", "alice", "bob", "notification", "hi", "body", "{}", "P2", 3600, nil, nil, []string{"bob"})
+	if err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	if msg.ID == "" {
+		t.Fatal("empty message id")
+	}
+
+	inbox, err := d.GetInbox("p1", "bob", true, 10)
+	if err != nil {
+		t.Fatalf("inbox: %v", err)
+	}
+	found := false
+	for _, m := range inbox {
+		if m.ID == msg.ID {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("message+delivery not atomic — message not visible in recipient inbox")
+	}
+}

--- a/internal/db/messages.go
+++ b/internal/db/messages.go
@@ -44,6 +44,65 @@ func (d *DB) InsertMessage(project, from, to, msgType, subject, content, metadat
 	return msg, nil
 }
 
+// InsertMessageWithDeliveries inserts a message and its delivery rows in a
+// single transaction. The inbox reads the deliveries table, so a message
+// inserted without its deliveries (a crash or error between the two writes) is
+// silently never delivered. recipients is the already-resolved fan-out list
+// (one entry for a direct send, every active peer for a broadcast). Notifying
+// recipients and team-inbox bookkeeping stay outside — they are best-effort.
+func (d *DB) InsertMessageWithDeliveries(project, from, to, msgType, subject, content, metadata, priority string, ttlSeconds int, replyTo, conversationID *string, recipients []string) (*models.Message, error) {
+	now := time.Now().UTC().Format("2006-01-02T15:04:05.000000Z")
+	if priority == "" {
+		priority = "P2"
+	}
+	if ttlSeconds < 0 {
+		ttlSeconds = 14400
+	}
+
+	msg := &models.Message{
+		ID:             uuid.New().String(),
+		From:           from,
+		To:             to,
+		ReplyTo:        replyTo,
+		Type:           msgType,
+		Subject:        subject,
+		Content:        normalize.JSONKeys(content),
+		Metadata:       normalize.JSONKeys(metadata),
+		CreatedAt:      now,
+		ConversationID: conversationID,
+		Project:        project,
+		Priority:       priority,
+		TTLSeconds:     ttlSeconds,
+	}
+
+	tx, err := d.conn.Begin()
+	if err != nil {
+		return nil, fmt.Errorf("begin tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }() // no-op once committed
+
+	if _, err := tx.Exec(
+		"INSERT INTO messages (id, from_agent, to_agent, reply_to, type, subject, content, metadata, created_at, conversation_id, project, priority, ttl_seconds) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+		msg.ID, msg.From, msg.To, msg.ReplyTo, msg.Type, msg.Subject, msg.Content, msg.Metadata, msg.CreatedAt, msg.ConversationID, msg.Project, msg.Priority, msg.TTLSeconds,
+	); err != nil {
+		return nil, fmt.Errorf("insert message: %w", err)
+	}
+
+	for i, agent := range recipients {
+		if _, err := tx.Exec(
+			"INSERT INTO deliveries (id, message_id, to_agent, state, sequence_number, created_at, project) VALUES (?, ?, ?, 'queued', ?, ?, ?)",
+			uuid.New().String(), msg.ID, agent, i, now, project,
+		); err != nil {
+			return nil, fmt.Errorf("create delivery for %s: %w", agent, err)
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("commit message+deliveries: %w", err)
+	}
+	return msg, nil
+}
+
 // InboxFilter holds optional filtering parameters for get_inbox.
 type InboxFilter struct {
 	MinPriority       string // e.g. "P1" — only messages with priority <= this

--- a/internal/relay/api.go
+++ b/internal/relay/api.go
@@ -684,14 +684,11 @@ func (r *Relay) apiPostUserResponse(w http.ResponseWriter, req *http.Request) {
 
 	replyTo := optionalString(body.ReplyTo)
 
-	msg, err := r.DB.InsertMessage(body.Project, "user", body.To, "response", "User response", body.Content, "{}", "P1", 3600, replyTo, nil)
+	msg, err := r.DB.InsertMessageWithDeliveries(body.Project, "user", body.To, "response", "User response", body.Content, "{}", "P1", 3600, replyTo, nil, []string{body.To})
 	if err != nil {
 		http.Error(w, `{"error":"failed to send response"}`, http.StatusInternalServerError)
 		return
 	}
-
-	// Create delivery record so the message appears in the agent's inbox
-	_ = r.DB.CreateDeliveries(msg.ID, body.Project, []string{body.To})
 
 	// Push notification to the target agent
 	r.Registry.Notify(body.Project, body.To, "user", "User response", msg.ID)

--- a/internal/relay/handlers.go
+++ b/internal/relay/handlers.go
@@ -212,13 +212,9 @@ func (h *Handlers) sendCrossProject(ctx context.Context, srcProject, from, dstPr
 	// Insert the message in the DESTINATION project scope — this is what makes
 	// it visible in the recipient's get_inbox(project=dstProject) without any
 	// special routing in the read path.
-	msg, err := h.db.InsertMessage(dstProject, from, to, msgType, subject, content, string(metaBytes), priority, ttlSeconds, replyTo, nil)
+	msg, err := h.db.InsertMessageWithDeliveries(dstProject, from, to, msgType, subject, content, string(metaBytes), priority, ttlSeconds, replyTo, nil, []string{to})
 	if err != nil {
-		return mcp.NewToolResultError(fmt.Sprintf("failed to insert cross-project message: %v", err)), nil
-	}
-	// Delivery for the single recipient in the destination project
-	if err := h.db.CreateDeliveries(msg.ID, dstProject, []string{to}); err != nil {
-		return mcp.NewToolResultError(fmt.Sprintf("delivery failed: %v", err)), nil
+		return mcp.NewToolResultError(fmt.Sprintf("failed to send cross-project message: %v", err)), nil
 	}
 
 	// Push notification if the target has an open session

--- a/internal/relay/handlers_messaging.go
+++ b/internal/relay/handlers_messaging.go
@@ -92,24 +92,25 @@ func (h *Handlers) HandleSendMessage(ctx context.Context, req mcp.CallToolReques
 			return mcp.NewToolResultError(fmt.Sprintf("team '%s' not found", teamSlug)), nil
 		}
 
-		msg, err := h.db.InsertMessage(project, from, to, msgType, subject, content, metadata, priority, ttlSeconds, replyTo, conversationID)
-		if err != nil {
-			return mcp.NewToolResultError(fmt.Sprintf("failed to send message: %v", err)), nil
-		}
-
-		// Add to team inbox
-		_ = h.db.AddToTeamInbox(team.ID, msg.ID)
-
-		// Create deliveries for team members
+		// Resolve team recipients first, then insert message + deliveries atomically.
 		members, _ := h.db.GetTeamMemberNames(team.ID)
 		var recipients []string
 		for _, member := range members {
 			if member != from {
 				recipients = append(recipients, member)
-				h.registry.Notify(project, member, from, subject, msg.ID)
 			}
 		}
-		_ = h.db.CreateDeliveries(msg.ID, project, recipients)
+
+		msg, err := h.db.InsertMessageWithDeliveries(project, from, to, msgType, subject, content, metadata, priority, ttlSeconds, replyTo, conversationID, recipients)
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("failed to send message: %v", err)), nil
+		}
+
+		// Best-effort bookkeeping + notifications after the durable write.
+		_ = h.db.AddToTeamInbox(team.ID, msg.ID)
+		for _, member := range recipients {
+			h.registry.Notify(project, member, from, subject, msg.ID)
+		}
 
 		return h.resultJSONTracked(project, from, "send_message", msg)
 	}
@@ -125,14 +126,13 @@ func (h *Handlers) HandleSendMessage(ctx context.Context, req mcp.CallToolReques
 		}
 	}
 
-	msg, err := h.db.InsertMessage(project, from, to, msgType, subject, content, metadata, priority, ttlSeconds, replyTo, conversationID)
+	// Resolve fan-out recipients first, then insert message + deliveries atomically
+	// so a message can never be persisted without its deliveries (silent non-delivery).
+	recipients, _ := h.db.ResolveRecipients(project, to, from, conversationID)
+	msg, err := h.db.InsertMessageWithDeliveries(project, from, to, msgType, subject, content, metadata, priority, ttlSeconds, replyTo, conversationID, recipients)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("failed to send message: %v", err)), nil
 	}
-
-	// Create deliveries
-	recipients, _ := h.db.ResolveRecipients(project, to, from, conversationID)
-	_ = h.db.CreateDeliveries(msg.ID, project, recipients)
 
 	// Push notification
 	if conversationID != nil {

--- a/internal/relay/notifications.go
+++ b/internal/relay/notifications.go
@@ -316,12 +316,11 @@ func (n *Notifier) doMessage(rule models.NotificationRule, project string, paylo
 
 	var sent int
 	for _, to := range recipients {
-		msg, err := n.db.InsertMessage(project, "notifier", to, "notification", subject, content, meta, priority, ttl, nil, nil)
+		msg, err := n.db.InsertMessageWithDeliveries(project, "notifier", to, "notification", subject, content, meta, priority, ttl, nil, nil, []string{to})
 		if err != nil {
 			rec.Error = err.Error()
 			continue
 		}
-		_ = n.db.CreateDeliveries(msg.ID, project, []string{to})
 		n.registry.Notify(project, to, "notifier", subject, msg.ID)
 		sent++
 	}


### PR DESCRIPTION
DB audit findings A (Critical) + B (High). Sec/CI/DB P3 batch, un-deferred per owner.

## A — prod-DB-path footgun *(Critical)*
DB path was hardcoded `~/.agent-relay/relay.db`, **no override** — a local `agent-relay send`/`serve` opened *and migrated* the production DB. Added `resolveDBPath()` with a **`RELAY_DB`** env override, threaded through `New()` / `DBPath()` / `NewReadOnly()`. Set `RELAY_DB=/tmp/dev.db` in dev/CI → local runs never touch prod.

## B — non-atomic message fan-out *(High)*
Handlers did `InsertMessage` then `_ = CreateDeliveries(...)` (error dropped). The inbox reads the **deliveries** table, so a crash/error between the two writes = a message silently never delivered. New `InsertMessageWithDeliveries` does both in **one transaction**, propagating the error. Converted all 5 server sites: send_message (direct + team), cross-project DM, notifier digest, REST user-response.

## Verification
- `go build`, `go vet` clean; `go test ./... -race` green
- New tests: `RELAY_DB` override + default; atomic insert→inbox visibility

Note: migrate-gating (CLI never running migrations) deferred — `RELAY_DB` already closes the dev-hits-prod path, the core risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)