### PR TITLE
fix(release): SHA256SUMS + verify on install/update; fix Windows updater

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,6 +90,12 @@ jobs:
           path: artifacts
           merge-multiple: true
 
+      - name: Generate SHA256SUMS
+        run: |
+          cd artifacts
+          sha256sum agent-relay-*.tar.gz agent-relay-*.zip > SHA256SUMS
+          cat SHA256SUMS
+
       - name: Create release
         env:
           GH_TOKEN: ${{ github.token }}
@@ -109,6 +115,7 @@ jobs:
           gh release upload "$VERSION" \
             artifacts/agent-relay-*.tar.gz \
             artifacts/agent-relay-*.zip \
+            artifacts/SHA256SUMS \
             install.sh \
             install.ps1 \
             --clobber

--- a/install.sh
+++ b/install.sh
@@ -443,6 +443,23 @@ download_prebuilt() {
   fi
   spinner_stop
 
+  # Verify integrity against the release SHA256SUMS before extracting. Fail
+  # closed on mismatch; only skip when the sums file is absent (older releases).
+  local sums_url="https://github.com/${REPO}/releases/download/${version}/SHA256SUMS"
+  if curl -fsSL "$sums_url" -o "$tmpdir/SHA256SUMS" 2>/dev/null; then
+    local sha_cmd="sha256sum"
+    command -v sha256sum >/dev/null 2>&1 || sha_cmd="shasum -a 256"
+    local got
+    got=$($sha_cmd "$tmpdir/archive.tar.gz")
+    got="${got%% *}"
+    if ! grep -q "$got" "$tmpdir/SHA256SUMS"; then
+      rm -rf "$tmpdir"
+      die "Checksum mismatch for ${archive_name} - refusing to install (possible tampering)."
+    fi
+  else
+    warn "SHA256SUMS not published for ${version} - skipping integrity check"
+  fi
+
   tar -xzf "$tmpdir/archive.tar.gz" -C "$tmpdir"
   install -m 755 "$tmpdir/agent-relay" "$bin_path"
 

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -1,8 +1,15 @@
 package cli
 
 import (
+	"archive/tar"
+	"archive/zip"
+	"bufio"
+	"compress/gzip"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"os/exec"
@@ -286,8 +293,13 @@ func tryDownloadUpdate(binPath, version string) bool {
 	osName := runtime.GOOS
 	arch := runtime.GOARCH
 
-	archiveName := fmt.Sprintf("agent-relay-%s-%s.tar.gz", osName, arch)
-	url := fmt.Sprintf("https://github.com/%s/releases/download/%s/%s", repo, version, archiveName)
+	// Windows ships a .zip; every other platform a .tar.gz.
+	ext := "tar.gz"
+	if osName == "windows" {
+		ext = "zip"
+	}
+	archiveName := fmt.Sprintf("agent-relay-%s-%s.%s", osName, arch, ext)
+	base := fmt.Sprintf("https://github.com/%s/releases/download/%s", repo, version)
 
 	tmpDir, err := os.MkdirTemp("", "agent-relay-dl-*")
 	if err != nil {
@@ -297,20 +309,153 @@ func tryDownloadUpdate(binPath, version string) bool {
 
 	fmt.Print("  downloading... ")
 	archivePath := filepath.Join(tmpDir, archiveName)
-	cmd := exec.Command("curl", "-fsSL", "-o", archivePath, url)
-	if err := cmd.Run(); err != nil {
+	if err := download(archivePath, base+"/"+archiveName); err != nil {
 		fmt.Println("failed")
 		return false
 	}
 	fmt.Println("ok")
 
-	// Extract
-	cmd = exec.Command("tar", "-xzf", archivePath, "-C", tmpDir)
-	if err := cmd.Run(); err != nil {
+	// Integrity: verify the archive against the release's SHA256SUMS before
+	// extracting/installing. Fail closed on mismatch; only skip when the sums
+	// file is absent (older releases that predate signing).
+	sumsPath := filepath.Join(tmpDir, "SHA256SUMS")
+	if err := download(sumsPath, base+"/SHA256SUMS"); err != nil {
+		fmt.Println("  warning: SHA256SUMS not published for this release — skipping integrity check")
+	} else {
+		ok, err := verifyChecksum(archivePath, archiveName, sumsPath)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "  error: checksum check failed: %v\n", err)
+			return false
+		}
+		if !ok {
+			fmt.Fprintln(os.Stderr, "  error: checksum mismatch — refusing to install (possible tampering)")
+			return false
+		}
+		fmt.Println("  checksum verified")
+	}
+
+	if err := extractArchive(archivePath, tmpDir); err != nil {
+		fmt.Fprintf(os.Stderr, "  error: extract failed: %v\n", err)
 		return false
 	}
 
-	return installBinary(filepath.Join(tmpDir, binaryName), binPath)
+	extracted := filepath.Join(tmpDir, binaryName)
+	if osName == "windows" {
+		extracted += ".exe"
+	}
+	return installBinary(extracted, binPath)
+}
+
+// download fetches url to dst with curl (already a dependency of the updater).
+func download(dst, url string) error {
+	return exec.Command("curl", "-fsSL", "-o", dst, url).Run()
+}
+
+// verifyChecksum compares the SHA-256 of file against the entry for name in a
+// `sha256sum`-format SHA256SUMS file ("<hex>  <name>" per line).
+func verifyChecksum(file, name, sumsPath string) (bool, error) {
+	sums, err := os.Open(sumsPath)
+	if err != nil {
+		return false, err
+	}
+	defer func() { _ = sums.Close() }()
+
+	want := ""
+	sc := bufio.NewScanner(sums)
+	for sc.Scan() {
+		fields := strings.Fields(sc.Text())
+		if len(fields) == 2 && filepath.Base(fields[1]) == name {
+			want = strings.ToLower(fields[0])
+			break
+		}
+	}
+	if want == "" {
+		return false, fmt.Errorf("no checksum entry for %s", name)
+	}
+
+	af, err := os.Open(file)
+	if err != nil {
+		return false, err
+	}
+	defer func() { _ = af.Close() }()
+	h := sha256.New()
+	if _, err := io.Copy(h, af); err != nil {
+		return false, err
+	}
+	return hex.EncodeToString(h.Sum(nil)) == want, nil
+}
+
+// extractArchive extracts files from a .tar.gz or .zip into destDir using the
+// Go stdlib — no external tar/unzip, which stock Windows lacks. Entry names are
+// flattened to their base to prevent path traversal (zip-slip).
+func extractArchive(archivePath, destDir string) error {
+	if strings.HasSuffix(archivePath, ".zip") {
+		return extractZip(archivePath, destDir)
+	}
+	return extractTarGz(archivePath, destDir)
+}
+
+func extractTarGz(archivePath, destDir string) error {
+	f, err := os.Open(archivePath)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+	gz, err := gzip.NewReader(f)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = gz.Close() }()
+	tr := tar.NewReader(gz)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return err
+		}
+		if hdr.Typeflag != tar.TypeReg {
+			continue
+		}
+		if err := writeExtracted(filepath.Join(destDir, filepath.Base(hdr.Name)), tr); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func extractZip(archivePath, destDir string) error {
+	r, err := zip.OpenReader(archivePath)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = r.Close() }()
+	for _, zf := range r.File {
+		if zf.FileInfo().IsDir() {
+			continue
+		}
+		rc, err := zf.Open()
+		if err != nil {
+			return err
+		}
+		err = writeExtracted(filepath.Join(destDir, filepath.Base(zf.Name)), rc)
+		_ = rc.Close()
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func writeExtracted(dst string, src io.Reader) error {
+	out, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o755)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = out.Close() }()
+	_, err = io.Copy(out, src) //nolint:gosec // size-bounded by our own release archive
+	return err
 }
 
 func installBinary(src, dst string) bool {

--- a/internal/cli/update_test.go
+++ b/internal/cli/update_test.go
@@ -1,0 +1,79 @@
+package cli
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeTarGz(t *testing.T, path, entry string, content []byte) {
+	t.Helper()
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = f.Close() }()
+	gz := gzip.NewWriter(f)
+	tw := tar.NewWriter(gz)
+	_ = tw.WriteHeader(&tar.Header{Name: entry, Mode: 0o755, Size: int64(len(content)), Typeflag: tar.TypeReg})
+	_, _ = tw.Write(content)
+	_ = tw.Close()
+	_ = gz.Close()
+}
+
+func TestExtractTarGz(t *testing.T) {
+	dir := t.TempDir()
+	arc := filepath.Join(dir, "agent-relay-linux-amd64.tar.gz")
+	writeTarGz(t, arc, "agent-relay", []byte("#!/bin/true\n"))
+
+	if err := extractArchive(arc, dir); err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	got, err := os.ReadFile(filepath.Join(dir, "agent-relay"))
+	if err != nil {
+		t.Fatalf("extracted binary missing: %v", err)
+	}
+	if string(got) != "#!/bin/true\n" {
+		t.Fatalf("bad content: %q", got)
+	}
+}
+
+func TestVerifyChecksum(t *testing.T) {
+	dir := t.TempDir()
+	arc := filepath.Join(dir, "agent-relay-linux-amd64.tar.gz")
+	if err := os.WriteFile(arc, []byte("payload"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	sum := sha256.Sum256([]byte("payload"))
+	sumsPath := filepath.Join(dir, "SHA256SUMS")
+	line := hex.EncodeToString(sum[:]) + "  agent-relay-linux-amd64.tar.gz\n"
+	if err := os.WriteFile(sumsPath, []byte("deadbeef  other.tar.gz\n"+line), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	ok, err := verifyChecksum(arc, "agent-relay-linux-amd64.tar.gz", sumsPath)
+	if err != nil || !ok {
+		t.Fatalf("valid checksum rejected: ok=%v err=%v", ok, err)
+	}
+
+	// Tamper the archive → must fail.
+	if err := os.WriteFile(arc, []byte("payload-TAMPERED"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ok, err = verifyChecksum(arc, "agent-relay-linux-amd64.tar.gz", sumsPath)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if ok {
+		t.Fatal("tampered archive passed checksum verification")
+	}
+
+	// Missing entry → error.
+	if _, err := verifyChecksum(arc, "nonexistent.tar.gz", sumsPath); err == nil {
+		t.Fatal("expected error for missing checksum entry")
+	}
+}


### PR DESCRIPTION
Supply-chain audit (release signing) + the broken Windows self-update.

## Integrity
- **release.yml** generates `SHA256SUMS` over all archives and uploads it with the assets.
- **update.go** downloads `SHA256SUMS` and verifies the archive **before installing** (fail closed on mismatch; skip only when absent on older releases).
- **install.sh** verifies the archive against `SHA256SUMS` before extracting.

## Windows self-update fix
`update.go` unconditionally fetched `.tar.gz` and shelled out to `tar` → **404 / no `tar`** on Windows. Now selects `.zip` on Windows and extracts via the **Go stdlib** (`archive/zip` + `archive/tar`), with zip-slip-safe base-name flattening (no external `tar`/`unzip` dependency anywhere).

## Verification
- `go build`, `go vet` clean; `go test ./...` green
- New tests: checksum verify (valid / tampered / missing entry) + tar.gz extract
- `bash -n install.sh` clean

Note: cosign/sigstore signing (provenance beyond integrity) noted as a further step — SHA256SUMS covers tamper-in-transit + corruption.

🤖 Generated with [Claude Code](https://claude.com/claude-code)