### PR TITLE
feat(v2): command layer — dependencies, force-transition, audit trail

### DIFF
--- a/internal/db/audit.go
+++ b/internal/db/audit.go
@@ -1,0 +1,66 @@
+package db
+
+import (
+	"agent-relay/internal/models"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// RecordAudit appends one entry to the audit trail. Best-effort: a failure here
+// must never block the action it describes, so callers ignore the error.
+func (d *DB) RecordAudit(e models.AuditEntry) error {
+	if e.ID == "" {
+		e.ID = uuid.New().String()
+	}
+	if e.CreatedAt == "" {
+		e.CreatedAt = time.Now().UTC().Format(memoryTimeFmt)
+	}
+	if e.ResourceType == "" {
+		e.ResourceType = "task"
+	}
+	if e.Project == "" {
+		e.Project = "default"
+	}
+	_, err := d.conn.Exec(
+		`INSERT INTO audit_log (id, project, actor, action, resource_type, resource_id, summary, details, reason, created_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		e.ID, e.Project, e.Actor, e.Action, e.ResourceType, e.ResourceID,
+		e.Summary, e.Details, e.Reason, e.CreatedAt,
+	)
+	return err
+}
+
+// ListAudit returns the most recent audit entries for a project, optionally
+// scoped to a single resource (e.g. one task). Newest first.
+func (d *DB) ListAudit(project, resourceID string, limit int) ([]models.AuditEntry, error) {
+	if limit <= 0 || limit > 500 {
+		limit = 100
+	}
+	query := `SELECT id, project, actor, action, resource_type, resource_id, summary, details, reason, created_at
+		FROM audit_log WHERE project = ?`
+	args := []any{project}
+	if resourceID != "" {
+		query += " AND resource_id = ?"
+		args = append(args, resourceID)
+	}
+	query += " ORDER BY created_at DESC LIMIT ?"
+	args = append(args, limit)
+
+	rows, err := d.ro().Query(query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	out := []models.AuditEntry{}
+	for rows.Next() {
+		var e models.AuditEntry
+		if err := rows.Scan(&e.ID, &e.Project, &e.Actor, &e.Action, &e.ResourceType,
+			&e.ResourceID, &e.Summary, &e.Details, &e.Reason, &e.CreatedAt); err != nil {
+			return nil, err
+		}
+		out = append(out, e)
+	}
+	return out, rows.Err()
+}

--- a/internal/db/command_layer_test.go
+++ b/internal/db/command_layer_test.go
@@ -1,0 +1,127 @@
+package db
+
+import (
+	"agent-relay/internal/models"
+	"strings"
+	"testing"
+)
+
+func auditEntry(project, actor, action, resource, summary string) models.AuditEntry {
+	return models.AuditEntry{
+		Project: project, Actor: actor, Action: action,
+		ResourceType: "task", ResourceID: resource, Summary: summary,
+	}
+}
+
+// Dependencies gate: an agent cannot claim/start a task whose dependency is
+// still open, but the orchestrator ("user") may force it through.
+func TestDependencyGate_BlocksAgentAllowsUser(t *testing.T) {
+	d := testDB(t)
+
+	dep, err := d.DispatchTask("p1", "dev", "cto", "build api", "", "P2", nil, nil)
+	if err != nil {
+		t.Fatalf("dispatch dep: %v", err)
+	}
+	task, err := d.DispatchTask("p1", "dev", "cto", "wire frontend", "", "P2", nil, nil)
+	if err != nil {
+		t.Fatalf("dispatch task: %v", err)
+	}
+	if _, err = d.SetTaskDependencies(task.ID, "p1", []string{dep.ID}); err != nil {
+		t.Fatalf("set deps: %v", err)
+	}
+
+	// Agent claim must be blocked while the dependency is open.
+	if _, err = d.ClaimTask(task.ID, "bot-a", "p1"); err == nil {
+		t.Fatal("expected claim to be blocked by open dependency")
+	} else if !strings.Contains(err.Error(), "unfinished dependenc") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Orchestrator override (user) bypasses the gate.
+	if _, err = d.ClaimTask(task.ID, "user", "p1"); err != nil {
+		t.Fatalf("user override should pass: %v", err)
+	}
+
+	// Once the dependency is done, the agent can claim.
+	other, _ := d.DispatchTask("p1", "dev", "cto", "another", "", "P2", nil, nil)
+	if _, err = d.SetTaskDependencies(other.ID, "p1", []string{dep.ID}); err != nil {
+		t.Fatalf("set deps 2: %v", err)
+	}
+	if _, err = d.CompleteTask(dep.ID, "bot-b", "p1", nil); err != nil {
+		t.Fatalf("complete dep: %v", err)
+	}
+	if _, err = d.ClaimTask(other.ID, "bot-a", "p1"); err != nil {
+		t.Fatalf("claim after dep done should pass: %v", err)
+	}
+}
+
+// Cycle rejection: a dependency edge that would close a loop is refused.
+func TestSetTaskDependencies_RejectsCycle(t *testing.T) {
+	d := testDB(t)
+
+	a, _ := d.DispatchTask("p1", "dev", "cto", "A", "", "P2", nil, nil)
+	b, _ := d.DispatchTask("p1", "dev", "cto", "B", "", "P2", nil, nil)
+
+	if _, err := d.SetTaskDependencies(b.ID, "p1", []string{a.ID}); err != nil {
+		t.Fatalf("b depends on a: %v", err)
+	}
+	// a depends on b would form a → b → a cycle.
+	if _, err := d.SetTaskDependencies(a.ID, "p1", []string{b.ID}); err == nil {
+		t.Fatal("expected cycle to be rejected")
+	}
+	// self-dependency is also rejected.
+	if _, err := d.SetTaskDependencies(a.ID, "p1", []string{a.ID}); err == nil {
+		t.Fatal("expected self-dependency to be rejected")
+	}
+}
+
+// Reassign hands the task to a new agent without changing status.
+func TestReassignTask(t *testing.T) {
+	d := testDB(t)
+
+	task, _ := d.DispatchTask("p1", "dev", "cto", "task", "", "P2", nil, nil)
+	if _, err := d.ClaimTask(task.ID, "bot-a", "p1"); err != nil {
+		t.Fatalf("claim: %v", err)
+	}
+	got, err := d.ReassignTask(task.ID, "p1", "bot-b")
+	if err != nil {
+		t.Fatalf("reassign: %v", err)
+	}
+	if got.AssignedTo == nil || *got.AssignedTo != "bot-b" {
+		t.Fatalf("expected assigned_to=bot-b, got %v", got.AssignedTo)
+	}
+	if got.Status != "accepted" {
+		t.Fatalf("status should be unchanged (accepted), got %s", got.Status)
+	}
+}
+
+// Audit round-trips entries newest-first, scoped to a resource.
+func TestAuditRoundTrip(t *testing.T) {
+	d := testDB(t)
+
+	if err := d.RecordAudit(auditEntry("p1", "user", "transition", "task-1", "pending → done")); err != nil {
+		t.Fatalf("record 1: %v", err)
+	}
+	if err := d.RecordAudit(auditEntry("p1", "user", "reassign", "task-1", "a → b")); err != nil {
+		t.Fatalf("record 2: %v", err)
+	}
+	if err := d.RecordAudit(auditEntry("p1", "user", "transition", "task-2", "x → y")); err != nil {
+		t.Fatalf("record 3: %v", err)
+	}
+
+	scoped, err := d.ListAudit("p1", "task-1", 50)
+	if err != nil {
+		t.Fatalf("list scoped: %v", err)
+	}
+	if len(scoped) != 2 {
+		t.Fatalf("expected 2 entries for task-1, got %d", len(scoped))
+	}
+
+	all, err := d.ListAudit("p1", "", 50)
+	if err != nil {
+		t.Fatalf("list all: %v", err)
+	}
+	if len(all) != 3 {
+		t.Fatalf("expected 3 entries for project, got %d", len(all))
+	}
+}

--- a/internal/db/command_layer_test.go
+++ b/internal/db/command_layer_test.go
@@ -95,6 +95,30 @@ func TestReassignTask(t *testing.T) {
 	}
 }
 
+// Linear-mirrored tasks reject orchestrator mutations — Linear is the SSOT.
+func TestCommandLayer_RejectsLinearMirroredTasks(t *testing.T) {
+	d := testDB(t)
+
+	native, _ := d.DispatchTask("p1", "dev", "cto", "native", "", "P2", nil, nil)
+	if err := d.UpsertLinearTask(LinearTaskSeed{
+		ID: "lin-1", Project: "p1", Title: "from linear", Status: "in-progress",
+		Priority: "P2", DispatchedAt: "2026-01-01T00:00:00.000000Z", Labels: "[]",
+	}); err != nil {
+		t.Fatalf("seed linear task: %v", err)
+	}
+
+	if _, err := d.SetTaskDependencies("lin-1", "p1", []string{native.ID}); err == nil {
+		t.Fatal("expected set-dependencies on a Linear task to be rejected")
+	}
+	if _, err := d.ReassignTask("lin-1", "p1", "bot-a"); err == nil {
+		t.Fatal("expected reassign on a Linear task to be rejected")
+	}
+	// A native task depending ON a Linear task is fine (Linear stays read-only).
+	if _, err := d.SetTaskDependencies(native.ID, "p1", []string{"lin-1"}); err != nil {
+		t.Fatalf("native task may depend on a linear task: %v", err)
+	}
+}
+
 // Audit round-trips entries newest-first, scoped to a resource.
 func TestAuditRoundTrip(t *testing.T) {
 	d := testDB(t)

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -408,6 +408,9 @@ func migrate(conn *sql.DB) error {
 		"blocked_periods": "TEXT NOT NULL DEFAULT '[]'", // json array of {start,end} (blocked_at[])
 		"in_review_at":    "TEXT",
 		"done_at":         "TEXT",
+
+		// --- Command layer (orchestrator-owned) ---
+		"depends_on": "TEXT NOT NULL DEFAULT '[]'", // json array of task IDs this task waits on
 	})
 	// Migrate legacy reply_to_task -> parent_task_id
 	_, _ = conn.Exec(`UPDATE tasks SET parent_task_id = reply_to_task WHERE reply_to_task IS NOT NULL AND parent_task_id IS NULL`)
@@ -428,6 +431,22 @@ func migrate(conn *sql.DB) error {
 		created_at TEXT NOT NULL
 	)`)
 	_, _ = conn.Exec(`CREATE INDEX IF NOT EXISTS idx_task_progress_notes_task ON task_progress_notes(task_id, created_at)`)
+
+	// Audit log — the "why" trail behind orchestrator/agent actions on the board.
+	_, _ = conn.Exec(`CREATE TABLE IF NOT EXISTS audit_log (
+		id            TEXT PRIMARY KEY,
+		project       TEXT NOT NULL DEFAULT 'default',
+		actor         TEXT NOT NULL,
+		action        TEXT NOT NULL,
+		resource_type TEXT NOT NULL DEFAULT 'task',
+		resource_id   TEXT NOT NULL,
+		summary       TEXT NOT NULL DEFAULT '',
+		details       TEXT NOT NULL DEFAULT '',
+		reason        TEXT NOT NULL DEFAULT '',
+		created_at    TEXT NOT NULL
+	)`)
+	_, _ = conn.Exec(`CREATE INDEX IF NOT EXISTS idx_audit_resource ON audit_log(project, resource_id, created_at)`)
+	_, _ = conn.Exec(`CREATE INDEX IF NOT EXISTS idx_audit_project ON audit_log(project, created_at)`)
 
 	// Linear connector sync log (capped audit trail of write-back outcomes).
 	_, _ = conn.Exec(`CREATE TABLE IF NOT EXISTS linear_sync_log (

--- a/internal/db/tasks.go
+++ b/internal/db/tasks.go
@@ -6,10 +6,18 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
 )
+
+func plural(n int, one, many string) string {
+	if n == 1 {
+		return one
+	}
+	return many
+}
 
 // blockedPeriod is one {start,end} window in the auto-stamped blocked_periods trail.
 type blockedPeriod struct {
@@ -62,7 +70,7 @@ var validTransitions = map[string][]string{
 
 const taskColumns = "id, profile_slug, assigned_to, dispatched_by, title, description, priority, status, result, blocked_reason, project, dispatched_at, accepted_at, started_at, completed_at, parent_task_id, ack_notified_at, ack_escalated_at, board_id, archived_at, " +
 	"source, linear_issue_id, linear_key, external_url, points, labels, linear_state, assignee, cycle_id, cycle_name, cycle_start, cycle_end, " +
-	"claimed_by, claimed_at, blocked_periods, in_review_at, done_at"
+	"claimed_by, claimed_at, blocked_periods, in_review_at, done_at, depends_on"
 
 func scanTask(row interface{ Scan(...any) error }) (models.Task, error) {
 	var t models.Task
@@ -72,7 +80,7 @@ func scanTask(row interface{ Scan(...any) error }) (models.Task, error) {
 		&t.AckNotifiedAt, &t.AckEscalatedAt, &t.BoardID, &t.ArchivedAt,
 		&t.Source, &t.LinearIssueID, &t.LinearKey, &t.ExternalURL, &t.Points, &t.Labels,
 		&t.LinearState, &t.Assignee, &t.CycleID, &t.CycleName, &t.CycleStart, &t.CycleEnd,
-		&t.ClaimedBy, &t.ClaimedAt, &t.BlockedPeriods, &t.InReviewAt, &t.DoneAt)
+		&t.ClaimedBy, &t.ClaimedAt, &t.BlockedPeriods, &t.InReviewAt, &t.DoneAt, &t.DependsOn)
 	return t, err
 }
 
@@ -163,6 +171,16 @@ func (d *DB) transitionTask(taskID, agentName, project, newStatus string, result
 		}
 		if !valid {
 			return nil, fmt.Errorf("invalid transition: %s → %s", task.Status, newStatus)
+		}
+	}
+
+	// Dependency readiness gate: an agent may not claim or start a task whose
+	// declared dependencies are still open. The orchestrator ("user") overrides.
+	if agentName != "user" && (newStatus == "accepted" || newStatus == "in-progress") {
+		open, derr := d.unfinishedDeps(task)
+		if derr == nil && len(open) > 0 {
+			return nil, fmt.Errorf("blocked by %d unfinished dependenc%s: %s",
+				len(open), plural(len(open), "y", "ies"), strings.Join(open, ", "))
 		}
 	}
 
@@ -861,4 +879,141 @@ func normalizePtr(s *string) *string {
 	}
 	v := normalize.JSONKeys(*s)
 	return &v
+}
+
+/* ============================================================= *
+ *  Command layer — dependencies & reassignment
+ * ============================================================= */
+
+// parseDeps reads a task's depends_on JSON array into a slice of task IDs.
+func parseDeps(raw string) []string {
+	if raw == "" {
+		return nil
+	}
+	var ids []string
+	if err := json.Unmarshal([]byte(raw), &ids); err != nil {
+		return nil
+	}
+	return ids
+}
+
+// unfinishedDeps returns the IDs of a task's dependencies that are not yet
+// resolved. A dependency counts as resolved when it is done or cancelled, or
+// when it no longer exists (a deleted dependency must never deadlock its
+// dependents).
+func (d *DB) unfinishedDeps(task *models.Task) ([]string, error) {
+	deps := parseDeps(task.DependsOn)
+	if len(deps) == 0 {
+		return nil, nil
+	}
+	var open []string
+	for _, id := range deps {
+		dep, err := d.GetTask(id, task.Project)
+		if err != nil {
+			return nil, err
+		}
+		if dep == nil {
+			continue // missing dependency — treat as resolved
+		}
+		if dep.Status != "done" && dep.Status != "cancelled" {
+			open = append(open, id)
+		}
+	}
+	return open, nil
+}
+
+// dependsReaches reports whether `from` can reach `target` by following
+// depends_on edges — used to reject cycles before they are written.
+func (d *DB) dependsReaches(from, target, project string, seen map[string]bool) bool {
+	if from == target {
+		return true
+	}
+	if seen[from] {
+		return false
+	}
+	seen[from] = true
+	t, err := d.GetTask(from, project)
+	if err != nil || t == nil {
+		return false
+	}
+	for _, next := range parseDeps(t.DependsOn) {
+		if d.dependsReaches(next, target, project, seen) {
+			return true
+		}
+	}
+	return false
+}
+
+// SetTaskDependencies replaces a task's dependency list. It validates that each
+// dependency exists in the same project, rejects self-references, and rejects
+// any edge that would introduce a cycle.
+func (d *DB) SetTaskDependencies(taskID, project string, deps []string) (*models.Task, error) {
+	task, err := d.GetTask(taskID, project)
+	if err != nil {
+		return nil, err
+	}
+	if task == nil {
+		return nil, fmt.Errorf("task not found: %s", taskID)
+	}
+
+	// Dedup + validate.
+	seen := map[string]bool{}
+	clean := make([]string, 0, len(deps))
+	for _, id := range deps {
+		id = strings.TrimSpace(id)
+		if id == "" || seen[id] {
+			continue
+		}
+		if id == taskID {
+			return nil, fmt.Errorf("a task cannot depend on itself")
+		}
+		dep, derr := d.GetTask(id, project)
+		if derr != nil {
+			return nil, derr
+		}
+		if dep == nil {
+			return nil, fmt.Errorf("dependency not found: %s", id)
+		}
+		// Would adding taskID → id create a cycle? Only if id already reaches taskID.
+		if d.dependsReaches(id, taskID, project, map[string]bool{}) {
+			return nil, fmt.Errorf("dependency would create a cycle: %s", id)
+		}
+		seen[id] = true
+		clean = append(clean, id)
+	}
+
+	raw, _ := json.Marshal(clean)
+	if _, err = d.conn.Exec(
+		"UPDATE tasks SET depends_on = ? WHERE id = ? AND project = ?",
+		string(raw), taskID, project,
+	); err != nil {
+		return nil, fmt.Errorf("set dependencies: %w", err)
+	}
+	task.DependsOn = string(raw)
+	return task, nil
+}
+
+// ReassignTask hands a task to a different agent without changing its status —
+// the orchestrator's "you take this now" lever. Stamps assigned_to + claimed_by.
+func (d *DB) ReassignTask(taskID, project, agent string) (*models.Task, error) {
+	agent = strings.TrimSpace(agent)
+	if agent == "" {
+		return nil, fmt.Errorf("agent is required")
+	}
+	task, err := d.GetTask(taskID, project)
+	if err != nil {
+		return nil, err
+	}
+	if task == nil {
+		return nil, fmt.Errorf("task not found: %s", taskID)
+	}
+	if _, err = d.conn.Exec(
+		"UPDATE tasks SET assigned_to = ?, claimed_by = ? WHERE id = ? AND project = ?",
+		agent, agent, taskID, project,
+	); err != nil {
+		return nil, fmt.Errorf("reassign task: %w", err)
+	}
+	task.AssignedTo = &agent
+	task.ClaimedBy = &agent
+	return task, nil
 }

--- a/internal/db/tasks.go
+++ b/internal/db/tasks.go
@@ -885,6 +885,10 @@ func normalizePtr(s *string) *string {
  *  Command layer — dependencies & reassignment
  * ============================================================= */
 
+// errLinearReadOnly guards orchestrator mutations against Linear-mirrored tasks:
+// Linear is the source of truth for those, so deps/assignment/force are refused.
+var errLinearReadOnly = fmt.Errorf("task is mirrored from Linear (read-only here — Linear is the source of truth)")
+
 // parseDeps reads a task's depends_on JSON array into a slice of task IDs.
 func parseDeps(raw string) []string {
 	if raw == "" {
@@ -955,6 +959,9 @@ func (d *DB) SetTaskDependencies(taskID, project string, deps []string) (*models
 	if task == nil {
 		return nil, fmt.Errorf("task not found: %s", taskID)
 	}
+	if task.Source == "linear" {
+		return nil, errLinearReadOnly
+	}
 
 	// Dedup + validate.
 	seen := map[string]bool{}
@@ -1006,6 +1013,9 @@ func (d *DB) ReassignTask(taskID, project, agent string) (*models.Task, error) {
 	}
 	if task == nil {
 		return nil, fmt.Errorf("task not found: %s", taskID)
+	}
+	if task.Source == "linear" {
+		return nil, errLinearReadOnly
 	}
 	if _, err = d.conn.Exec(
 		"UPDATE tasks SET assigned_to = ?, claimed_by = ? WHERE id = ? AND project = ?",

--- a/internal/models/task.go
+++ b/internal/models/task.go
@@ -43,7 +43,25 @@ type Task struct {
 	InReviewAt     *string `json:"in_review_at,omitempty"`
 	DoneAt         *string `json:"done_at,omitempty"`
 
+	// --- Command layer (orchestrator-owned) ---
+	DependsOn string `json:"depends_on"` // json array of task IDs this task waits on
+
 	Subtasks []Task `json:"subtasks,omitempty"`
+}
+
+// AuditEntry is one logged orchestrator/agent action against a resource — the
+// "why" trail behind every consequential move on the board.
+type AuditEntry struct {
+	ID           string `json:"id"`
+	Project      string `json:"project"`
+	Actor        string `json:"actor"`         // who did it ("user" for the orchestrator)
+	Action       string `json:"action"`        // transition | force_transition | set_dependencies | reassign
+	ResourceType string `json:"resource_type"` // "task"
+	ResourceID   string `json:"resource_id"`
+	Summary      string `json:"summary"`           // one-line human description
+	Details      string `json:"details,omitempty"` // optional json blob (old/new)
+	Reason       string `json:"reason,omitempty"`
+	CreatedAt    string `json:"created_at"`
 }
 
 type Board struct {

--- a/internal/relay/api.go
+++ b/internal/relay/api.go
@@ -1258,10 +1258,15 @@ func (r *Relay) apiTransitionTask(w http.ResponseWriter, req *http.Request, path
 		body.Agent = "user"
 	}
 
-	// Capture the prior status for the audit trail before the move.
+	// Capture the prior status for the audit trail before the move. A forced
+	// override on a Linear-mirrored task is refused — Linear is the SSOT there.
 	var fromStatus string
 	if prev, perr := r.DB.GetTask(taskID, body.Project); perr == nil && prev != nil {
 		fromStatus = prev.Status
+		if body.Force && prev.Source == "linear" {
+			http.Error(w, `{"error":"task is mirrored from Linear (read-only here — Linear is the source of truth)"}`, http.StatusBadRequest)
+			return
+		}
 	}
 
 	var task *models.Task

--- a/internal/relay/api.go
+++ b/internal/relay/api.go
@@ -1421,7 +1421,7 @@ func (r *Relay) apiGetAudit(w http.ResponseWriter, req *http.Request) {
 	resource := req.URL.Query().Get("resource")
 	limit := 0
 	if l := req.URL.Query().Get("limit"); l != "" {
-		fmt.Sscanf(l, "%d", &limit)
+		limit, _ = strconv.Atoi(l)
 	}
 	entries, err := r.DB.ListAudit(project, resource, limit)
 	if err != nil {

--- a/internal/relay/api.go
+++ b/internal/relay/api.go
@@ -18,7 +18,11 @@ import (
 // apiError logs the full error server-side and returns a safe message to the client.
 func apiError(w http.ResponseWriter, status int, msg string, err error) {
 	log.Printf("API error: %s: %v", msg, err)
-	b, _ := json.Marshal(map[string]string{"error": msg})
+	payload := map[string]string{"error": msg}
+	if err != nil {
+		payload["detail"] = err.Error() // surfaced to the same-origin dashboard
+	}
+	b, _ := json.Marshal(payload)
 	http.Error(w, string(b), status)
 }
 
@@ -106,8 +110,14 @@ func (r *Relay) ServeAPI(w http.ResponseWriter, req *http.Request) {
 		r.apiDispatchTask(w, req)
 	case strings.HasPrefix(path, "/tasks/") && strings.HasSuffix(path, "/transition") && req.Method == http.MethodPost:
 		r.apiTransitionTask(w, req, path)
+	case strings.HasPrefix(path, "/tasks/") && strings.HasSuffix(path, "/dependencies") && req.Method == http.MethodPost:
+		r.apiSetTaskDependencies(w, req, path)
+	case strings.HasPrefix(path, "/tasks/") && strings.HasSuffix(path, "/reassign") && req.Method == http.MethodPost:
+		r.apiReassignTask(w, req, path)
 	case strings.HasPrefix(path, "/tasks/") && strings.HasSuffix(path, "/progress") && req.Method == http.MethodGet:
 		r.apiGetTaskProgress(w, req, path)
+	case path == "/audit" && req.Method == http.MethodGet:
+		r.apiGetAudit(w, req)
 	case strings.HasPrefix(path, "/tasks/") && req.Method == http.MethodPut:
 		r.apiUpdateTask(w, req, path)
 	case strings.HasPrefix(path, "/tasks/") && req.Method == http.MethodDelete:
@@ -1226,6 +1236,7 @@ func (r *Relay) apiTransitionTask(w http.ResponseWriter, req *http.Request, path
 		Agent   string  `json:"agent"`
 		Result  *string `json:"result,omitempty"`
 		Reason  *string `json:"reason,omitempty"`
+		Force   bool    `json:"force,omitempty"`
 	}
 	if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
 		http.Error(w, `{"error":"invalid json"}`, http.StatusBadRequest)
@@ -1240,6 +1251,17 @@ func (r *Relay) apiTransitionTask(w http.ResponseWriter, req *http.Request, path
 	}
 	if body.Agent == "" {
 		body.Agent = "user"
+	}
+	// A forced move bypasses the state machine + dependency gate — the DB grants
+	// that only to the "user" actor.
+	if body.Force {
+		body.Agent = "user"
+	}
+
+	// Capture the prior status for the audit trail before the move.
+	var fromStatus string
+	if prev, perr := r.DB.GetTask(taskID, body.Project); perr == nil && prev != nil {
+		fromStatus = prev.Status
 	}
 
 	var task *models.Task
@@ -1268,6 +1290,25 @@ func (r *Relay) apiTransitionTask(w http.ResponseWriter, req *http.Request, path
 		return
 	}
 
+	// Audit the move (best-effort). A forced move is flagged distinctly.
+	action := "transition"
+	if body.Force {
+		action = "force_transition"
+	}
+	reason := ""
+	if body.Reason != nil {
+		reason = *body.Reason
+	}
+	_ = r.DB.RecordAudit(models.AuditEntry{
+		Project:      body.Project,
+		Actor:        body.Agent,
+		Action:       action,
+		ResourceType: "task",
+		ResourceID:   taskID,
+		Summary:      fmt.Sprintf("%s → %s", orDash(fromStatus), body.Status),
+		Reason:       reason,
+	})
+
 	// Emit the matching semantic event so notification rules fire for web-UI
 	// driven transitions too (the MCP handlers emit their own).
 	if evType, line := semanticForStatus(body.Status, task.Title); evType != "" {
@@ -1285,6 +1326,111 @@ func (r *Relay) apiTransitionTask(w http.ResponseWriter, req *http.Request, path
 	}
 
 	writeJSON(w, task)
+}
+
+func orDash(s string) string {
+	if s == "" {
+		return "—"
+	}
+	return s
+}
+
+// apiSetTaskDependencies replaces a task's dependency list. Path: /tasks/{id}/dependencies
+func (r *Relay) apiSetTaskDependencies(w http.ResponseWriter, req *http.Request, path string) {
+	trimmed := strings.TrimPrefix(path, "/tasks/")
+	taskID, _, _ := strings.Cut(trimmed, "/")
+	if taskID == "" {
+		http.Error(w, `{"error":"missing task id"}`, http.StatusBadRequest)
+		return
+	}
+	var body struct {
+		Project   string   `json:"project"`
+		DependsOn []string `json:"depends_on"`
+	}
+	if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
+		http.Error(w, `{"error":"invalid json"}`, http.StatusBadRequest)
+		return
+	}
+	if body.Project == "" {
+		body.Project = "default"
+	}
+	task, err := r.DB.SetTaskDependencies(taskID, body.Project, body.DependsOn)
+	if err != nil {
+		apiError(w, http.StatusBadRequest, "failed to set dependencies", err)
+		return
+	}
+	_ = r.DB.RecordAudit(models.AuditEntry{
+		Project:      body.Project,
+		Actor:        "user",
+		Action:       "set_dependencies",
+		ResourceType: "task",
+		ResourceID:   taskID,
+		Summary:      fmt.Sprintf("set %d dependenc%s", len(body.DependsOn), pluralize(len(body.DependsOn), "y", "ies")),
+		Details:      task.DependsOn,
+	})
+	writeJSON(w, task)
+}
+
+// apiReassignTask hands a task to a different agent. Path: /tasks/{id}/reassign
+func (r *Relay) apiReassignTask(w http.ResponseWriter, req *http.Request, path string) {
+	trimmed := strings.TrimPrefix(path, "/tasks/")
+	taskID, _, _ := strings.Cut(trimmed, "/")
+	if taskID == "" {
+		http.Error(w, `{"error":"missing task id"}`, http.StatusBadRequest)
+		return
+	}
+	var body struct {
+		Project string `json:"project"`
+		Agent   string `json:"agent"`
+	}
+	if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
+		http.Error(w, `{"error":"invalid json"}`, http.StatusBadRequest)
+		return
+	}
+	if body.Project == "" {
+		body.Project = "default"
+	}
+	prev := ""
+	if cur, perr := r.DB.GetTask(taskID, body.Project); perr == nil && cur != nil && cur.AssignedTo != nil {
+		prev = *cur.AssignedTo
+	}
+	task, err := r.DB.ReassignTask(taskID, body.Project, body.Agent)
+	if err != nil {
+		apiError(w, http.StatusBadRequest, "failed to reassign task", err)
+		return
+	}
+	_ = r.DB.RecordAudit(models.AuditEntry{
+		Project:      body.Project,
+		Actor:        "user",
+		Action:       "reassign",
+		ResourceType: "task",
+		ResourceID:   taskID,
+		Summary:      fmt.Sprintf("%s → %s", orDash(prev), body.Agent),
+	})
+	writeJSON(w, task)
+}
+
+// apiGetAudit returns the audit trail for a project, optionally scoped to one task.
+func (r *Relay) apiGetAudit(w http.ResponseWriter, req *http.Request) {
+	project := projectFromRequest(req)
+	resource := req.URL.Query().Get("resource")
+	limit := 0
+	if l := req.URL.Query().Get("limit"); l != "" {
+		fmt.Sscanf(l, "%d", &limit)
+	}
+	entries, err := r.DB.ListAudit(project, resource, limit)
+	if err != nil {
+		http.Error(w, `{"error":"failed to list audit"}`, http.StatusInternalServerError)
+		return
+	}
+	writeJSON(w, entries)
+}
+
+func pluralize(n int, one, many string) string {
+	if n == 1 {
+		return one
+	}
+	return many
 }
 
 // semanticForStatus maps a kanban status to its semantic event type + line.

--- a/internal/web/static/index.html
+++ b/internal/web/static/index.html
@@ -66,6 +66,10 @@
         <span id="zoom-level" class="zoom-level" aria-live="polite">100%</span>
         <button id="zoom-in" class="zoom-btn" title="Zoom in [+]" aria-label="Zoom in">+</button>
       </div>
+      <a id="v2-link" class="v2-link" href="/v2/" title="Open the v2 control room" aria-label="Open the v2 control room">
+        <span class="v2-link-label">v2</span>
+        <span class="v2-link-arrow" aria-hidden="true">&#8599;</span>
+      </a>
       <button id="settings-btn" class="help-btn" title="Settings" aria-label="Settings">&#9881;</button>
       <button id="help-btn" class="help-btn" title="Help [?]" aria-label="Help">?</button>
     </div>

--- a/internal/web/static/style.css
+++ b/internal/web/static/style.css
@@ -2199,6 +2199,38 @@ body.view-galaxy .quest-tracker { display: none !important; }
   color: #fff;
 }
 
+/* v2 cross-link — sends you to the new control room */
+.v2-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  min-height: 26px;
+  padding: 0 10px;
+  border-radius: 13px;
+  border: 1px solid rgba(108, 92, 231, 0.45);
+  background: linear-gradient(135deg, rgba(108, 92, 231, 0.18), rgba(108, 92, 231, 0.06));
+  color: #c4bdff;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-decoration: none;
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: background 0.2s, border-color 0.2s, color 0.2s, transform 0.2s;
+}
+.v2-link:hover {
+  background: linear-gradient(135deg, rgba(108, 92, 231, 0.4), rgba(108, 92, 231, 0.18));
+  border-color: #6c5ce7;
+  color: #fff;
+  transform: translateY(-1px);
+}
+.v2-link:focus-visible {
+  outline: 2px solid #a29bfe;
+  outline-offset: 2px;
+}
+.v2-link-arrow { font-size: 12px; line-height: 1; }
+
 /* Help modal */
 .help-modal { position: fixed; inset: 0; z-index: var(--z-modal); display: flex; align-items: center; justify-content: center; }
 .help-modal.hidden { display: none; }

--- a/internal/web/static/v2/api.js
+++ b/internal/web/static/v2/api.js
@@ -13,9 +13,9 @@ async function sendJSON(method, url, body) {
     body: body == null ? undefined : JSON.stringify(body),
   });
   if (!res.ok) {
-    let detail = '';
-    try { detail = (await res.json()).error || ''; } catch (_) { /* ignore */ }
-    throw new Error(detail || `${res.status} ${url}`);
+    let msg = '';
+    try { const j = await res.json(); msg = j.detail || j.error || ''; } catch (_) { /* ignore */ }
+    throw new Error(msg || `${res.status} ${url}`);
   }
   return res.status === 204 ? null : res.json();
 }
@@ -43,6 +43,12 @@ export const api = {
   // mutations (native projects only)
   transition: (id, body) =>
     sendJSON('POST', `/api/tasks/${encodeURIComponent(id)}/transition`, body),
+  setDependencies: (id, project, dependsOn) =>
+    sendJSON('POST', `/api/tasks/${encodeURIComponent(id)}/dependencies`, { project, depends_on: dependsOn }),
+  reassign: (id, project, agent) =>
+    sendJSON('POST', `/api/tasks/${encodeURIComponent(id)}/reassign`, { project, agent }),
+  audit: (project, resource, limit = 50) =>
+    getJSON(`/api/audit?${q({ project, resource, limit })}`),
   setAgentAvatar: (project, name, url) =>
     sendJSON('PUT', '/api/agents/avatar', { project, name, url }),
   dispatchTask: (body) => sendJSON('POST', '/api/tasks', body),

--- a/internal/web/static/v2/board.js
+++ b/internal/web/static/v2/board.js
@@ -87,6 +87,13 @@ export function initBoard(root, ctx) {
     if (!kids.length) return null;
     return { done: kids.filter((k) => k.status === 'done').length, total: kids.length };
   };
+  const parseDeps = (t) => { try { const a = JSON.parse(t.depends_on || '[]'); return Array.isArray(a) ? a : []; } catch (_) { return []; } };
+  // Unresolved dependencies, resolved against the loaded board set. Tasks outside
+  // the current cycle aren't loaded → treated as resolved here (the server-side
+  // gate stays authoritative).
+  const depBlockers = (t) => parseDeps(t).map((id) => byId.get(id)).filter((d) => d && d.status !== 'done' && d.status !== 'cancelled');
+  // Known agent names across the loaded board — used for the reassign datalist.
+  const agentNames = () => [...new Set(tasks.flatMap((t) => [t.assigned_to, t.claimed_by].filter(Boolean)))].sort();
 
   /* ---------------- render ---------------- */
   function render() {
@@ -135,6 +142,7 @@ export function initBoard(root, ctx) {
       <div class="kcard-meta">
         ${labels.map((l) => `<span class="lchip">${esc(l)}</span>`).join('')}
         ${roll ? `<span class="rollup" title="${roll.done}/${roll.total} children done">▣ ${roll.done}/${roll.total}</span>` : ''}
+        ${(() => { const b = depBlockers(t); return b.length ? `<span class="dep-chip" title="waiting on ${b.length} unfinished task${b.length === 1 ? '' : 's'}">⛓ ${b.length}</span>` : ''; })()}
         ${inReview ? `<span class="review-timer" data-since="${esc(t.in_review_at)}">in review ${fmtAgo(t.in_review_at)}</span>` : ''}
         ${blocked ? `<span class="blocked-badge" title="${esc(t.blocked_reason || 'blocked')}"><span class="blk-dot"></span>blocked</span>` : ''}
       </div>
@@ -354,6 +362,12 @@ export function initBoard(root, ctx) {
   }
 
   /* ---------------- detail slide-over ---------------- */
+  const STATUSES = [
+    { v: 'pending', l: 'pending' }, { v: 'accepted', l: 'accepted' },
+    { v: 'in-progress', l: 'in-progress' }, { v: 'in-review', l: 'in-review' },
+    { v: 'blocked', l: 'blocked' }, { v: 'done', l: 'done' }, { v: 'cancelled', l: 'cancelled' },
+  ];
+
   async function openDetail(t) {
     const node = document.createElement('div');
     node.className = 'sheet-inner';
@@ -367,6 +381,89 @@ export function initBoard(root, ctx) {
         ? notes.slice().reverse().map((n) => `<div class="note"><div class="note-head"><span class="kc-avatar sm" style="background:${colorFor(n.agent)}">${esc(initialFor(n.agent))}</span><span>${esc(n.agent)}</span><span class="note-ts">${fmtAgo(n.created_at)} ago</span></div><div class="note-body">${esc(n.note)}</div></div>`).join('')
         : '<div class="empty">No progress notes</div>';
     } catch (_) { notesEl.innerHTML = '<div class="empty">Could not load notes</div>'; }
+    if (canEdit && t.source !== 'linear') {
+      wireCommand(node, t);
+      loadAudit(node, t);
+    }
+  }
+
+  // The orchestrator command panel: dependencies, reassign, force status.
+  function commandSection(t) {
+    const deps = parseDeps(t);
+    const depRows = deps.length ? deps.map((id) => {
+      const d = byId.get(id);
+      const done = d && (d.status === 'done' || d.status === 'cancelled');
+      const title = d ? (d.title || id.slice(0, 8)) : id.slice(0, 8);
+      return `<li class="dep-row"><span class="dep-stat ${done ? 'ok' : 'open'}" aria-hidden="true"></span><span class="dep-name">${esc(title)}</span><button class="dep-del" data-dep="${esc(id)}" aria-label="Remove dependency ${esc(title)}">✕</button></li>`;
+    }).join('') : '<li class="dep-empty">no dependencies</li>';
+    const cand = tasks.filter((o) => o.id !== t.id && !deps.includes(o.id))
+      .map((o) => `<option value="${esc(o.id)}">${esc(o.title || o.id.slice(0, 8))}</option>`).join('');
+    const agents = agentNames().map((a) => `<option value="${esc(a)}"></option>`).join('');
+    const statusOpts = STATUSES.map((s) => `<option value="${s.v}"${s.v === t.status ? ' selected' : ''}>${s.l}</option>`).join('');
+    return `<div class="sheet-section command">
+        <div class="sheet-label">command</div>
+        <div class="cmd-block">
+          <div class="cmd-h">dependencies</div>
+          <ul class="dep-list">${depRows}</ul>
+          <select class="cmd-input dep-pick" aria-label="Add a dependency"><option value="">+ add dependency…</option>${cand}</select>
+        </div>
+        <div class="cmd-block">
+          <div class="cmd-h">reassign</div>
+          <div class="cmd-row">
+            <input class="cmd-input reassign-input" list="cmdAgentList" placeholder="agent name" aria-label="Reassign to agent" />
+            <datalist id="cmdAgentList">${agents}</datalist>
+            <button class="cmd-btn reassign-btn" type="button">assign</button>
+          </div>
+        </div>
+        <div class="cmd-block">
+          <div class="cmd-h">force status</div>
+          <div class="cmd-row">
+            <select class="cmd-input force-status" aria-label="Force status">${statusOpts}</select>
+            <button class="cmd-btn force-btn" type="button">force</button>
+          </div>
+          <input class="cmd-input force-reason" placeholder="reason (optional)" aria-label="Reason for forcing status" />
+        </div>
+        <div class="cmd-msg" aria-live="polite"></div>
+      </div>`;
+  }
+
+  function wireCommand(node, t) {
+    const project = t.project || selection();
+    const msg = node.querySelector('.cmd-msg');
+    const ok = (s) => { msg.textContent = s; msg.dataset.kind = 'ok'; };
+    const fail = (e) => { msg.textContent = e.message || String(e); msg.dataset.kind = 'err'; };
+    const refresh = async (apply) => {
+      try { await apply(); ok('saved'); await load(false); const nt = byId.get(t.id); if (nt) openDetail(nt); }
+      catch (e) { fail(e); }
+    };
+    const deps = parseDeps(t);
+    node.querySelector('.dep-pick')?.addEventListener('change', (e) => {
+      const id = e.target.value;
+      if (id) refresh(() => ctx.api.setDependencies(t.id, project, [...deps, id]));
+    });
+    node.querySelectorAll('.dep-del').forEach((b) => b.addEventListener('click', () => {
+      refresh(() => ctx.api.setDependencies(t.id, project, deps.filter((d) => d !== b.dataset.dep)));
+    }));
+    node.querySelector('.reassign-btn')?.addEventListener('click', () => {
+      const agent = node.querySelector('.reassign-input').value.trim();
+      if (agent) refresh(() => ctx.api.reassign(t.id, project, agent));
+    });
+    node.querySelector('.force-btn')?.addEventListener('click', () => {
+      const status = node.querySelector('.force-status').value;
+      const reason = node.querySelector('.force-reason').value.trim() || undefined;
+      if (status && status !== t.status) refresh(() => ctx.api.transition(t.id, { project, status, reason, force: true }));
+    });
+  }
+
+  async function loadAudit(node, t) {
+    const el = node.querySelector('.sheet-audit');
+    if (!el) return;
+    try {
+      const rows = await ctx.api.audit(t.project || selection(), t.id, 30);
+      el.innerHTML = Array.isArray(rows) && rows.length
+        ? rows.map((a) => `<div class="audit-row"><span class="audit-act">${esc(a.action.replace(/_/g, ' '))}</span><span class="audit-sum">${esc(a.summary || '')}</span>${a.reason ? `<span class="audit-reason">${esc(a.reason)}</span>` : ''}<span class="audit-ts">${fmtAgo(a.created_at)} ago</span></div>`).join('')
+        : '<div class="empty">No actions logged yet</div>';
+    } catch (_) { el.innerHTML = '<div class="empty">Could not load audit</div>'; }
   }
 
   function detailShell(t) {
@@ -390,7 +487,9 @@ export function initBoard(root, ctx) {
       ${t.blocked_reason ? `<div class="sheet-blocked"><span class="blk-dot"></span>${esc(t.blocked_reason)}</div>` : ''}
       <div class="sheet-section"><div class="sheet-label">timeline</div><ol class="trail">${trail}</ol></div>
       ${t.description ? `<div class="sheet-section"><div class="sheet-label">description</div><div class="sheet-desc">${esc(t.description).slice(0, 4000)}</div></div>` : ''}
-      <div class="sheet-section"><div class="sheet-label">progress notes</div><div class="sheet-notes"><div class="skel" style="height:14px;width:60%"></div></div></div>`;
+      ${canEdit && t.source !== 'linear' ? commandSection(t) : ''}
+      <div class="sheet-section"><div class="sheet-label">progress notes</div><div class="sheet-notes"><div class="skel" style="height:14px;width:60%"></div></div></div>
+      ${canEdit && t.source !== 'linear' ? '<div class="sheet-section"><div class="sheet-label">audit</div><div class="sheet-audit"><div class="skel" style="height:14px;width:50%"></div></div></div>' : ''}`;
   }
 
   function buildTrail(t) {

--- a/internal/web/static/v2/index.html
+++ b/internal/web/static/v2/index.html
@@ -54,8 +54,8 @@
       <section class="page page-home" data-page="home">
         <div class="home-hero">
           <div class="home-hero-text">
-            <h1 class="home-title">control room</h1>
-            <p class="home-sub">each project is a place — enter one to watch its board, its agents, its conversations.</p>
+            <h1 class="home-title">mission control</h1>
+            <p class="home-sub">you're directing a fleet now, not babysitting one chat. every project is a crew — drop in to see who's shipping, who's blocked, and what just landed.</p>
           </div>
           <div class="home-agg" id="homeAgg" aria-label="All-projects summary"></div>
         </div>

--- a/internal/web/static/v2/team.js
+++ b/internal/web/static/v2/team.js
@@ -185,7 +185,7 @@ export function initTeam(root, ctx) {
     const save = async (url) => {
       status.textContent = '…';
       try {
-        await api.setAgentAvatar(ctx.selection, a.name, url);
+        await ctx.api.setAgentAvatar(ctx.selection, a.name, url);
         a.avatar_url = url || null;
         renderNodes(); placeNodes();
         status.textContent = url ? 'ok' : 'retiré';

--- a/internal/web/static/v2/v2.css
+++ b/internal/web/static/v2/v2.css
@@ -709,3 +709,79 @@ button { font-family: inherit; }
 .as-actions .as-save { border-color: var(--accent, #4ade80); color: var(--accent, #4ade80); }
 .as-actions button:hover { background: #1b2029; }
 .as-status { font-size: 12px; color: var(--muted, #6b7385); }
+
+/* ============================================================= *
+ *  Command layer — dependency chip, command panel, audit trail
+ * ============================================================= */
+
+/* dependency chip on board cards */
+.dep-chip {
+  display: inline-flex; align-items: center; gap: 3px;
+  font-size: 10px; color: var(--amber);
+  border: 1px solid color-mix(in srgb, var(--amber) 35%, transparent);
+  background: color-mix(in srgb, var(--amber) 10%, transparent);
+  padding: 1px 5px; border-radius: 5px;
+}
+
+/* command panel inside the task sheet */
+.sheet-section.command { border-top: 1px solid var(--border-soft); padding-top: 16px; }
+.cmd-block { margin-bottom: 14px; }
+.cmd-h {
+  font-size: 10px; letter-spacing: 0.6px; text-transform: uppercase;
+  color: var(--text-muted); margin-bottom: 6px;
+}
+.cmd-row { display: flex; gap: 8px; align-items: center; }
+.cmd-input {
+  flex: 1; min-width: 0; min-height: 36px;
+  background: var(--bg-card); color: var(--text);
+  border: 1px solid var(--border); border-radius: 6px;
+  font-family: inherit; font-size: 12px; padding: 6px 9px;
+}
+.cmd-input:focus-visible { outline: none; border-color: var(--accent-dim); box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent) 25%, transparent); }
+.force-reason { margin-top: 8px; width: 100%; }
+.cmd-btn {
+  min-height: 36px; padding: 0 14px;
+  background: var(--bg-elev); color: var(--text);
+  border: 1px solid var(--border); border-radius: 6px;
+  font-family: inherit; font-size: 12px; font-weight: 600; cursor: pointer;
+  transition: background .15s, border-color .15s;
+}
+.cmd-btn:hover { background: #1b2029; border-color: var(--accent-dim); }
+.cmd-btn:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+
+.dep-list { list-style: none; margin: 0 0 8px; padding: 0; display: flex; flex-direction: column; gap: 5px; }
+.dep-row { display: flex; align-items: center; gap: 8px; font-size: 12px; color: var(--text); }
+.dep-empty { font-size: 12px; color: var(--text-dim); font-style: italic; }
+.dep-stat { width: 8px; height: 8px; border-radius: 50%; flex-shrink: 0; }
+.dep-stat.ok { background: var(--accent); }
+.dep-stat.open { background: var(--amber); }
+.dep-name { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.dep-del {
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 24px; height: 24px; flex-shrink: 0;
+  background: none; border: 0; color: var(--text-dim);
+  cursor: pointer; border-radius: 5px; font-size: 12px;
+}
+.dep-del:hover { color: var(--red); background: color-mix(in srgb, var(--red) 12%, transparent); }
+.dep-del:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
+
+.cmd-msg { font-size: 11px; min-height: 14px; }
+.cmd-msg[data-kind="ok"] { color: var(--accent); }
+.cmd-msg[data-kind="err"] { color: var(--red); }
+
+/* audit trail */
+.sheet-audit { display: flex; flex-direction: column; gap: 7px; }
+.audit-row { display: flex; align-items: baseline; gap: 8px; font-size: 11.5px; flex-wrap: wrap; }
+.audit-act { color: var(--text); font-weight: 600; }
+.audit-sum { color: var(--text-muted); }
+.audit-reason { color: var(--text-dim); font-style: italic; flex-basis: 100%; }
+.audit-ts { margin-left: auto; color: var(--text-dim); font-size: 10.5px; white-space: nowrap; }
+
+/* ---- folded-in a11y / touch pass on existing controls ---- */
+.cyc-pill:focus-visible,
+.qa-btn:focus-visible,
+.mini:focus-visible,
+.tbl-toggle:focus-visible,
+.sheet-close:focus-visible {
+  outline: 2px solid var(--accent); outline-offset: 2px;
+}


### PR DESCRIPTION
Turns the v2 board from a dashboard you *watch* into a console you *command* — positioned for developers transitioning into agent orchestrators.

## Backend
- **Task dependencies**: `depends_on` column + readiness gate. Agents can't claim/start a task with open deps; the `user` orchestrator overrides. Cycle + self-reference rejected on `SetTaskDependencies`.
- **Reassign**: hand a task to another agent without changing status.
- **Force transition**: explicit `force` flag on the transition endpoint (bypasses the state machine + dep gate via the user actor).
- **Audit trail**: new `audit_log` table + `RecordAudit`/`ListAudit`. Every transition / force / reassign / dependency edit is logged with the why.
- **Error detail**: `apiError` now surfaces the underlying reason to the same-origin dashboard (e.g. "dependency would create a cycle").
- New endpoints: `POST /tasks/{id}/dependencies`, `POST /tasks/{id}/reassign`, `GET /audit`; `force` flag on `POST /tasks/{id}/transition`.

## Frontend (v2)
- Board cards show a `⛓ N` chip when blocked by unfinished deps.
- Task sheet gains a **command panel** (dependencies, reassign, force status) + an **audit timeline** — native non-mirror projects only.
- Folded-in a11y: focus-visible rings on v2 controls.

## Also
- v1: `v2 ↗` cross-link in the header to the new control room.
- v2: reframed home hero copy for the orchestrator audience.
- Fix: `team.js` avatar save called a bare `api` (undefined) → `ctx.api`.

## Tests
New `command_layer_test.go`: dependency gate (block agent / allow user), cycle rejection, reassign, audit round-trip. Build + vet + `-race` suite green. Verified end-to-end against a freshly-migrated DB (dep gate blocks, cycle rejected, force/reassign/audit all work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)