### PR TITLE
fix(db): return newest messages first for Messages view

### DIFF
--- a/internal/db/web_queries.go
+++ b/internal/db/web_queries.go
@@ -58,7 +58,7 @@ func (d *DB) GetAllRecentMessages(project string, limit int) ([]models.Message, 
 		SELECT id, from_agent, to_agent, reply_to, type, subject, content, metadata, created_at, read_at, conversation_id, project, task_id, priority, ttl_seconds, expired_at
 		FROM messages
 		WHERE project = ?
-		ORDER BY created_at ASC
+		ORDER BY created_at DESC
 		LIMIT ?
 	`
 	return d.queryMessages(query, project, limit)
@@ -108,7 +108,7 @@ func (d *DB) GetAllRecentMessagesAllProjects(limit int) ([]models.Message, error
 	query := `
 		SELECT id, from_agent, to_agent, reply_to, type, subject, content, metadata, created_at, read_at, conversation_id, project, task_id, priority, ttl_seconds, expired_at
 		FROM messages
-		ORDER BY created_at ASC
+		ORDER BY created_at DESC
 		LIMIT ?
 	`
 	return d.queryMessages(query, limit)


### PR DESCRIPTION
## Problem

Notifications appeared in the **Team → transcript** view but **not** in the **Messages** view.

`GetAllRecentMessages` / `GetAllRecentMessagesAllProjects` sorted `created_at ASC` with `LIMIT`, so they returned the **oldest** N rows — despite doc comments promising "most recent". In projects with >500 messages, the Messages page only ever showed the 500 earliest rows; new traffic never appeared.

Team transcript was unaffected because it's fed by `GetMessagesSince` (`WHERE created_at > now-3h`) — time-bounded, not count-bounded.

## Fix

Flip both `GetAllRecent*` queries to `ORDER BY created_at DESC`.

- Matches the doc comments ("most recent")
- Matches `messages.js`'s documented newest-first assumption (`th[0]` = latest, `lastProjectForAgent` reads index 0)
- Thread display already re-sorts ASC itself (`messages.js:122`), so chronological order is preserved
- `GetMessagesSince` left untouched — team re-sorts and is time-bounded

## Test

`go build ./internal/db/` clean. Restart relay to pick up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)