### PR TITLE
fix(auth): trust loopback when RELAY_API_KEY set + refresh shipped skill

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,140 @@
+# Deployment
+
+Single Go binary, SQLite on disk, embedded web UI. No required external services.
+This guide covers exposing the relay to a team/server: bind, auth, reverse proxy,
+TLS, and the full environment reference.
+
+## Bind & exposure
+
+By default the relay binds **loopback only** (`127.0.0.1:8090`) — safe for a
+single machine where every client is local.
+
+- `RELAY_BIND` — host to bind. Default `127.0.0.1`. Set `0.0.0.0` (or a specific
+  interface / docker-bridge IP) to expose beyond the host.
+- `PORT` — port. Default `8090`.
+
+**The relay refuses to bind a non-loopback address without auth.** If you set
+`RELAY_BIND=0.0.0.0` without `RELAY_API_KEY`, startup fails:
+
+```
+refusing to bind 0.0.0.0:8090 without auth: set RELAY_API_KEY to expose on a
+non-loopback address, or unset RELAY_BIND to bind 127.0.0.1
+```
+
+## Authentication
+
+Set `RELAY_API_KEY` to a strong shared secret. When set, every request must
+carry `Authorization: Bearer <key>` — **except loopback clients**, which stay
+keyless so the host's own MCP connections (`http://localhost:8090/mcp`), API
+scripts, ingest hooks, and health checks keep working without the key.
+
+```bash
+RELAY_API_KEY=$(openssl rand -hex 32)
+```
+
+- Remote callers (through a reverse proxy / another host) send the Bearer token.
+- `RELAY_TRUST_LOOPBACK=0` disables the loopback exemption — the token is then
+  required even from `127.0.0.1`.
+- The loopback check uses the real TCP peer (`RemoteAddr`), not
+  `X-Forwarded-For`, so a remote client cannot spoof it with a header.
+
+### ⚠️ Reverse-proxy + loopback caveat (read this)
+
+The loopback exemption is only safe if **your reverse proxy does not reach the
+relay over `127.0.0.1`**. If the proxy connects to the relay on loopback (common
+when both run on the same host), the proxy's forwarded public traffic appears as
+a loopback peer and **skips authentication entirely**.
+
+**Do one of:**
+
+1. **Recommended** — bind a non-loopback address and point the proxy at *that*:
+   `RELAY_BIND=0.0.0.0` (or the docker-bridge / LAN IP) + `RELAY_API_KEY=…`.
+   The proxy connects over the non-loopback address → its traffic requires the
+   token; the host's own clients still use `127.0.0.1` → keyless. Firewall the
+   bind port so it is reachable only via the proxy.
+2. Keep loopback bind but set `RELAY_TRUST_LOOPBACK=0` and give the proxy the
+   key. (Local host clients then also need the key.)
+
+## Reverse proxy
+
+Terminate TLS at the proxy and forward to the relay over a **non-loopback**
+address (see caveat above).
+
+### Traefik (docker labels)
+
+```yaml
+labels:
+  - traefik.enable=true
+  - traefik.http.routers.relay.rule=Host(`relay.example.com`)
+  - traefik.http.routers.relay.entrypoints=websecure
+  - traefik.http.routers.relay.tls.certresolver=le
+  - traefik.http.services.relay.loadbalancer.server.port=8090
+```
+
+Reach the relay via its container/service name (a non-loopback address), not
+`127.0.0.1`. Clients send `Authorization: Bearer <RELAY_API_KEY>`; Traefik
+forwards the header.
+
+### nginx
+
+```nginx
+server {
+  listen 443 ssl;
+  server_name relay.example.com;
+  # ssl_certificate / ssl_certificate_key ...
+  location / {
+    proxy_pass http://10.0.0.5:8090;   # the relay's non-loopback address
+    proxy_http_version 1.1;
+    proxy_set_header Connection "";     # keep SSE/long-poll alive
+    proxy_buffering off;                # required for /api/*/stream (SSE)
+    proxy_read_timeout 1h;
+  }
+}
+```
+
+### Caddy
+
+```
+relay.example.com {
+  reverse_proxy 10.0.0.5:8090 {
+    flush_interval -1   # stream SSE without buffering
+  }
+}
+```
+
+SSE endpoints (`/api/activity/stream`, `/api/events/stream`) need proxy
+buffering **off** and a long read timeout.
+
+## Environment reference
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `RELAY_BIND` | `127.0.0.1` | Bind host. `0.0.0.0` to expose (requires `RELAY_API_KEY`). |
+| `PORT` | `8090` | Bind port. |
+| `RELAY_API_KEY` | _(unset)_ | Bearer token. Required to bind non-loopback. Loopback exempt. |
+| `RELAY_TRUST_LOOPBACK` | `1` | `0` requires the token even from loopback. |
+| `RELAY_CORS_ORIGINS` | _(none)_ | Comma-separated allowed origins (else same-origin only). |
+| `RELAY_MAX_BODY` | _(unlimited)_ | Max request body, bytes. |
+| `RELAY_RATE_LIMIT` | _(off)_ | Requests/minute per IP. |
+| `RELAY_DB` | `~/.agent-relay/relay.db` | DB file path (set in dev/CI so a local run never migrates prod). |
+| `RELAY_LINEAR_MODE` | `false` | `1`/`true` enables the Linear mirror (needs `LINEAR_API_KEY`). |
+| `LINEAR_API_KEY` | _(unset)_ | Linear GraphQL personal key (mirror mode). |
+| `LINEAR_WEBHOOK_SECRET` | _(unset)_ | HMAC secret for inbound Linear webhooks. |
+| `LINEAR_TEAM_KEY` | _(unset)_ | Linear team key (e.g. `SYN`) — reconcile + state scope. |
+| `RELAY_LINEAR_RECONCILE_INTERVAL` | `5m` | Active-cycle reconcile poll interval. |
+
+## TLS
+
+The relay serves plain HTTP; terminate TLS at the reverse proxy (Traefik/nginx/
+Caddy with Let's Encrypt). Do not expose the relay's HTTP port publicly — route
+all external traffic through the proxy.
+
+## Platform notes
+
+- **macOS (launchd):** see `com.agent-relay.plist`; `RUN_AT_LOAD` + `KEEP_ALIVE`.
+  Restart after env changes: `launchctl bootout gui/$(id -u)/com.agent-relay &&
+  launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.agent-relay.plist`.
+- **Linux (systemd):** run the binary as a service with the env vars above; set
+  `RELAY_DB` to a stable path and back it up (`relay.db` is the single source).
+- **Docker:** put the relay and proxy on the same network; the proxy reaches the
+  relay by service name (non-loopback) — satisfies the caveat above.

--- a/install.sh
+++ b/install.sh
@@ -588,50 +588,49 @@ install_hooks() {
   local settings_file="$HOME/.claude/settings.json"
   mkdir -p "$hooks_dir"
 
-  # Create PostToolUse hook script
-  cat > "$hooks_dir/ingest-post-tool.sh" <<'HOOK_EOF'
+  # Download all five activity hooks from the repo; inline fallback for the two
+  # core ones so an offline install still gets basic tracking.
+  local hook
+  for hook in ingest-pre-tool ingest-post-tool ingest-stop ingest-subagent-start ingest-subagent-stop; do
+    curl -fsSL "https://raw.githubusercontent.com/${REPO}/main/skill/hooks/${hook}.sh" -o "$hooks_dir/${hook}.sh" 2>/dev/null || true
+    [[ -s "$hooks_dir/${hook}.sh" ]] && chmod +x "$hooks_dir/${hook}.sh"
+  done
+
+  if [[ ! -s "$hooks_dir/ingest-post-tool.sh" ]]; then
+    cat > "$hooks_dir/ingest-post-tool.sh" <<'HOOK_EOF'
 #!/usr/bin/env bash
 command -v jq &>/dev/null || exit 0
-
 EVENTS_DIR="$HOME/.pixel-office/events"
 mkdir -p "$EVENTS_DIR"
-
 INPUT=$(cat)
 SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // "unknown"')
 TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // "unknown"')
 TS=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-
 FILENAME="$EVENTS_DIR/tool-end-$$-$(date +%s).json"
 TMP="$FILENAME.tmp"
-printf '{"type":"tool_end","session_id":"%s","tool":"%s","ts":"%s"}' \
-  "$SESSION_ID" "$TOOL_NAME" "$TS" > "$TMP"
+printf '{"type":"tool_end","session_id":"%s","tool":"%s","ts":"%s"}' "$SESSION_ID" "$TOOL_NAME" "$TS" > "$TMP"
 mv "$TMP" "$FILENAME"
-
 exit 0
 HOOK_EOF
-  chmod +x "$hooks_dir/ingest-post-tool.sh"
-
-  # Create Stop hook script
-  cat > "$hooks_dir/ingest-stop.sh" <<'HOOK_EOF'
+    chmod +x "$hooks_dir/ingest-post-tool.sh"
+  fi
+  if [[ ! -s "$hooks_dir/ingest-stop.sh" ]]; then
+    cat > "$hooks_dir/ingest-stop.sh" <<'HOOK_EOF'
 #!/usr/bin/env bash
 command -v jq &>/dev/null || exit 0
-
 EVENTS_DIR="$HOME/.pixel-office/events"
 mkdir -p "$EVENTS_DIR"
-
 INPUT=$(cat)
 SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // "unknown"')
 TS=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-
 FILENAME="$EVENTS_DIR/stop-$$-$(date +%s).json"
 TMP="$FILENAME.tmp"
-printf '{"type":"stop","session_id":"%s","tool":"","file":"","ts":"%s"}' \
-  "$SESSION_ID" "$TS" > "$TMP"
+printf '{"type":"stop","session_id":"%s","tool":"","file":"","ts":"%s"}' "$SESSION_ID" "$TS" > "$TMP"
 mv "$TMP" "$FILENAME"
-
 exit 0
 HOOK_EOF
-  chmod +x "$hooks_dir/ingest-stop.sh"
+    chmod +x "$hooks_dir/ingest-stop.sh"
+  fi
 
   # Merge hooks into Claude Code settings.json (backup first)
   if [[ -f "$settings_file" ]]; then
@@ -645,41 +644,36 @@ path = os.path.expanduser('$settings_file')
 data = {}
 if os.path.exists(path):
     with open(path) as f:
-        data = json.load(f)
+        try:
+            data = json.load(f)
+        except Exception:
+            data = {}
 
 hooks = data.setdefault('hooks', {})
 
-# PostToolUse hook
-post_hooks = hooks.setdefault('PostToolUse', [])
-hook_cmd = '$hooks_dir/ingest-post-tool.sh'
-already = any(
-    h.get('hooks', [{}])[0].get('command', '') == hook_cmd
-    if isinstance(h, dict) else False
-    for h in post_hooks
-)
-if not already:
-    post_hooks.append({
-        'hooks': [{'type': 'command', 'command': hook_cmd, 'timeout': 5}]
-    })
-
-# Stop hook
-stop_hooks = hooks.setdefault('Stop', [])
-stop_cmd = '$hooks_dir/ingest-stop.sh'
-already = any(
-    h.get('hooks', [{}])[0].get('command', '') == stop_cmd
-    if isinstance(h, dict) else False
-    for h in stop_hooks
-)
-if not already:
-    stop_hooks.append({
-        'hooks': [{'type': 'command', 'command': stop_cmd, 'timeout': 5}]
-    })
+events = {
+    'PreToolUse': '$hooks_dir/ingest-pre-tool.sh',
+    'PostToolUse': '$hooks_dir/ingest-post-tool.sh',
+    'Stop': '$hooks_dir/ingest-stop.sh',
+    'SubagentStart': '$hooks_dir/ingest-subagent-start.sh',
+    'SubagentStop': '$hooks_dir/ingest-subagent-stop.sh',
+}
+for event, cmd in events.items():
+    if not os.path.exists(os.path.expanduser(cmd)):
+        continue
+    arr = hooks.setdefault(event, [])
+    already = any(
+        isinstance(h, dict) and h.get('hooks', [{}])[0].get('command', '') == cmd
+        for h in arr
+    )
+    if not already:
+        arr.append({'hooks': [{'type': 'command', 'command': cmd, 'timeout': 5}]})
 
 with open(path, 'w') as f:
     json.dump(data, f, indent=4)
     f.write('\n')
 " 2>/dev/null
-    success "Installed activity hooks (PostToolUse + Stop)"
+    success "Installed activity hooks (up to 5 events)"
   elif command -v jq &>/dev/null; then
     warn "Hook auto-config requires python3 — add hooks manually to ${BOLD}${settings_file}${RESET}"
   else
@@ -700,6 +694,9 @@ install_skill() {
   # Download the skill file from repo or use bundled version
   local tmpdir
   tmpdir=$(mktemp -d)
+
+  # Companion reference (best-effort — relay.md links to it).
+  curl -fsSL "https://raw.githubusercontent.com/${REPO}/main/skill/tools-reference.md" -o "${skill_dir}/tools-reference.md" 2>/dev/null || true
 
   if curl -fsSL "https://raw.githubusercontent.com/${REPO}/main/skill/relay.md" -o "$tmpdir/relay.md" 2>/dev/null; then
     cp "$tmpdir/relay.md" "$skill_path"

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -105,6 +105,11 @@ flags:
 		os.Exit(1)
 	}
 
+	// 5b. Refresh the shipped skill + activity hooks (best-effort — never fails
+	// the binary update). A binary-only swap would leave the /relay skill and the
+	// ingest hooks stale on the user's machine.
+	refreshSkillAndHooks(latestVersion)
+
 	// 6. Restart service
 	restartService()
 
@@ -349,6 +354,46 @@ func tryDownloadUpdate(binPath, version string) bool {
 // download fetches url to dst with curl (already a dependency of the updater).
 func download(dst, url string) error {
 	return exec.Command("curl", "-fsSL", "-o", dst, url).Run()
+}
+
+// refreshSkillAndHooks pulls the /relay skill docs and the activity-tracking
+// hooks for the just-installed version and writes them to the user's Claude
+// config (same layout as install.sh): skill → ~/.claude/commands/, hooks →
+// ~/.claude/hooks/. Best-effort — a failure here never fails the binary update.
+func refreshSkillAndHooks(version string) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return
+	}
+	base := "https://raw.githubusercontent.com/" + repo + "/" + version + "/skill/"
+	fmt.Print("  refreshing skill + hooks... ")
+
+	// Skill docs → ~/.claude/commands/
+	cmdDir := filepath.Join(home, ".claude", "commands")
+	_ = os.MkdirAll(cmdDir, 0o755)
+	skillOK := 0
+	for _, f := range []string{"relay.md", "tools-reference.md"} {
+		if download(filepath.Join(cmdDir, f), base+f) == nil {
+			skillOK++
+		}
+	}
+
+	// Activity hooks → ~/.claude/hooks/ (executable)
+	hooksDir := filepath.Join(home, ".claude", "hooks")
+	_ = os.MkdirAll(hooksDir, 0o755)
+	hooks := []string{
+		"ingest-pre-tool.sh", "ingest-post-tool.sh", "ingest-stop.sh",
+		"ingest-subagent-start.sh", "ingest-subagent-stop.sh",
+	}
+	hookOK := 0
+	for _, h := range hooks {
+		dst := filepath.Join(hooksDir, h)
+		if download(dst, base+"hooks/"+h) == nil {
+			_ = os.Chmod(dst, 0o755)
+			hookOK++
+		}
+	}
+	fmt.Printf("skill %d/2, hooks %d/%d\n", skillOK, hookOK, len(hooks))
 }
 
 // verifyChecksum compares the SHA-256 of file against the entry for name in a

--- a/internal/relay/middleware.go
+++ b/internal/relay/middleware.go
@@ -4,6 +4,7 @@ import (
 	"crypto/subtle"
 	"net"
 	"net/http"
+	"os"
 	"sync"
 	"time"
 
@@ -12,12 +13,30 @@ import (
 
 // authMiddleware rejects requests without a valid Bearer token.
 // If apiKey is empty, all requests pass through (local-mode).
+//
+// When a key IS set, loopback clients (127.0.0.0/8, ::1) are still trusted
+// without a token, so enabling RELAY_API_KEY to expose the relay through an
+// external reverse proxy does not 401 every same-host client: the ~dozens of
+// local .mcp.json connections (http://localhost:8090/mcp), API scripts, the
+// ingest hooks, and health checks all keep working keyless. Remote callers
+// (through the proxy) still need the Bearer token.
+//
+// SECURITY: this is only safe if your reverse proxy does NOT reach the relay
+// over loopback. If Traefik/nginx connects to 127.0.0.1:8090, its proxied
+// public traffic would appear local and skip auth. Front the relay from a
+// non-loopback address (docker bridge / host LAN IP), or set
+// RELAY_TRUST_LOOPBACK=0 to require the token even from loopback.
 func authMiddleware(apiKey string, next http.Handler) http.Handler {
 	if apiKey == "" {
 		return next
 	}
+	trustLoopback := os.Getenv("RELAY_TRUST_LOOPBACK") != "0"
 	expected := []byte(apiKey)
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if trustLoopback && isLoopbackRemote(r.RemoteAddr) {
+			next.ServeHTTP(w, r)
+			return
+		}
 		token := r.Header.Get("Authorization")
 		const prefix = "Bearer "
 		if len(token) > len(prefix) && token[:len(prefix)] == prefix {
@@ -31,6 +50,18 @@ func authMiddleware(apiKey string, next http.Handler) http.Handler {
 		}
 		next.ServeHTTP(w, r)
 	})
+}
+
+// isLoopbackRemote reports whether an http.Request RemoteAddr ("host:port") is a
+// loopback address. Uses the real TCP peer — not any X-Forwarded-For header — so
+// it can't be spoofed by a remote client setting a header.
+func isLoopbackRemote(remoteAddr string) bool {
+	host, _, err := net.SplitHostPort(remoteAddr)
+	if err != nil {
+		host = remoteAddr
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
 }
 
 // bodySizeLimitMiddleware wraps request bodies with http.MaxBytesReader.

--- a/internal/relay/middleware_test.go
+++ b/internal/relay/middleware_test.go
@@ -1,0 +1,66 @@
+package relay
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestAuthMiddleware_LoopbackExemption(t *testing.T) {
+	t.Setenv("RELAY_TRUST_LOOPBACK", "") // default: trust loopback
+	ok := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(200) })
+	h := authMiddleware("secret", ok)
+
+	call := func(remote, token string) int {
+		req := httptest.NewRequest("GET", "/api/health", nil)
+		req.RemoteAddr = remote
+		if token != "" {
+			req.Header.Set("Authorization", "Bearer "+token)
+		}
+		rr := httptest.NewRecorder()
+		h.ServeHTTP(rr, req)
+		return rr.Code
+	}
+
+	if c := call("127.0.0.1:5555", ""); c != 200 {
+		t.Fatalf("loopback IPv4 no-token: want 200, got %d", c)
+	}
+	if c := call("[::1]:5555", ""); c != 200 {
+		t.Fatalf("loopback IPv6 no-token: want 200, got %d", c)
+	}
+	if c := call("10.1.2.3:5555", ""); c != 401 {
+		t.Fatalf("remote no-token: want 401, got %d", c)
+	}
+	if c := call("10.1.2.3:5555", "secret"); c != 200 {
+		t.Fatalf("remote good token: want 200, got %d", c)
+	}
+	if c := call("10.1.2.3:5555", "wrong"); c != 401 {
+		t.Fatalf("remote bad token: want 401, got %d", c)
+	}
+}
+
+func TestAuthMiddleware_TrustLoopbackDisabled(t *testing.T) {
+	t.Setenv("RELAY_TRUST_LOOPBACK", "0")
+	ok := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(200) })
+	h := authMiddleware("secret", ok)
+
+	req := httptest.NewRequest("GET", "/api/health", nil)
+	req.RemoteAddr = "127.0.0.1:5555"
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	if rr.Code != 401 {
+		t.Fatalf("loopback with trust disabled: want 401, got %d", rr.Code)
+	}
+}
+
+func TestAuthMiddleware_NoKeyPassesThrough(t *testing.T) {
+	ok := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(200) })
+	h := authMiddleware("", ok)
+	req := httptest.NewRequest("GET", "/api/health", nil)
+	req.RemoteAddr = "10.1.2.3:5555"
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	if rr.Code != 200 {
+		t.Fatalf("no key should pass through: want 200, got %d", rr.Code)
+	}
+}

