### PR TITLE
feat(linear): status + comment write-back → Linear (the only two agent actions)

### DIFF
--- a/internal/connector/connector.go
+++ b/internal/connector/connector.go
@@ -29,6 +29,13 @@ type TaskConnector interface {
 	// the team's In Review state and post a comment. Bounded retries inside.
 	PushInReview(linearIssueID, comment string) error
 
+	// PushStatus moves the issue to the workflow state matching a relay status and
+	// posts an optional comment — the status write-back for any transition.
+	PushStatus(linearIssueID, status, comment string) error
+
+	// Comment posts a standalone comment to the issue (no state change).
+	Comment(linearIssueID, body string) error
+
 	// ReconcileCycle pulls the active cycle's issues and upserts the mirror,
 	// healing missed webhooks. Returns the number of rows upserted.
 	ReconcileCycle(project string) (upserted int, err error)
@@ -48,6 +55,8 @@ type Noop struct{}
 
 func (Noop) Ingest(_ []byte, _ string) ([]TaskEvent, error) { return nil, nil }
 func (Noop) PushInReview(_ string, _ string) error          { return nil }
+func (Noop) PushStatus(_, _, _ string) error                { return nil }
+func (Noop) Comment(_, _ string) error                      { return nil }
 func (Noop) ReconcileCycle(_ string) (int, error)           { return 0, nil }
 func (Noop) Active() bool                                   { return false }
 

--- a/internal/connector/linear/linear.go
+++ b/internal/connector/linear/linear.go
@@ -5,6 +5,7 @@ package linear
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"strings"
 	"sync"
@@ -30,6 +31,7 @@ type Connector struct {
 	viewerID    string               // the API key's own user id (anti-loop)
 	reviewState string               // cached "In Review" state id
 	states      map[string]stateInfo // team workflow states by id (cache)
+	stateList   []stateInfo          // same states in workflow order (for outbound resolution)
 
 	lastWebhookAt   atomic.Int64 // unix ms
 	lastReconcileAt atomic.Int64 // unix ms
@@ -147,6 +149,10 @@ func looksLikeReview(name string) bool {
 	return strings.Contains(strings.ToLower(name), "review")
 }
 
+func looksLikeBlocked(name string) bool {
+	return strings.Contains(strings.ToLower(name), "block")
+}
+
 // Warmup fetches the viewer id (anti-loop) and the team's workflow states. It is
 // best-effort: failures are logged and retried lazily on first use. Safe to call
 // from a startup goroutine.
@@ -214,6 +220,7 @@ func (c *Connector) ensureReviewState(ctx context.Context) (string, error) {
 	}
 	c.mu.Lock()
 	c.states = byID
+	c.stateList = states
 	if chosen != "" {
 		c.reviewState = chosen
 	}
@@ -222,6 +229,29 @@ func (c *Connector) ensureReviewState(ctx context.Context) (string, error) {
 		return "", errNoReviewState
 	}
 	return chosen, nil
+}
+
+// statesList returns the team's workflow states in order, fetching+caching on
+// first use. Tolerates a team with no "In Review" state (the states are still
+// cached for outbound resolution).
+func (c *Connector) statesList(ctx context.Context) ([]stateInfo, error) {
+	c.mu.RLock()
+	list := c.stateList
+	c.mu.RUnlock()
+	if len(list) > 0 {
+		return list, nil
+	}
+	// ensureReviewState populates c.stateList even when no review state exists.
+	if _, err := c.ensureReviewState(ctx); err != nil && err != errNoReviewState {
+		return nil, err
+	}
+	c.mu.RLock()
+	list = c.stateList
+	c.mu.RUnlock()
+	if len(list) == 0 {
+		return nil, fmt.Errorf("no team workflow states")
+	}
+	return list, nil
 }
 
 // Status returns a small health snapshot for /api/health.

--- a/internal/connector/linear/writeback_test.go
+++ b/internal/connector/linear/writeback_test.go
@@ -1,0 +1,46 @@
+package linear
+
+import "testing"
+
+func TestResolveStateID(t *testing.T) {
+	states := []stateInfo{
+		{ID: "bk", Name: "Backlog", Type: "backlog"},
+		{ID: "td", Name: "Todo", Type: "unstarted"},
+		{ID: "ip", Name: "In Progress", Type: "started"},
+		{ID: "rev", Name: "In Review", Type: "started"},
+		{ID: "blk", Name: "Blocked", Type: "started"},
+		{ID: "dn", Name: "Done", Type: "completed"},
+		{ID: "cx", Name: "Canceled", Type: "canceled"},
+	}
+	cases := map[string]string{
+		"in-review":   "rev",
+		"blocked":     "blk",
+		"in-progress": "ip",
+		"accepted":    "ip",
+		"done":        "dn",
+		"cancelled":   "cx",
+		"pending":     "td",
+		"bogus":       "",
+	}
+	for status, want := range cases {
+		if got := resolveStateID(status, states); got != want {
+			t.Errorf("resolveStateID(%q) = %q, want %q", status, got, want)
+		}
+	}
+}
+
+// A team without a Blocked state → blocked maps to nothing (caller falls back to
+// a comment), and in-progress still resolves to the lone started state.
+func TestResolveStateID_NoBlockedState(t *testing.T) {
+	states := []stateInfo{
+		{ID: "td", Name: "Todo", Type: "unstarted"},
+		{ID: "ip", Name: "Doing", Type: "started"},
+		{ID: "dn", Name: "Done", Type: "completed"},
+	}
+	if got := resolveStateID("blocked", states); got != "" {
+		t.Errorf("blocked without a Blocked state = %q, want empty", got)
+	}
+	if got := resolveStateID("in-progress", states); got != "ip" {
+		t.Errorf("in-progress = %q, want ip", got)
+	}
+}

--- a/internal/connector/linear/writer.go
+++ b/internal/connector/linear/writer.go
@@ -12,35 +12,60 @@ const (
 	writerTimeout    = 20 * time.Second
 )
 
-// PushInReview is the agent's single owned write-back: move the issue to the
-// team's In Review state, then post a comment. Bounded exponential retries.
-// Outcomes are logged to the linear_sync_log audit table and reflected in the
-// connector's failure counter (surfaced via /api/health).
+// PushInReview is kept for back-compat — a write-back to the team's In Review
+// state plus a comment. New callers use PushStatus.
 func (c *Connector) PushInReview(linearIssueID, comment string) error {
+	return c.PushStatus(linearIssueID, "in-review", comment)
+}
+
+// PushStatus moves a Linear issue to the workflow state matching a relay status,
+// then posts an optional comment. The two writes an agent/orchestrator may make
+// back to Linear — Linear stays the source of truth, the relay only mirrors.
+//
+// State resolution maps the relay status to a team workflow state by TYPE
+// (started/completed/canceled/unstarted) plus NAME for the states Linear models
+// by name only ("In Review", "Blocked"). When no state matches (e.g. a team
+// without a Blocked state), the move is skipped and the action is recorded as a
+// comment instead — honest, never a wrong status. Bounded retries; outcomes go
+// to linear_sync_log + the failure counter (surfaced via /api/health).
+func (c *Connector) PushStatus(linearIssueID, status, comment string) error {
 	if linearIssueID == "" {
 		return fmt.Errorf("empty linear issue id")
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), writerTimeout)
 	defer cancel()
 
-	stateID, err := c.ensureReviewState(ctx)
-	if err != nil {
-		c.writerFailures.Add(1)
-		c.db.LogLinearSync(linearIssueID, "in_review", "error", "resolve state: "+err.Error())
-		return fmt.Errorf("resolve in-review state: %w", err)
+	stateID := ""
+	if status == "in-review" {
+		// Fast path + honors a directly-cached review state.
+		if id, err := c.ensureReviewState(ctx); err == nil {
+			stateID = id
+		}
+	}
+	if stateID == "" {
+		if states, err := c.statesList(ctx); err == nil {
+			stateID = resolveStateID(status, states)
+		}
 	}
 
-	if err := c.retry(ctx, func() error { return c.gql.issueUpdateState(ctx, linearIssueID, stateID) }); err != nil {
-		c.writerFailures.Add(1)
-		c.db.LogLinearSync(linearIssueID, "in_review", "error", "issueUpdate: "+err.Error())
-		return fmt.Errorf("issueUpdate in-review: %w", err)
+	if stateID != "" {
+		if err := c.retry(ctx, func() error { return c.gql.issueUpdateState(ctx, linearIssueID, stateID) }); err != nil {
+			c.writerFailures.Add(1)
+			c.db.LogLinearSync(linearIssueID, status, "error", "issueUpdate: "+err.Error())
+			return fmt.Errorf("issueUpdate %s: %w", status, err)
+		}
+		c.db.LogLinearSync(linearIssueID, status, "ok", "")
+	} else {
+		// No mappable Linear state — fall back to a comment so the status change
+		// is at least recorded, without lying about the issue's state.
+		c.db.LogLinearSync(linearIssueID, status, "skip", "no matching Linear state")
+		if comment == "" {
+			comment = fmt.Sprintf("relay: status → %s (no matching Linear state)", status)
+		}
 	}
-	c.db.LogLinearSync(linearIssueID, "in_review", "ok", "")
 
 	if comment != "" {
 		if err := c.retry(ctx, func() error { return c.gql.commentCreate(ctx, linearIssueID, comment) }); err != nil {
-			// The transition is the load-bearing write; a failed comment is logged
-			// but not fatal (the state already moved).
 			c.writerFailures.Add(1)
 			c.db.LogLinearSync(linearIssueID, "comment", "error", err.Error())
 			return fmt.Errorf("commentCreate: %w", err)
@@ -48,6 +73,70 @@ func (c *Connector) PushInReview(linearIssueID, comment string) error {
 		c.db.LogLinearSync(linearIssueID, "comment", "ok", "")
 	}
 	return nil
+}
+
+// Comment posts a standalone comment to a Linear issue (no state change).
+func (c *Connector) Comment(linearIssueID, body string) error {
+	if linearIssueID == "" {
+		return fmt.Errorf("empty linear issue id")
+	}
+	if body == "" {
+		return fmt.Errorf("empty comment body")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), writerTimeout)
+	defer cancel()
+	if err := c.retry(ctx, func() error { return c.gql.commentCreate(ctx, linearIssueID, body) }); err != nil {
+		c.writerFailures.Add(1)
+		c.db.LogLinearSync(linearIssueID, "comment", "error", err.Error())
+		return fmt.Errorf("commentCreate: %w", err)
+	}
+	c.db.LogLinearSync(linearIssueID, "comment", "ok", "")
+	return nil
+}
+
+// resolveStateID maps a relay status to a Linear workflow state id, given the
+// team's states in workflow order. Returns "" when nothing matches.
+func resolveStateID(status string, states []stateInfo) string {
+	pick := func(match func(stateInfo) bool) string {
+		for _, s := range states {
+			if match(s) {
+				return s.ID
+			}
+		}
+		return ""
+	}
+	switch status {
+	case "in-review":
+		if id := pick(func(s stateInfo) bool { return s.Type == "started" && looksLikeReview(s.Name) }); id != "" {
+			return id
+		}
+		if id := pick(func(s stateInfo) bool { return looksLikeReview(s.Name) }); id != "" {
+			return id
+		}
+		return pick(func(s stateInfo) bool { return s.Type == "started" })
+	case "blocked":
+		// Linear models "blocked" only by name; "" if the team has no such state.
+		return pick(func(s stateInfo) bool { return looksLikeBlocked(s.Name) })
+	case "accepted", "in-progress":
+		// Prefer a plain started state, not the review/blocked-named one.
+		if id := pick(func(s stateInfo) bool {
+			return s.Type == "started" && !looksLikeReview(s.Name) && !looksLikeBlocked(s.Name)
+		}); id != "" {
+			return id
+		}
+		return pick(func(s stateInfo) bool { return s.Type == "started" })
+	case "done":
+		return pick(func(s stateInfo) bool { return s.Type == "completed" })
+	case "cancelled":
+		return pick(func(s stateInfo) bool { return s.Type == "canceled" })
+	case "pending":
+		for _, t := range []string{"unstarted", "backlog", "triage"} {
+			if id := pick(func(s stateInfo) bool { return s.Type == t }); id != "" {
+				return id
+			}
+		}
+	}
+	return ""
 }
 
 // retry runs fn with bounded exponential backoff, honoring ctx cancellation.

--- a/internal/relay/api.go
+++ b/internal/relay/api.go
@@ -112,6 +112,8 @@ func (r *Relay) ServeAPI(w http.ResponseWriter, req *http.Request) {
 		r.apiTransitionTask(w, req, path)
 	case strings.HasPrefix(path, "/tasks/") && strings.HasSuffix(path, "/reassign") && req.Method == http.MethodPost:
 		r.apiReassignTask(w, req, path)
+	case strings.HasPrefix(path, "/tasks/") && strings.HasSuffix(path, "/comment") && req.Method == http.MethodPost:
+		r.apiTaskComment(w, req, path)
 	case strings.HasPrefix(path, "/tasks/") && strings.HasSuffix(path, "/progress") && req.Method == http.MethodGet:
 		r.apiGetTaskProgress(w, req, path)
 	case path == "/audit" && req.Method == http.MethodGet:
@@ -1342,11 +1344,13 @@ func (r *Relay) apiTransitionTask(w http.ResponseWriter, req *http.Request, path
 		r.Events.EmitSemantic(evType, body.Project, body.Agent, payload)
 	}
 
-	// Write-back (Linear mode): a web-driven → In Review fires the one owned
-	// transition + comment, fire-and-forget. No-op in native mode.
-	if body.Status == "in-review" {
-		pushInReviewAsync(r.TaskConn(), task, body.Agent, body.Result)
+	// Write-back (Linear mode): mirror the status change to the Linear issue
+	// (state move + optional comment), fire-and-forget. No-op in native mode.
+	note := body.Result
+	if note == nil {
+		note = body.Reason
 	}
+	pushStatusAsync(r.TaskConn(), task, body.Status, note)
 
 	writeJSON(w, task)
 }
@@ -1395,6 +1399,53 @@ func (r *Relay) apiReassignTask(w http.ResponseWriter, req *http.Request, path s
 		Summary:      fmt.Sprintf("%s → %s", orDash(prev), body.Agent),
 	})
 	writeJSON(w, task)
+}
+
+// apiTaskComment posts a comment on a task. On a Linear-mirrored task it goes to
+// the Linear issue; otherwise it's saved as a local progress note. Path:
+// /tasks/{id}/comment
+func (r *Relay) apiTaskComment(w http.ResponseWriter, req *http.Request, path string) {
+	trimmed := strings.TrimPrefix(path, "/tasks/")
+	taskID, _, _ := strings.Cut(trimmed, "/")
+	if taskID == "" {
+		http.Error(w, `{"error":"missing task id"}`, http.StatusBadRequest)
+		return
+	}
+	var body struct {
+		Project string `json:"project"`
+		Body    string `json:"body"`
+	}
+	if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
+		http.Error(w, `{"error":"invalid json"}`, http.StatusBadRequest)
+		return
+	}
+	if body.Project == "" {
+		body.Project = "default"
+	}
+	body.Body = strings.TrimSpace(body.Body)
+	if body.Body == "" {
+		http.Error(w, `{"error":"body is required"}`, http.StatusBadRequest)
+		return
+	}
+	task, err := r.DB.GetTask(taskID, body.Project)
+	if err != nil || task == nil {
+		http.Error(w, `{"error":"task not found"}`, http.StatusNotFound)
+		return
+	}
+	conn := r.TaskConn()
+	if task.Source == "linear" && conn.Active() && task.LinearIssueID != nil && *task.LinearIssueID != "" {
+		if err := conn.Comment(*task.LinearIssueID, body.Body); err != nil {
+			apiError(w, http.StatusBadGateway, "failed to post comment to Linear", err)
+			return
+		}
+		writeJSON(w, map[string]any{"posted": "linear"})
+		return
+	}
+	if err := r.DB.AddProgressNote(taskID, body.Project, "user", body.Body); err != nil {
+		apiError(w, http.StatusInternalServerError, "failed to add note", err)
+		return
+	}
+	writeJSON(w, map[string]any{"posted": "note"})
 }
 
 // apiGetAudit returns the audit trail for a project, optionally scoped to one task.

--- a/internal/relay/handlers_tasks.go
+++ b/internal/relay/handlers_tasks.go
@@ -146,6 +146,7 @@ func (h *Handlers) HandleClaimTask(ctx context.Context, req mcp.CallToolRequest)
 	}
 	h.events.Emit(MCPEvent{Type: "task", Action: "claim", Agent: agent, Project: project, Label: task.Title})
 	emitTaskEvent(h.events, "task.claimed", "claim", project, task)
