### PR TITLE
fix(security): dashboard XSS — DOMPurify sanitize + quote-safe escapers

### DIFF
--- a/internal/web/static/index.html
+++ b/internal/web/static/index.html
@@ -9,7 +9,8 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easymde/dist/easymde.min.css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@xterm/xterm@5/css/xterm.css">
   <link rel="stylesheet" href="/style.css">
-  <script src="https://cdn.jsdelivr.net/npm/marked/lib/marked.umd.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/dompurify@3.1.6/dist/purify.min.js" integrity="sha384-oSkv+S0MkwAcbyC/m+8Xv0z2k1yEL2Bh2YFaSfAxItCDpVsKOvjHVTt3ul8mgA+g" crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/marked@12.0.2/marked.min.js" integrity="sha384-5sPe13xoCFZTyUgG9cuSUbCYjJgaKotjMbseBqsz7kO/VDf6rDVPnHYa6LbEPaj+" crossorigin="anonymous"></script>
 </head>
 <body>
   <header id="header">

--- a/internal/web/static/js/command-panel.js
+++ b/internal/web/static/js/command-panel.js
@@ -3,10 +3,15 @@
 // HUD / Retro-futurism aesthetic: scanlines, neon glow, monospace
 
 function esc(str) {
-  if (!str) return '';
-  const d = document.createElement('div');
-  d.textContent = str;
-  return d.innerHTML;
+  // Quote-safe: also escapes " and ' so values are safe inside HTML attributes
+  // (textContent→innerHTML does NOT escape quotes → attribute-injection XSS).
+  if (str == null) return '';
+  return String(str)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
 }
 
 function timeAgo(dateStr) {

--- a/internal/web/static/js/kanban.js
+++ b/internal/web/static/js/kanban.js
@@ -114,10 +114,14 @@ function fmtTS(ts) {
 }
 
 function esc(str) {
+  // Quote-safe (escapes " and ') for safe use inside HTML attributes.
   if (str === undefined || str === null) return "";
-  const d = document.createElement("div");
-  d.textContent = String(str);
-  return d.innerHTML;
+  return String(str)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
 }
 
 function parseLabels(raw) {

--- a/internal/web/static/js/main.js
+++ b/internal/web/static/js/main.js
@@ -1805,18 +1805,23 @@ function formatTime(isoStr) {
 }
 
 function escapeHtml(str) {
-  return str
+  return String(str ?? "")
     .replace(/&/g, "&amp;")
     .replace(/</g, "&lt;")
     .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;");
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
 }
 
 /** Render markdown to HTML using marked (loaded via CDN). Falls back to escaped text. */
 function renderMarkdown(text) {
-  if (typeof marked !== "undefined") {
+  // Sanitize marked's HTML with DOMPurify before it ever reaches innerHTML —
+  // task descriptions/messages are agent-controlled, so unsanitized markdown is
+  // a stored-XSS sink. Require BOTH libs; if either is missing, fall back to
+  // escaped text rather than inject raw HTML.
+  if (typeof marked !== "undefined" && typeof DOMPurify !== "undefined") {
     try {
-      return marked.parse(text, { gfm: true, breaks: true });
+      return DOMPurify.sanitize(marked.parse(text, { gfm: true, breaks: true }));
     } catch (_) { /* fall through */ }
   }
   return escapeHtml(text).replace(/\n/g, "<br>");
@@ -2075,8 +2080,13 @@ function getViewFilteredTasks() {
 }
 
 function esc(s) {
-  if (!s) return "";
-  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+  if (s == null) return "";
+  return String(s)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
 }
 
 function renderTasks() {

--- a/internal/web/static/js/notifications.js
+++ b/internal/web/static/js/notifications.js
@@ -14,10 +14,14 @@ const EVENTS = [
 const ACTIONS = ["message", "webhook", "slack"];
 
 function esc(s) {
+  // Quote-safe (escapes " and ') for safe use inside HTML attributes.
   if (s == null) return "";
-  const d = document.createElement("div");
-  d.textContent = String(s);
-  return d.innerHTML;
+  return String(s)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
 }
 
 function timeAgo(dateStr) {

--- a/internal/web/static/js/stats.js
+++ b/internal/web/static/js/stats.js
@@ -14,10 +14,14 @@ const STATE_STYLE = {
 };
 
 function esc(str) {
+  // Quote-safe (escapes " and ') for safe use inside HTML attributes.
   if (str == null) return "";
-  const d = document.createElement("div");
-  d.textContent = String(str);
-  return d.innerHTML;
+  return String(str)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
 }
 
 // Format seconds → compact human duration.


### PR DESCRIPTION
Security audit H3 + the attribute-injection finding.

## Stored XSS *(High)*
`renderMarkdown` piped agent-controlled task descriptions/messages through `marked.parse` → `innerHTML` with **no sanitizer**. Now wraps marked output in `DOMPurify.sanitize` (requires both libs, else escaped-text fallback). `marked` pinned **v12.0.2** + **DOMPurify@3.1.6** added, both with **SRI** integrity (marked was loading unpinned from CDN).

## Attribute-injection XSS *(Med-High)*
`esc()` in command-panel/stats/kanban/notifications used `textContent→innerHTML` — escapes `<>&` but **not quotes**, so agent-controlled names/titles in `value="…"`/`href="…"` could break out. All replaced with a quote-safe escaper (also `"` and `'`); `escapeHtml` + main.js `esc()` hardened too.

## ⚠️ CSP deferred
A wrong CSP silently breaks the dashboard (xterm WS terminal, easymde, dynamic CDN loads) and there's **no frontend CI** to catch it. Needs a live-dashboard test pass — flagged as follow-up rather than shipped blind.

## Verification
- `go build` clean (assets embed); `go test ./...` green
- `node --check` passes on all 5 edited JS files
- SRI hashes computed from the pinned CDN files

🤖 Generated with [Claude Code](https://claude.com/claude-code)