--- a/skill/relay.md
+++ b/skill/relay.md
@@ -164,4 +164,4 @@ The relay auto-normalizes JSON keys to snake_case on ingestion, but agents shoul
 
 ## Reference
 
-See `skill/tools-reference.md` for the full 61 MCP tools list.
+See `skill/tools-reference.md` for the full 58 MCP tools list.

--- a/skill/relay.md
+++ b/skill/relay.md
@@ -17,6 +17,17 @@ Tell user to run `/mcp` to reload. Stop here.
 
 **Available?** Proceed below.
 
+### Auth (only if the relay has `RELAY_API_KEY` set)
+
+Local/loopback clients (same host) connect **keyless** — `http://localhost:8090/mcp` and same-host API scripts work as-is. Only **remote** callers (through a reverse proxy / different host) need a token:
+
+```json
+{ "mcpServers": { "agent-relay": { "type": "http", "url": "https://relay.example.com/mcp",
+  "headers": { "Authorization": "Bearer <RELAY_API_KEY>" } } } }
+```
+
+API scripts: add `-H "Authorization: Bearer <RELAY_API_KEY>"`. A `401 {"error":"unauthorized"}` means the key is required (you're not on loopback) and missing/wrong.
+
 ## Identity
 
 1. Infer agent name + project from context, or ask user.
@@ -49,24 +60,18 @@ Re-registering the same name+project is a respawn: it updates `role`/`descriptio
 ### Tasks
 - **`tasks`**: List assigned + dispatched tasks. Use `list_tasks(status: "active")` for non-done/cancelled.
 - **`dispatch <profile> <title> [--priority P0-P3] [--board id] [--parent id]`**: Create task. Auto-notifies agents running that profile.
-- **`claim/start/done/block <task_id> [result|reason]`**: State transitions
-- **`task <id>`**: Details + subtasks + goal chain
-- **`move <task_id> --board <id> --goal <id>`**: `move_task` — move to different board/goal
+- **`claim/start/review/done/block <task_id> [result|reason]`**: State transitions (`review_task` = "PR up" → in-review)
+- **`task <id>`**: Details + subtask chain
+- **`move <task_id> --board <id>`**: `move_task` — move to a different board
 - **`batch-done <tasks_json>`**: `batch_complete_tasks` — complete multiple tasks at once
 - **`batch-dispatch <tasks_json>`**: `batch_dispatch_tasks` — dispatch multiple tasks at once
 - **`list_tasks(include_archived: true)`**: Include archived tasks in results
 
-State machine: `pending → accepted → in-progress → done|blocked|cancelled`. `done` and `cancelled` reachable from any state.
+State machine: `pending → accepted → in-progress → in-review → done|blocked|cancelled`. `done` and `cancelled` reachable from any state; `blocked` resumes via `resume_task`.
 
 ### Project Setup
 - **`create_project(name, [description], [cwd], [interactive])`**: One-command colony setup — generates 8-phase onboarding prompt (analyze codebase, define profiles, spawn workers with boot sequence, plan sprints)
 - Interactive mode pauses at each phase for user approval; auto mode executes everything
-
-### Goals
-- **`create_goal(type, title, [parent_goal_id], [owner_agent])`**: Types: mission, project_goal, agent_goal
-- **`list_goals / get_goal / update_goal / get_goal_cascade`**: Manage goal hierarchy
-
-Goal cascade: Mission → Project Goal → Agent Goal → Task. Agents see the full WHY chain.
 
 ### Teams & Orgs
 - **`teams / create-team / join-team / leave-team / team-inbox`**: Team management
@@ -136,8 +141,8 @@ Link session to agent: pass `session_id` from `whoami` in `register_agent`.
 
 ## Token Efficiency
 
-- **Worker agents should connect with `?tools=discovery`** (`http://localhost:8090/mcp?tools=discovery`): only 2 tools are exposed (~460 tokens of schemas instead of ~11,000). Call `discover_tools(category)` to fetch one category's schemas, then `call_tool(tool: "send_message", args: {...})` to invoke. Categories: session, messaging, conversations, tasks, boards, goals, memory, profiles, agents, teams, locks, projects.
-- **`get_inbox`, `list_tasks`, `list_agents`, `list_memories`, `list_goals` return compact markdown tables by default** (~half the tokens of JSON). Pass `format: "json"` when you need the structured shape.
+- **Worker agents should connect with `?tools=discovery`** (`http://localhost:8090/mcp?tools=discovery`): only 2 tools are exposed (~460 tokens of schemas instead of ~11,000). Call `discover_tools(category)` to fetch one category's schemas, then `call_tool(tool: "send_message", args: {...})` to invoke. Categories: session, messaging, conversations, tasks, boards, memory, profiles, agents, teams, projects.
+- **`get_inbox`, `list_tasks`, `list_agents`, `list_memories` return compact markdown tables by default** (~half the tokens of JSON). Pass `format: "json"` when you need the structured shape.
 - Default connection (no `?tools=`) keeps full schemas for compatibility.
 
 ## Data Conventions
@@ -151,12 +156,12 @@ Link session to agent: pass `session_id` from `whoami` in `register_agent`.
 - Any structured data exchanged between agents
 
 ```
-✅ {"task_id": "abc", "assigned_to": "bot-a", "parent_goal_id": "g1"}
-❌ {"taskId": "abc", "assignedTo": "bot-a", "parentGoalId": "g1"}
+✅ {"task_id": "abc", "assigned_to": "bot-a", "parent_task_id": "t1"}
+❌ {"taskId": "abc", "assignedTo": "bot-a", "parentTaskId": "t1"}
 ```
 
 The relay auto-normalizes JSON keys to snake_case on ingestion, but agents should follow this convention to avoid confusion.
 
 ## Reference
 
-See `skill/tools-reference.md` for the full 65 MCP tools list.
+See `skill/tools-reference.md` for the full 61 MCP tools list.

--- a/skill/tools-reference.md
+++ b/skill/tools-reference.md
@@ -1,9 +1,13 @@
-# MCP Tools Reference (65 tools)
+# MCP Tools Reference (61 tools)
+
+## Auth (only when RELAY_API_KEY is set)
+
+Loopback / same-host clients connect **keyless** (local `.mcp.json`, API scripts on the host). **Remote** callers send `Authorization: Bearer <RELAY_API_KEY>` on every request (MCP + REST); a missing/wrong key returns `401 {"error":"unauthorized"}`. Set `RELAY_TRUST_LOOPBACK=0` to require the token even from loopback.
 
 ## Token-Efficient Connection (optional)
 
 - Connect with `?tools=discovery` on the MCP URL to expose only 2 tools (~460 tokens instead of ~11,000): `discover_tools(category)` returns one category's schemas on demand; `call_tool(tool, args)` invokes any tool by name. Recommended for worker agents.
-- `get_inbox`, `list_tasks`, `list_agents`, `list_memories`, `list_goals` return compact markdown tables by default (~half the tokens of JSON); pass `format: "json"` for the structured shape.
+- `get_inbox`, `list_tasks`, `list_agents`, `list_memories` return compact markdown tables by default (~half the tokens of JSON); pass `format: "json"` for the structured shape.
 
 ## Core
 - `register_agent` — register/update agent identity (name, role, description, reports_to, is_executive, profile_slug, session_id, interest_tags, max_context_bytes)
@@ -29,27 +33,21 @@
 - `archive_conversation` — archive a conversation
 
 ## Tasks
-- `dispatch_task` — create task for a profile (priority, board_id, parent_task_id, goal_id). Auto-notifies agents running the profile.
+- `dispatch_task` — create task for a profile (priority, board_id, parent_task_id). Auto-notifies agents running the profile.
 - `claim_task` — accept a pending task
 - `start_task` — begin work on task
+- `review_task` — mark "PR up" → in-review (fires the Linear In-Review write-back on mirror projects)
 - `complete_task` — finish with result
 - `block_task` — block with reason (notifies dispatcher + parent chain)
 - `resume_task` — move a blocked task back to in-progress
 - `cancel_task` — cancel from any state with optional reason
-- `get_task` — details + optional subtask chain + goal ancestry if linked
+- `get_task` — details + optional subtask chain
 - `list_tasks` — filtered list (status, profile, priority, board_id, assigned_to). Use status="active" for non-done/cancelled. include_archived option.
-- `update_task` — update title, description, priority, board_id, goal_id without changing status
-- `move_task` — move task to different board/goal (shortcut for update_task)
+- `update_task` — update title, description, priority, board_id without changing status
+- `move_task` — move task to a different board (shortcut for update_task)
 - `archive_tasks` — bulk archive done/cancelled tasks by status/board
 - `batch_complete_tasks` — complete multiple tasks at once (JSON array of {task_id, result})
-- `batch_dispatch_tasks` — dispatch multiple tasks at once (JSON array of {profile, title, description, priority, board_id, goal_id})
-
-## Goals
-- `create_goal` — create goal in cascade (type: mission|project_goal|agent_goal)
-- `list_goals` — list with progress (filter by type, status, owner_agent)
-- `get_goal` — full details + ancestry + progress + children
-- `update_goal` — update title, description, status
-- `get_goal_cascade` — full tree for project with progress
+- `batch_dispatch_tasks` — dispatch multiple tasks at once (JSON array of {profile, title, description, priority, board_id})
 
 ## Boards
 - `create_board` — create task board (name, slug, description)
@@ -81,11 +79,6 @@
 - `get_team_inbox` — team messages
 - `add_notify_channel` — allow cross-team messaging to a specific agent
 
-## File Locks
-- `claim_files` — lock files for editing (broadcasts steering notification, TTL-based)
-- `release_files` — release file locks
-- `list_locks` — list active file locks
-
 ## Project Management
 - `create_project` — one-command colony setup (8-phase onboarding prompt)
 - `delete_project` — cascade delete project and all associated data
@@ -95,12 +88,17 @@
 - `deactivate_agent` — permanently deactivate (re-register to restore)
 - `delete_agent` — soft-delete (hidden from UI, re-register to restore)
 
-## REST API (Web UI)
+## REST API (Web UI + scripts)
 - `GET /api/health` — status, version, uptime, db stats
 - `GET /api/projects` — list projects with stats (agents, tasks, tokens_24h)
-- `GET /api/token-usage` — per-project token usage breakdown
-- `GET /api/token-usage/project` — per-agent breakdown
-- `GET /api/token-usage/agent` — per-tool breakdown
-- `GET /api/token-usage/timeseries` — time series data
-- `GET /api/activity/stream` — SSE real-time activity stream
-- `GET /api/events/stream` — SSE MCP events stream
+- `GET /api/messages?project=` — recent messages; `GET /api/messages/all-projects` — fleet-wide
+- `POST /api/user-response` — send as the orchestrator `{project, to, content, reply_to}` (`to:"*"` broadcasts)
+- `GET /api/memories?project=[&scope=&agent=&tag=]` · `GET /api/memories/search?project=&q=`
+- `POST /api/memories` — set `{project, key, value, scope, layer, tags, agent_name}`
+- `DELETE /api/memories/{id}` · `POST /api/memories/{key}/resolve {project, chosen_value, scope}`
+- `GET /api/tasks?project=` · `GET /api/tasks/board?project=&cycle=` · `POST /api/tasks` (dispatch)
+- `POST /api/tasks/{id}/transition {project, status, agent, reason}`
+- `GET /api/token-usage[/project|/agent|/timeseries]` — token usage breakdowns
+- `GET /api/activity/stream` · `GET /api/events/stream` — SSE streams
+
+> All POST/DELETE bodies are JSON. When `RELAY_API_KEY` is set, remote scripts add `-H "Authorization: Bearer <key>"`.

--- a/skill/tools-reference.md
+++ b/skill/tools-reference.md
@@ -1,4 +1,4 @@
-# MCP Tools Reference (61 tools)
+# MCP Tools Reference (58 tools, + discover_tools/call_tool in discovery mode)
 
 ## Auth (only when RELAY_API_KEY is set)
 


### PR DESCRIPTION
Unblocks the prod 502 / "messages don't arrive" / broken local MCP — all one root cause: `RELAY_API_KEY` made `authMiddleware` 401 **every** request (no loopback exemption). Plus the shipped skill had drifted from the served toolset.

## Auth
- `authMiddleware` exempts **loopback** (127.0.0.0/8, ::1) when a key is set → local `.mcp.json`, API scripts, ingest hooks, and health checks keep working **keyless**; remote callers (through a proxy) still need `Authorization: Bearer`.
- Uses the real TCP peer (`RemoteAddr`), **not** `X-Forwarded-For` — can't be spoofed by a header.
- Escape hatch: `RELAY_TRUST_LOOPBACK=0` requires the token even from loopback.
- **SECURITY caveat** (in code + below): only safe if the reverse proxy does **not** reach the relay over loopback. Front it from a non-loopback address (docker bridge / LAN), else proxied public traffic appears local and skips auth.
- Tests: loopback exempt (v4/v6), remote requires token, trust-disabled, no-key passthrough.

## Skill refresh (`skill/relay.md`, `skill/tools-reference.md`)
- Removed **Goals** (subsystem dropped) and **File Locks** (tools disabled in the slim refactor) — agents were being told about tools that return "unknown tool".
- Fixed count 65 → **61**; fixed `discover_tools` category list (dropped `goals`, `locks`).
- Added `review_task` + in-review state to the lifecycle; dropped `goal_id` params.
- Added an **Auth** section (loopback keyless / remote Bearer) + the message/memory REST endpoints scripts use.

Branches off `main`; independent of the open board PR (#55).

🤖 Generated with [Claude Code](https://claude.com/claude-code)