### PR TITLE
fix(security): allowlist writable settings keys

### DIFF
--- a/internal/relay/api.go
+++ b/internal/relay/api.go
@@ -297,11 +297,30 @@ func (r *Relay) apiGetSettings(w http.ResponseWriter) {
 	})
 }
 
+// writableSettings is the allowlist of keys the settings API may write. Without
+// it, an (unauthenticated by default) caller could set arbitrary key→value pairs
+// — including swapping linear_api_key or repointing the connector.
+var writableSettings = map[string]bool{
+	"sun_type":        true,
+	setLinearEnabled:  true,
+	setLinearAPIKey:   true,
+	setLinearTeamKey:  true,
+	setLinearProject:  true,
+	setLinearInterval: true,
+}
+
 func (r *Relay) apiPutSetting(w http.ResponseWriter, req *http.Request) {
 	var body map[string]string
 	if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
 		http.Error(w, `{"error":"invalid json"}`, http.StatusBadRequest)
 		return
+	}
+	// Reject the whole request if any key is not writable (fail before applying).
+	for k := range body {
+		if !writableSettings[k] {
+			http.Error(w, fmt.Sprintf(`{"error":"setting %q is not writable"}`, k), http.StatusForbidden)
+			return
+		}
 	}
 	linearChanged := false
 	for k, v := range body {

--- a/internal/relay/api_test.go
+++ b/internal/relay/api_test.go
@@ -873,3 +873,22 @@ func TestAPIGetActivity(t *testing.T) {
 		t.Errorf("expected 0 sessions with nil ingester, got %d", len(sessions))
 	}
 }
+
+func TestApiPutSetting_Allowlist(t *testing.T) {
+	r := testRelay(t)
+
+	// Allowed key → 200.
+	w := doAPI(r, "PUT", "/settings", `{"linear_api_key":"lin_test"}`)
+	if w.Code != 200 {
+		t.Fatalf("allowed setting rejected: %d %s", w.Code, w.Body.String())
+	}
+
+	// Disallowed key → 403, and nothing written.
+	w = doAPI(r, "PUT", "/settings", `{"evil_key":"x"}`)
+	if w.Code != 403 {
+		t.Fatalf("disallowed setting accepted: %d %s", w.Code, w.Body.String())
+	}
+	if got := r.DB.GetSetting("evil_key"); got != "" {
+		t.Fatalf("disallowed key was written: %q", got)
+	}
+}


### PR DESCRIPTION
Security audit Finding 7 (Low/Med).

`apiPutSetting` wrote any caller-supplied `key→value` — so an unauthenticated-by-default caller could set arbitrary settings, including swapping `linear_api_key` or repointing the connector. Now restricted to an allowlist (`sun_type` + the `linear_*` connector keys); rejects the whole request with **403** if any key isn't writable, before applying anything.

Already fine / deferred:
- Agent-avatar endpoint already validates the URL scheme (http(s)/data:image) — no change.
- RegisterAgent SELECT-then-write TOCTOU left as-is: unique index makes the worst case a spurious registration error, not corruption (Low).

## Verification
- `go build`, `go vet` clean; `go test ./... -race` green
- New `TestApiPutSetting_Allowlist` (allowed 200, disallowed 403 + not written)

🤖 Generated with [Claude Code](https://claude.com/claude-code)