+	pushStatusAsync(h.getConnector(), task, "accepted", nil)
 	return h.resultJSONTracked(project, agent, "claim_task", task)
 }
 
@@ -167,6 +168,7 @@ func (h *Handlers) HandleStartTask(ctx context.Context, req mcp.CallToolRequest)
 	}
 	h.events.Emit(MCPEvent{Type: "task", Action: "start", Agent: agent, Project: project, Label: task.Title})
 	emitTaskEvent(h.events, "task.in_progress", "start", project, task)
+	pushStatusAsync(h.getConnector(), task, "in-progress", nil)
 	return h.resultJSONTracked(project, agent, "start_task", task)
 }
 
@@ -200,6 +202,7 @@ func (h *Handlers) HandleResumeTask(ctx context.Context, req mcp.CallToolRequest
 	}
 	h.events.Emit(MCPEvent{Type: "task", Action: "resume", Agent: agent, Project: project, Label: task.Title})
 	emitTaskEvent(h.events, "task.in_progress", "resume", project, task)
+	pushStatusAsync(h.getConnector(), task, "in-progress", nil)
 
 	return h.resultJSONTracked(project, agent, "resume_task", task)
 }
@@ -226,12 +229,45 @@ func (h *Handlers) HandleReviewTask(ctx context.Context, req mcp.CallToolRequest
 	// Notify dispatcher — work is up for review.
 	h.registry.Notify(project, task.DispatchedBy, agent, fmt.Sprintf("In review: %s", task.Title), task.ID)
 
-	// Write-back (Linear mode): after the local stamp succeeds, fire-and-forget
-	// the agent's one owned transition (→ In Review + comment). No-op in native.
+	// Write-back (Linear mode): after the local stamp succeeds, move the issue to
+	// In Review + optional comment, fire-and-forget. No-op in native.
 	comment := optionalString(req.GetString("comment", ""))
-	pushInReviewAsync(h.getConnector(), task, agent, comment)
+	pushStatusAsync(h.getConnector(), task, "in-review", comment)
 
 	return h.resultJSONTracked(project, agent, "review_task", task)
+}
+
+// HandleComment posts a comment on a task. On a Linear-mirrored task it goes to
+// the Linear issue (Linear is SSOT); otherwise it is saved as a local progress
+// note so the action still lands somewhere.
+func (h *Handlers) HandleComment(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	project := resolveProject(ctx, req)
+	agent := resolveAgent(ctx, req)
+	taskID := req.GetString("task_id", "")
+	body := strings.TrimSpace(req.GetString("body", ""))
+	if taskID == "" || body == "" {
+		return mcp.NewToolResultError("task_id and body are required"), nil
+	}
+	taskID, err := h.resolveTaskID(taskID, project)
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+	task, err := h.db.GetTask(taskID, project)
+	if err != nil || task == nil {
+		return mcp.NewToolResultError("task not found"), nil
+	}
+
+	conn := h.getConnector()
+	if task.Source == "linear" && conn.Active() && task.LinearIssueID != nil && *task.LinearIssueID != "" {
+		if err := conn.Comment(*task.LinearIssueID, body); err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("failed to post comment to Linear: %v", err)), nil
+		}
+		return h.resultJSONTracked(project, agent, "comment", map[string]any{"posted": "linear", "task_id": taskID})
+	}
+	if err := h.db.AddProgressNote(taskID, project, agent, body); err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("failed to add note: %v", err)), nil
+	}
+	return h.resultJSONTracked(project, agent, "comment", map[string]any{"posted": "note", "task_id": taskID})
 }
 
 func (h *Handlers) HandleCompleteTask(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -254,6 +290,7 @@ func (h *Handlers) HandleCompleteTask(ctx context.Context, req mcp.CallToolReque
 
 	h.events.Emit(MCPEvent{Type: "task", Action: "complete", Agent: agent, Project: project, Target: task.DispatchedBy, Label: task.Title})
 	emitTaskEvent(h.events, "task.done", "complete", project, task)
+	pushStatusAsync(h.getConnector(), task, "done", result)
 
 	// Notify dispatcher
 	h.registry.Notify(project, task.DispatchedBy, agent, fmt.Sprintf("Task done: %s", task.Title), task.ID)
@@ -309,6 +346,7 @@ func (h *Handlers) HandleBlockTask(ctx context.Context, req mcp.CallToolRequest)
 		blockedExtra["reason"] = *reason
 	}
 	emitTaskEvent(h.events, "task.blocked", "block", project, task, blockedExtra)
+	pushStatusAsync(h.getConnector(), task, "blocked", reason)
 
 	// Notify dispatcher — blocked is critical
 	reasonStr := ""
@@ -346,6 +384,7 @@ func (h *Handlers) HandleCancelTask(ctx context.Context, req mcp.CallToolRequest
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("failed to cancel task: %v", err)), nil
 	}
