### PR TITLE
fix(v2): SSE stream stuck on "connecting" for idle projects

### DIFF
--- a/internal/relay/api.go
+++ b/internal/relay/api.go
@@ -1026,9 +1026,21 @@ func (r *Relay) apiStreamEvents(w http.ResponseWriter, req *http.Request) {
 	w.Header().Set("Content-Type", "text/event-stream")
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("X-Accel-Buffering", "no") // disable proxy (nginx) buffering of the stream
 
 	ch := r.Events.Subscribe()
 	defer r.Events.Unsubscribe(ch)
+
+	// Flush headers + an opening comment immediately so the client's EventSource
+	// fires onopen right away. Without this the headers aren't sent until the
+	// first event, so a quiet project leaves the UI stuck on "connecting".
+	_, _ = fmt.Fprint(w, ": connected\n\n")
+	flusher.Flush()
+
+	// Heartbeat keeps idle connections (and proxies) alive and lets the client
+	// detect a dead stream.
+	ping := time.NewTicker(25 * time.Second)
+	defer ping.Stop()
 
 	for {
 		select {
@@ -1036,6 +1048,9 @@ func (r *Relay) apiStreamEvents(w http.ResponseWriter, req *http.Request) {
 			return
 		case <-r.shutdownCtx.Done():
 			return
+		case <-ping.C:
+			_, _ = fmt.Fprint(w, ": ping\n\n")
+			flusher.Flush()
 		case evt, ok := <-ch:
 			if !ok {
 				return


### PR DESCRIPTION
The v2 live indicator stuck on **"connecting"**.

**Cause:** `apiStreamEvents` set the SSE headers but never wrote/flushed until the first event. Go only sends headers on the first write, so on an idle project the browser's `EventSource` never received headers → stayed in `CONNECTING` → `onopen` never fired → indicator stuck on "connecting" (and `onerror` didn't fire either, so it never even showed "reconnecting").

**Fix:**
- Flush an opening `: connected` SSE comment immediately → `EventSource.onopen` fires → "live".
- 25s heartbeat (`: ping`) to keep idle connections + proxies alive.
- `X-Accel-Buffering: no` so nginx-style proxies don't buffer the stream (pairs with the SSE notes in docs/deployment.md).

Verified: a freshly booted empty relay emits `: connected` on connect instead of nothing. Build + vet green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)