### PR TITLE
fix(db): rotated backups (VACUUM INTO) + drop DeleteProject no-op FK PRAGMA

### DIFF
--- a/internal/db/backup_test.go
+++ b/internal/db/backup_test.go
@@ -1,0 +1,41 @@
+package db
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestBackup_VacuumIntoAndRotate(t *testing.T) {
+	dir := t.TempDir()
+	d, err := NewTestDB(filepath.Join(dir, "relay.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = d.Close() }()
+
+	// First snapshot.
+	p0, err := d.Backup(3)
+	if err != nil {
+		t.Fatalf("backup: %v", err)
+	}
+	if _, err := os.Stat(p0); err != nil {
+		t.Fatalf("snapshot not written: %v", err)
+	}
+
+	// A few more rotations; .bak.0 stays newest, older slots fill in.
+	for i := 0; i < 3; i++ {
+		if _, err := d.Backup(3); err != nil {
+			t.Fatalf("backup %d: %v", i, err)
+		}
+	}
+	for _, slot := range []string{".bak.0", ".bak.1", ".bak.2"} {
+		if _, err := os.Stat(filepath.Join(dir, "relay.db"+slot)); err != nil {
+			t.Errorf("expected rotated snapshot %s: %v", slot, err)
+		}
+	}
+	// keep=3 → no .bak.3
+	if _, err := os.Stat(filepath.Join(dir, "relay.db.bak.3")); err == nil {
+		t.Error("retained more snapshots than keep=3")
+	}
+}

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -97,6 +97,32 @@ func (d *DB) Optimize() {
 	_, _ = d.conn.Exec("PRAGMA wal_checkpoint(PASSIVE)")
 }
 
+// Backup writes a consistent snapshot of the database next to it via SQLite's
+// VACUUM INTO (safe on a live WAL database), rotating through `keep` numbered
+// files: relay.db.bak.0 (newest) .. relay.db.bak.(keep-1). Returns the path of
+// the new snapshot. Gives a recovery point against corruption or an accidental
+// destructive operation — the single DB file was previously the only copy.
+func (d *DB) Backup(keep int) (string, error) {
+	if keep < 1 {
+		keep = 1
+	}
+	// Rotate older snapshots up by one slot; the oldest drops off.
+	for i := keep - 1; i > 0; i-- {
+		older := fmt.Sprintf("%s.bak.%d", d.path, i)
+		newer := fmt.Sprintf("%s.bak.%d", d.path, i-1)
+		_ = os.Remove(older)
+		if _, err := os.Stat(newer); err == nil {
+			_ = os.Rename(newer, older)
+		}
+	}
+	dst := fmt.Sprintf("%s.bak.0", d.path)
+	_ = os.Remove(dst) // VACUUM INTO fails if the target already exists
+	if _, err := d.conn.Exec("VACUUM INTO ?", dst); err != nil {
+		return "", fmt.Errorf("vacuum into %s: %w", dst, err)
+	}
+	return dst, nil
+}
+
 // GetHealthStats returns aggregate database statistics for the /health endpoint.
 func (d *DB) GetHealthStats() map[string]int64 {
 	stats := map[string]int64{}

--- a/internal/db/projects.go
+++ b/internal/db/projects.go
@@ -73,8 +73,11 @@ func (d *DB) DeleteProject(name string) error {
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	// Disable FK checks during cascade delete to avoid ordering issues
-	_, _ = tx.Exec("PRAGMA foreign_keys = OFF")
+	// NOTE: PRAGMA foreign_keys is a no-op inside an active transaction (SQLite
+	// ignores it once BEGIN has run), so we don't try to disable FK enforcement.
+	// Instead the deletes below are ordered children-first (junction tables →
+	// project-scoped tables → orgs → the project row) so every FK constraint is
+	// already satisfied at each step. Keep this ordering when adding tables.
 
 	// Delete junction tables that lack a project column (linked via IDs)
 	_, _ = tx.Exec("DELETE FROM conversation_members WHERE conversation_id IN (SELECT id FROM conversations WHERE project = ?)", name)
@@ -113,7 +116,6 @@ func (d *DB) DeleteProject(name string) error {
 	if err := tx.Commit(); err != nil {
 		return err
 	}
-	_, _ = d.conn.Exec("PRAGMA foreign_keys = ON")
 	return nil
 }
 

--- a/internal/relay/cleanup.go
+++ b/internal/relay/cleanup.go
@@ -19,12 +19,17 @@ const (
 	ACKNotifyAge = 15 * time.Minute
 	// ACKEscalateAge is when to escalate the no-ACK notification.
 	ACKEscalateAge = 45 * time.Minute
+	// BackupInterval is how often a rotated DB snapshot is written.
+	BackupInterval = time.Hour
+	// BackupKeep is how many rotated snapshots to retain.
+	BackupKeep = 3
 )
 
 // StartCleanup runs a background goroutine that marks stale agents as inactive.
 // It stops when the done channel is closed.
 func StartCleanup(database *db.DB, done <-chan struct{}) {
 	ticker := time.NewTicker(PurgeInterval)
+	lastBackup := time.Now() // first snapshot fires BackupInterval after boot
 	go func() {
 		defer ticker.Stop()
 		for {
@@ -64,6 +69,15 @@ func StartCleanup(database *db.DB, done <-chan struct{}) {
 					log.Printf("purged %d old token usage record(s)", purged)
 				}
 				database.Optimize()
+
+				if time.Since(lastBackup) >= BackupInterval {
+					if path, err := database.Backup(BackupKeep); err != nil {
+						log.Printf("db backup error: %v", err)
+					} else {
+						lastBackup = time.Now()
+						log.Printf("db snapshot written: %s", path)
+					}
+				}
 			}
 		}
 	}()


### PR DESCRIPTION
DB audit: backups (Med) + DeleteProject PRAGMA (Med).

## Backups
The single `relay.db` was the only copy — corruption or an accidental `DeleteProject` was unrecoverable. Added `DB.Backup(keep)` using SQLite **`VACUUM INTO`** (safe on a live WAL db) with numbered rotation (`relay.db.bak.0..N`), wired into the cleanup loop **hourly**, retaining **3**.

## DeleteProject FK PRAGMA
`PRAGMA foreign_keys = OFF` was set **inside an active transaction**, where SQLite silently ignores it — FK enforcement was actually ON throughout, and the cascade only worked because the deletes are ordered children-first. Removed the misleading PRAGMA (and the dead `= ON` after commit); documented the required ordering.

## Deferred
Full migration versioning / fail-fast rewrite — higher risk, wants dedicated testing against real prod DBs. Noted, not in scope here.

## Verification
- `go build`, `go vet` clean; `go test ./... -race` green
- New `TestBackup_VacuumIntoAndRotate` (snapshot + rotation + keep bound)

🤖 Generated with [Claude Code](https://claude.com/claude-code)