+	pushStatusAsync(h.getConnector(), task, "cancelled", reason)
 
 	// Notify dispatcher
 	reasonStr := ""

--- a/internal/relay/linear_webhook.go
+++ b/internal/relay/linear_webhook.go
@@ -84,20 +84,3 @@ func pushStatusAsync(conn connector.TaskConnector, task *models.Task, status str
 		}
 	}()
 }
-
-// pushCommentAsync posts a standalone comment to a Linear-sourced task's issue.
-func pushCommentAsync(conn connector.TaskConnector, task *models.Task, body string) {
-	if conn == nil || !conn.Active() || task == nil || strings.TrimSpace(body) == "" {
-		return
-	}
-	if task.Source != "linear" || task.LinearIssueID == nil || *task.LinearIssueID == "" {
-		return
-	}
-	issueID := *task.LinearIssueID
-	go func() {
-		if err := conn.Comment(issueID, body); err != nil {
-			log.Printf("[linear] push comment %s: %v", issueID, err)
-		}
-	}()
-}
-

--- a/internal/relay/linear_webhook.go
+++ b/internal/relay/linear_webhook.go
@@ -60,12 +60,13 @@ func (r *Relay) apiLinearWebhook(w http.ResponseWriter, req *http.Request) {
 	}()
 }
 
-// pushInReviewAsync fires the connector's one owned write-back (→ In Review +
-// comment) for a Linear-sourced task, after the local in_review_at stamp has
-// already succeeded. It is a no-op in native mode (the no-op connector reports
-// Active()==false) or for tasks without a Linear issue id. Best-effort: a failed
-// push never affects the local transition (Linear reconcile is the backstop).
-func pushInReviewAsync(conn connector.TaskConnector, task *models.Task, agent string, comment *string) {
+// pushStatusAsync mirrors a relay status change to the Linear issue (move state +
+// optional comment), after the local transition has already succeeded. No-op in
+// native mode or for tasks without a Linear issue id. Best-effort: a failed push
+// never affects the local transition (Linear reconcile is the backstop). The
+// comment is posted only when a note is supplied, so routine claim/start moves
+// stay quiet in Linear.
+func pushStatusAsync(conn connector.TaskConnector, task *models.Task, status string, note *string) {
 	if conn == nil || !conn.Active() || task == nil {
 		return
 	}
@@ -73,28 +74,30 @@ func pushInReviewAsync(conn connector.TaskConnector, task *models.Task, agent st
 		return
 	}
 	issueID := *task.LinearIssueID
-	body := buildReviewComment(task, agent, comment)
+	comment := ""
+	if note != nil {
+		comment = strings.TrimSpace(*note)
+	}
 	go func() {
-		if err := conn.PushInReview(issueID, body); err != nil {
-			log.Printf("[linear] push in-review %s: %v", issueID, err)
+		if err := conn.PushStatus(issueID, status, comment); err != nil {
+			log.Printf("[linear] push status %s %s: %v", status, issueID, err)
 		}
 	}()
 }
 
-// buildReviewComment composes the Linear comment posted on the In Review
-// write-back: who moved it plus the optional result/PR note the agent attached.
-func buildReviewComment(task *models.Task, agent string, note *string) string {
-	var b strings.Builder
-	b.WriteString("Moved to In Review by ")
-	if agent != "" {
-		b.WriteString(agent)
-	} else {
-		b.WriteString("a relay agent")
+// pushCommentAsync posts a standalone comment to a Linear-sourced task's issue.
+func pushCommentAsync(conn connector.TaskConnector, task *models.Task, body string) {
+	if conn == nil || !conn.Active() || task == nil || strings.TrimSpace(body) == "" {
+		return
 	}
-	b.WriteString(".")
-	if note != nil && strings.TrimSpace(*note) != "" {
-		b.WriteString("\n\n")
-		b.WriteString(strings.TrimSpace(*note))
+	if task.Source != "linear" || task.LinearIssueID == nil || *task.LinearIssueID == "" {
+		return
 	}
-	return b.String()
+	issueID := *task.LinearIssueID
+	go func() {
+		if err := conn.Comment(issueID, body); err != nil {
+			log.Printf("[linear] push comment %s: %v", issueID, err)
+		}
+	}()
 }
+

--- a/internal/relay/tools.go
+++ b/internal/relay/tools.go
@@ -375,6 +375,17 @@ func startTaskTool() mcp.Tool {
 	)
 }
 
+func commentTool() mcp.Tool {
+	return mcp.NewTool(
+		"comment",
+		mcp.WithDescription("Comment on a task. On a Linear-mirrored task the comment is posted to the Linear issue (Linear is the source of truth); otherwise it is saved as a local progress note."),
+		asParam,
+		projectParam,
+		mcp.WithString("task_id", mcp.Description("Task ID"), mcp.Required()),
+		mcp.WithString("body", mcp.Description("Comment text"), mcp.Required()),
+	)
+}
+
 func reviewTaskTool() mcp.Tool {
 	return mcp.NewTool(
 		"review_task",

--- a/internal/relay/toolset.go
+++ b/internal/relay/toolset.go
@@ -60,6 +60,7 @@ func (h *Handlers) toolRegistry() []registeredTool {
 		{server.ServerTool{Tool: claimTaskTool(), Handler: h.HandleClaimTask}, "tasks"},
 		{server.ServerTool{Tool: startTaskTool(), Handler: h.HandleStartTask}, "tasks"},
 		{server.ServerTool{Tool: reviewTaskTool(), Handler: h.HandleReviewTask}, "tasks"},
+		{server.ServerTool{Tool: commentTool(), Handler: h.HandleComment}, "tasks"},
 		{server.ServerTool{Tool: completeTaskTool(), Handler: h.HandleCompleteTask}, "tasks"},
 		{server.ServerTool{Tool: blockTaskTool(), Handler: h.HandleBlockTask}, "tasks"},
 		{server.ServerTool{Tool: resumeTaskTool(), Handler: h.HandleResumeTask}, "tasks"},

--- a/internal/relay/toolset_test.go
+++ b/internal/relay/toolset_test.go
@@ -143,8 +143,8 @@ func TestDiscoverSchemasValidJSON(t *testing.T) {
 	if err := json.Unmarshal([]byte(text), &parsed); err != nil {
 		t.Fatalf("discover output not valid JSON: %v", err)
 	}
-	if len(parsed.Tools) != 15 {
-		t.Errorf("tasks tools = %d, want 15", len(parsed.Tools))
+	if len(parsed.Tools) != 16 {
+		t.Errorf("tasks tools = %d, want 16", len(parsed.Tools))
 	}
 	for _, tool := range parsed.Tools {
 		if tool.InputSchema["type"] != "object" {

--- a/internal/web/static/v2/api.js
+++ b/internal/web/static/v2/api.js
@@ -56,6 +56,8 @@ export const api = {
     sendJSON('POST', `/api/tasks/${encodeURIComponent(id)}/transition`, body),
   reassign: (id, project, agent) =>
     sendJSON('POST', `/api/tasks/${encodeURIComponent(id)}/reassign`, { project, agent }),
+  comment: (id, project, body) =>
+    sendJSON('POST', `/api/tasks/${encodeURIComponent(id)}/comment`, { project, body }),
   audit: (project, resource, limit = 50) =>
     getJSON(`/api/audit?${q({ project, resource, limit })}`),
   setAgentAvatar: (project, name, url) =>

--- a/internal/web/static/v2/board.js
+++ b/internal/web/static/v2/board.js
@@ -199,7 +199,9 @@ export function initBoard(root, ctx) {
     const pr = priorityRank(t.priority);
     const stale = staleness(t);
     // Drag only makes sense in status mode (drop maps a column → a status).
-    const draggable = canEdit && t.source !== 'linear' && groupBy === 'status';
+    // Status-mode drag: native tasks on writable projects, and mirror tasks
+    // (the status move round-trips to Linear). Not in the all-projects view.
+    const draggable = groupBy === 'status' && selection() !== 'all' && (t.source === 'linear' || canEdit);
     // Outside status mode, show a status pill so the card stays legible.
     const statusTag = groupBy !== 'status' ? `<span class="kcard-status s-${esc(col)}">${esc((COLUMNS.find((c) => c.key === col) || {}).label || t.status)}</span>` : '';
     const projTag = (selection() === 'all' && t.project) ? `<span class="kcard-proj">${esc(t.project)}</span>` : '';
@@ -398,7 +400,8 @@ export function initBoard(root, ctx) {
   function openCard(id) {
     const t = byId.get(id);
     if (!t) return;
-    if (t.source === 'linear' && t.external_url) { window.open(t.external_url, '_blank', 'noopener'); return; }
+    // Mirror tasks open the detail sheet too (status change + comment → Linear);
+    // the sheet keeps an "open in Linear ↗" link.
     openDetail(t);
   }
 
@@ -494,6 +497,7 @@ export function initBoard(root, ctx) {
     node.innerHTML = detailShell(t);
     node.querySelector('.sheet-close').addEventListener('click', ctx.closeSheet);
     ctx.openSheet(node);
+    wireComment(node, t);
     const notesEl = node.querySelector('.sheet-notes');
     try {
       const notes = await ctx.api.progress(t.id, t.project || selection());
@@ -564,6 +568,26 @@ export function initBoard(root, ctx) {
     } catch (_) { el.innerHTML = '<div class="empty">Could not load audit</div>'; }
   }
 
+  // Comment box → Linear comment on a mirror task, else a local progress note.
+  function wireComment(node, t) {
+    const send = node.querySelector('.cmt-send');
+    const input = node.querySelector('.cmt-input');
+    const msg = node.querySelector('.cmt-msg');
+    if (!send || !input) return;
+    send.addEventListener('click', async () => {
+      const body = input.value.trim();
+      if (!body) return;
+      send.disabled = true;
+      try {
+        const r = await ctx.api.comment(t.id, t.project || selection(), body);
+        input.value = '';
+        if (r && r.posted === 'linear') { msg.textContent = 'posted to Linear'; msg.dataset.kind = 'ok'; }
+        else { openDetail(t); } // native note added — refresh the sheet to show it
+      } catch (e) { msg.textContent = e.message || 'failed'; msg.dataset.kind = 'err'; }
+      finally { send.disabled = false; }
+    });
+  }
+
   function detailShell(t) {
     const col = columnFor(t);
     const cdef = COLUMNS.find((c) => c.key === col) || {};
@@ -586,6 +610,11 @@ export function initBoard(root, ctx) {
       <div class="sheet-section"><div class="sheet-label">timeline</div><ol class="trail">${trail}</ol></div>
       ${t.description ? `<div class="sheet-section"><div class="sheet-label">description</div><div class="sheet-desc">${esc(t.description).slice(0, 4000)}</div></div>` : ''}
       ${canEdit && t.source !== 'linear' ? commandSection(t) : ''}
+      <div class="sheet-section">
+        <div class="sheet-label">${t.source === 'linear' ? 'comment → linear' : 'comment'}</div>
+        <textarea class="cmt-input" rows="2" placeholder="${t.source === 'linear' ? 'post a comment to the Linear issue…' : 'add a progress note…'}" aria-label="Comment"></textarea>
+        <div class="cmt-row"><button class="cmt-send" type="button">${t.source === 'linear' ? 'post to Linear' : 'add note'}</button><span class="cmt-msg" aria-live="polite"></span></div>
+      </div>
       <div class="sheet-section"><div class="sheet-label">progress notes</div><div class="sheet-notes"><div class="skel" style="height:14px;width:60%"></div></div></div>
       ${canEdit && t.source !== 'linear' ? '<div class="sheet-section"><div class="sheet-label">audit</div><div class="sheet-audit"><div class="skel" style="height:14px;width:50%"></div></div></div>' : ''}`;
   }

--- a/internal/web/static/v2/v2.css
+++ b/internal/web/static/v2/v2.css
@@ -937,3 +937,24 @@ button { font-family: inherit; }
 /* overload — an agent group holding too many active tasks */
 .col-over .col-head { background: color-mix(in srgb, var(--red) 8%, transparent); }
 .over-flag { color: var(--red); }
+
+/* ============================================================= *
+ *  Task sheet — comment box (→ Linear on mirror tasks, else note)
+ * ============================================================= */
+.cmt-input {
+  width: 100%; resize: vertical; min-height: 52px;
+  background: var(--bg-card); border: 1px solid var(--border); color: var(--text);
+  border-radius: 7px; padding: 8px 10px; font-family: inherit; font-size: 12.5px; line-height: 1.45;
+}
+.cmt-input:focus-visible { outline: none; border-color: var(--accent-dim); }
+.cmt-row { display: flex; align-items: center; gap: 10px; margin-top: 8px; }
+.cmt-send {
+  background: var(--accent); color: #06120c; border: 0; border-radius: 7px;
+  padding: 7px 14px; font-family: inherit; font-size: 12px; font-weight: 700; cursor: pointer;
+}
+.cmt-send:hover { filter: brightness(1.08); }
+.cmt-send:disabled { opacity: .5; cursor: not-allowed; }
+.cmt-send:focus-visible { outline: 2px solid var(--text); outline-offset: 2px; }
+.cmt-msg { font-size: 11px; }
+.cmt-msg[data-kind="ok"] { color: var(--accent); }
+.cmt-msg[data-kind="err"] { color: var(--red); }

--- a/skill/relay.md
+++ b/skill/relay.md
@@ -164,4 +164,4 @@ The relay auto-normalizes JSON keys to snake_case on ingestion, but agents shoul
 
 ## Reference
 
-See `skill/tools-reference.md` for the full 58 MCP tools list.
+See `skill/tools-reference.md` for the full 59 MCP tools list.

--- a/skill/tools-reference.md
+++ b/skill/tools-reference.md
@@ -1,4 +1,4 @@
-# MCP Tools Reference (58 tools, + discover_tools/call_tool in discovery mode)
+# MCP Tools Reference (59 tools, + discover_tools/call_tool in discovery mode)
 
 ## Auth (only when RELAY_API_KEY is set)
 
@@ -36,12 +36,15 @@ Loopback / same-host clients connect **keyless** (local `.mcp.json`, API scripts
 - `dispatch_task` — create task for a profile (priority, board_id, parent_task_id). Auto-notifies agents running the profile.
 - `claim_task` — accept a pending task
 - `start_task` — begin work on task
-- `review_task` — mark "PR up" → in-review (fires the Linear In-Review write-back on mirror projects)
+- `review_task` — mark "PR up" → in-review
 - `complete_task` — finish with result
 - `block_task` — block with reason (notifies dispatcher + parent chain)
 - `resume_task` — move a blocked task back to in-progress
 - `cancel_task` — cancel from any state with optional reason
+- `comment` — comment on a task → posts to the Linear issue on a mirror task, else a local progress note
 - `get_task` — details + optional subtask chain
+
+> On Linear-mirror projects, every status transition (claim/start/review/complete/block/cancel) is mirrored back to the issue's Linear workflow state; `comment` and the status change are the only writes that reach Linear.
 - `list_tasks` — filtered list (status, profile, priority, board_id, assigned_to). Use status="active" for non-done/cancelled. include_archived option.
 - `update_task` — update title, description, priority, board_id without changing status
 - `move_task` — move task to a different board (shortcut for update_task)


### PR DESCRIPTION
Realizes the model: the only actions an agent/orchestrator takes from the relay that reach Linear are **change status** and **comment** — and now they both do, for every transition (not just in-review). Linear stays the source of truth.

## Connector
- **`PushStatus(issueID, status, comment)`** — maps a relay status to a Linear workflow state by **TYPE** (started/completed/canceled/unstarted) + **NAME** for the states Linear models by name only (`In Review`, `Blocked`). No matching state → skip the move, post a comment instead (honest — never a wrong status).
- **`Comment(issueID, body)`** — standalone comment.
- `PushInReview` delegates to `PushStatus("in-review", …)`. Anti-loop unchanged (self-authored webhook echoes already dropped by viewer id).

## Wiring
- Every transition (claim/start/resume/review/complete/block/cancel) pushes the mapped state; a comment is posted only when a note is given (block reason / result / review note) so routine moves stay quiet in Linear. Same for the web/board transition endpoint.
- New **`comment` MCP tool** + **`POST /api/tasks/{id}/comment`**: → Linear on a mirror task, else a local progress note.

## v2 UI (act on mirror tasks)
- Mirror cards are **draggable in status mode** → drop transitions → pushes to Linear (not in all-projects view).
- Task sheet gains a **comment box** (→ Linear on mirror, note otherwise); mirror cards open the sheet (with "open in Linear ↗") instead of jumping out.

## Tests
`resolveStateID` mapping incl. no-Blocked-state fallback; existing PushInReview retry test green via the review fast-path. Build + vet + `-race` green.

Branches off `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)