### PR TITLE
feat(v2): rebuild mission control as a fleet-ops console

### DIFF
--- a/internal/db/fleet.go
+++ b/internal/db/fleet.go
@@ -1,0 +1,62 @@
+package db
+
+import (
+	"agent-relay/internal/models"
+	"time"
+)
+
+// FleetThroughput returns a fleet-wide daily time series for the last `days`
+// days (oldest → newest, gap-filled with zeros): tasks completed (by
+// completed_at) and tasks dispatched (by dispatched_at) per calendar day (UTC).
+// This is the persistent "heartbeat" behind mission control's pulse chart — it
+// survives restarts, unlike the in-memory event ring buffer.
+func (d *DB) FleetThroughput(days int) ([]models.DayBucket, error) {
+	if days <= 0 {
+		days = 30
+	}
+	now := time.Now().UTC()
+	start := now.AddDate(0, 0, -(days - 1))
+	since := start.Format("2006-01-02")
+
+	tally := func(query string) (map[string]int, error) {
+		rows, err := d.ro().Query(query, since)
+		if err != nil {
+			return nil, err
+		}
+		defer func() { _ = rows.Close() }()
+		m := make(map[string]int)
+		for rows.Next() {
+			var day string
+			var n int
+			if err := rows.Scan(&day, &n); err != nil {
+				return nil, err
+			}
+			m[day] = n
+		}
+		return m, rows.Err()
+	}
+
+	done, err := tally(`
+		SELECT substr(completed_at, 1, 10) AS d, COUNT(*)
+		FROM tasks
+		WHERE status = 'done' AND completed_at IS NOT NULL AND substr(completed_at, 1, 10) >= ?
+		GROUP BY d`)
+	if err != nil {
+		return nil, err
+	}
+	disp, err := tally(`
+		SELECT substr(dispatched_at, 1, 10) AS d, COUNT(*)
+		FROM tasks
+		WHERE dispatched_at IS NOT NULL AND substr(dispatched_at, 1, 10) >= ?
+		GROUP BY d`)
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]models.DayBucket, 0, days)
+	for i := 0; i < days; i++ {
+		day := start.AddDate(0, 0, i).Format("2006-01-02")
+		out = append(out, models.DayBucket{Date: day, Done: done[day], Dispatched: disp[day]})
+	}
+	return out, nil
+}

--- a/internal/db/projects.go
+++ b/internal/db/projects.go
@@ -129,7 +129,9 @@ func (d *DB) ListProjectsWithInfo() ([]models.ProjectInfo, error) {
 			COALESCE(tc.total_tasks, 0),
 			COALESCE(tc.active_tasks, 0),
 			COALESCE(tc.done_tasks, 0),
-			COALESCE(tu.tokens_24h, 0)
+			COALESCE(tc.blocked_tasks, 0),
+			COALESCE(tu.tokens_24h, 0),
+			COALESCE(tc.last_activity, '')
 		FROM projects p
 		LEFT JOIN (
 			SELECT project, COUNT(*) as agent_count,
@@ -139,8 +141,10 @@ func (d *DB) ListProjectsWithInfo() ([]models.ProjectInfo, error) {
 		) ac ON ac.project = p.name
 		LEFT JOIN (
 			SELECT project, COUNT(*) as total_tasks,
-				SUM(CASE WHEN status IN ('accepted', 'in-progress') THEN 1 ELSE 0 END) as active_tasks,
-				SUM(CASE WHEN status = 'done' THEN 1 ELSE 0 END) as done_tasks
+				SUM(CASE WHEN status IN ('accepted', 'in-progress', 'in-review') THEN 1 ELSE 0 END) as active_tasks,
+				SUM(CASE WHEN status = 'done' THEN 1 ELSE 0 END) as done_tasks,
+				SUM(CASE WHEN status = 'blocked' THEN 1 ELSE 0 END) as blocked_tasks,
+				MAX(COALESCE(completed_at, started_at, accepted_at, dispatched_at)) as last_activity
 			FROM tasks GROUP BY project
 		) tc ON tc.project = p.name
 		LEFT JOIN (
@@ -157,7 +161,7 @@ func (d *DB) ListProjectsWithInfo() ([]models.ProjectInfo, error) {
 	var projects []models.ProjectInfo
 	for rows.Next() {
 		var p models.ProjectInfo
-		if err := rows.Scan(&p.Name, &p.PlanetType, &p.CreatedAt, &p.AgentCount, &p.OnlineCount, &p.TotalTasks, &p.ActiveTasks, &p.DoneTasks, &p.Tokens24h); err != nil {
+		if err := rows.Scan(&p.Name, &p.PlanetType, &p.CreatedAt, &p.AgentCount, &p.OnlineCount, &p.TotalTasks, &p.ActiveTasks, &p.DoneTasks, &p.BlockedTasks, &p.Tokens24h, &p.LastActivity); err != nil {
 			return nil, err
 		}
 		projects = append(projects, p)

--- a/internal/models/project.go
+++ b/internal/models/project.go
@@ -1,5 +1,12 @@
 package models
 
+// DayBucket is one day of fleet-wide throughput (mission control pulse chart).
+type DayBucket struct {
+	Date       string `json:"date"` // YYYY-MM-DD (UTC)
+	Done       int    `json:"done"`
+	Dispatched int    `json:"dispatched"`
+}
+
 type Project struct {
 	Name       string `json:"name"`
 	PlanetType string `json:"planet_type"`
@@ -7,13 +14,15 @@ type Project struct {
 }
 
 type ProjectInfo struct {
-	Name        string `json:"name"`
-	PlanetType  string `json:"planet_type"`
-	CreatedAt   string `json:"created_at"`
-	AgentCount  int    `json:"agent_count"`
-	OnlineCount int    `json:"online_count"`
-	TotalTasks  int    `json:"total_tasks"`
-	ActiveTasks int    `json:"active_tasks"`
-	DoneTasks   int    `json:"done_tasks"`
-	Tokens24h   int64  `json:"tokens_24h"`
+	Name         string `json:"name"`
+	PlanetType   string `json:"planet_type"`
+	CreatedAt    string `json:"created_at"`
+	AgentCount   int    `json:"agent_count"`
+	OnlineCount  int    `json:"online_count"`
+	TotalTasks   int    `json:"total_tasks"`
+	ActiveTasks  int    `json:"active_tasks"`
+	DoneTasks    int    `json:"done_tasks"`
+	BlockedTasks int    `json:"blocked_tasks"`
+	Tokens24h    int64  `json:"tokens_24h"`
+	LastActivity string `json:"last_activity"` // ISO ts of the most recent task movement; "" if none
 }

--- a/internal/relay/api.go
+++ b/internal/relay/api.go
@@ -37,6 +37,8 @@ func (r *Relay) ServeAPI(w http.ResponseWriter, req *http.Request) {
 		r.apiHealth(w)
 	case path == "/projects" && req.Method == http.MethodGet:
 		r.apiGetProjects(w)
+	case path == "/fleet/throughput" && req.Method == http.MethodGet:
+		r.apiFleetThroughput(w, req)
 	case strings.HasPrefix(path, "/projects/") && req.Method == http.MethodDelete:
 		r.apiDeleteProject(w, strings.TrimPrefix(path, "/projects/"))
 	case strings.HasPrefix(path, "/projects/") && req.Method == http.MethodPatch:
@@ -201,6 +203,30 @@ func (r *Relay) apiGetProjects(w http.ResponseWriter) {
 		projects = []models.ProjectInfo{}
 	}
 	writeJSON(w, projects)
+}
+
+// apiFleetThroughput returns a fleet-wide daily throughput series (done +
+// dispatched per day) for the mission control pulse chart. ?days= (default 30,
+// clamped 1..90).
+func (r *Relay) apiFleetThroughput(w http.ResponseWriter, req *http.Request) {
+	days := 30
+	if v := req.URL.Query().Get("days"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			days = n
+		}
+	}
+	if days > 90 {
+		days = 90
+	}
+	buckets, err := r.DB.FleetThroughput(days)
+	if err != nil {
+		http.Error(w, `{"error":"failed to compute throughput"}`, http.StatusInternalServerError)
+		return
+	}
+	if buckets == nil {
+		buckets = []models.DayBucket{}
+	}
+	writeJSON(w, buckets)
 }
 
 func (r *Relay) apiHealth(w http.ResponseWriter) {

--- a/internal/web/static/v2/api.js
+++ b/internal/web/static/v2/api.js
@@ -33,6 +33,10 @@ export const api = {
   cycles: (project) => getJSON(`/api/cycles?${q({ project })}`),
   profiles: (project) => getJSON(`/api/profiles?${q({ project })}`),
   agents: (project) => getJSON(`/api/agents?${q({ project })}`),
+  agentsAll: () => getJSON('/api/agents/all'),
+  tasksAll: () => getJSON('/api/tasks/all'),
+  fleetThroughput: (days = 30) => getJSON(`/api/fleet/throughput?${q({ days })}`),
+  liveActivity: () => getJSON('/api/activity'),
   messagesLatest: (project, since) =>
     getJSON(`/api/messages/latest?${q({ project, since })}`),
   progress: (id, project) =>

--- a/internal/web/static/v2/home.js
+++ b/internal/web/static/v2/home.js
@@ -1,117 +1,319 @@
-// Project home — the landing. Every project is a place rendered as a card in a
-// bento grid; clicking a card ENTERS that project. The all-projects aggregate
-// lives here and only here (the old global dropdown is gone). The mirror project
-// wears a Linear badge with a click-through ↗.
+// Mission control — the fleet-ops console. Cross-project command center that
+// answers, top-to-bottom (urgent first, F-pattern): what's the fleet doing right
+// now (golden-signal KPIs), what's the throughput trend (the pulse chart), which
+// crews need me (attention rows), and the full roster (fleet cards with live crew
+// pips). Per-agent deep-dive stays on the project pages; the home is altitude.
+//   data: /api/projects (per-crew rollup) · /api/agents/all (live roster) ·
+//   /api/fleet/throughput (persistent daily series) · SSE stream (the ticker).
 export function initHome(root, ctx) {
   const esc = ctx.esc;
-  const bento = root.querySelector('#bento');
-  const agg = root.querySelector('#homeAgg');
+  const $ = (id) => root.querySelector('#' + id);
+  const kpisBox = $('mcKpis');
+  const pulseWrap = $('pulseWrap');
+  const pulseMeta = $('pulseMeta');
+  const ticker = $('fleetTicker');
+  const attnSection = $('attnSection');
+  const attnList = $('attnList');
+  const attnCount = $('attnCount');
+  const fleetCount = $('fleetCount');
+  const bento = $('bento');
+
   let projects = [];
+  let agentsByProj = new Map();
+  let ticks = [];
   let loaded = false;
   const cardByName = new Map();
 
+  const STALE_MS = 24 * 3600e3;
   const fmtNum = (n) => {
     n = Number(n) || 0;
     if (n >= 1e6) return (n / 1e6).toFixed(1).replace(/\.0$/, '') + 'M';
     if (n >= 1000) return (n / 1000).toFixed(1).replace(/\.0$/, '') + 'k';
     return String(n);
   };
+  const plur = (n, w) => `${n} ${w}${n === 1 ? '' : 's'}`;
 
   async function refresh() {
     if (!loaded) skeleton();
-    let list = [];
-    try { list = await ctx.api.projects(); } catch (_) { list = ctx.projects || []; }
-    projects = Array.isArray(list) ? list : [];
+    const [pl, al, tp] = await Promise.allSettled([
+      ctx.api.projects(),
+      ctx.api.agentsAll(),
+      ctx.api.fleetThroughput(30),
+    ]);
+    projects = pl.status === 'fulfilled' && Array.isArray(pl.value) ? pl.value : (ctx.projects || []);
+    const agents = al.status === 'fulfilled' && Array.isArray(al.value) ? al.value : [];
+    agentsByProj = new Map();
+    for (const a of agents) {
+      const k = a.project || '';
+      if (!agentsByProj.has(k)) agentsByProj.set(k, []);
+      agentsByProj.get(k).push(a);
+    }
     loaded = true;
-    renderAgg();
-    renderBento();
+    renderKpis(agents);
+    renderPulse(tp.status === 'fulfilled' && Array.isArray(tp.value) ? tp.value : []);
+    renderFleet();
   }
 
-  function renderAgg() {
-    const agents = projects.reduce((a, p) => a + (Number(p.agent_count) || 0), 0);
-    const online = projects.reduce((a, p) => a + (Number(p.online_count) || 0), 0);
-    const total = projects.reduce((a, p) => a + (Number(p.total_tasks) || 0), 0);
-    const done = projects.reduce((a, p) => a + (Number(p.done_tasks) || 0), 0);
-    const active = projects.reduce((a, p) => a + (Number(p.active_tasks) || 0), 0);
+  /* ---------------- golden-signal KPIs ---------------- */
+  function renderKpis(agents) {
+    const sum = (k) => projects.reduce((a, p) => a + (Number(p[k]) || 0), 0);
+    const total = sum('total_tasks');
+    const done = sum('done_tasks');
+    const active = sum('active_tasks');
+    const blocked = sum('blocked_tasks');
+    const online = agents.filter((a) => a.online).length;
+    const roster = agents.length;
     const pct = total ? Math.round(done / total * 100) : 0;
-    agg.innerHTML = [
-      aggStat(String(projects.length), 'projects'),
-      aggStat(`${fmtNum(online)}<span class="of">/${fmtNum(agents)}</span>`, 'agents online'),
-      aggStat(String(active), 'active tasks'),
-      aggStat(`${pct}%`, `${fmtNum(done)}/${fmtNum(total)} done`),
+    kpisBox.innerHTML = [
+      kpi(String(online), `/ ${roster}`, 'agents online', online ? 'good' : 'dim'),
+      kpi(String(active), '', 'active tasks', active ? '' : 'dim'),
+      kpi(String(blocked), '', 'blocked', blocked ? 'bad' : 'dim'),
+      kpi(String(projects.length), '', 'crews', ''),
+      kpi(`${pct}%`, '', `${fmtNum(done)} / ${fmtNum(total)} shipped`, ''),
     ].join('');
   }
-  const aggStat = (num, label) =>
-    `<div class="agg-stat"><span class="agg-num">${num}</span><span class="agg-label">${esc(label)}</span></div>`;
+  const kpi = (num, of, label, cls) =>
+    `<div class="mc-kpi${cls ? ' ' + cls : ''}">
+      <span class="mck-num">${num}${of ? `<span class="of">${esc(of)}</span>` : ''}</span>
+      <span class="mck-label">${esc(label)}</span>
+    </div>`;
 
-  function renderBento() {
+  /* ---------------- pulse chart — daily throughput ---------------- */
+  function renderPulse(buckets) {
+    if (!buckets.length) { pulseWrap.innerHTML = '<div class="empty">No throughput yet.</div>'; pulseMeta.textContent = ''; return; }
+    const W = 600, H = 84, n = buckets.length, gap = n > 40 ? 1 : 2, bw = (W - gap * (n - 1)) / n;
+    const maxV = Math.max(1, ...buckets.map((b) => Math.max(b.done, b.dispatched)));
+    const y = (v) => H - 4 - (v / maxV) * (H - 14);
+    let bars = '', pts = [];
+    buckets.forEach((b, i) => {
+      const x = i * (bw + gap);
+      const top = y(b.done);
+      bars += `<rect x="${x.toFixed(1)}" y="${top.toFixed(1)}" width="${bw.toFixed(1)}" height="${(H - 4 - top).toFixed(1)}" rx="${Math.min(1.5, bw / 3).toFixed(1)}" class="pl-bar${i === n - 1 ? ' today' : ''}"><title>${b.date}: ${b.done} shipped · ${b.dispatched} dispatched</title></rect>`;
+      pts.push(`${(x + bw / 2).toFixed(1)},${y(b.dispatched).toFixed(1)}`);
+    });
+    const area = `<polygon class="pl-area" points="0,${H - 4} ${pts.join(' ')} ${W},${H - 4}" />`;
+    const line = `<polyline class="pl-disp" points="${pts.join(' ')}" vector-effect="non-scaling-stroke" />`;
+    const base = `<line class="pl-base" x1="0" y1="${H - 4}" x2="${W}" y2="${H - 4}" vector-effect="non-scaling-stroke" />`;
+    pulseWrap.innerHTML = `<svg class="pulse-svg" viewBox="0 0 ${W} ${H}" preserveAspectRatio="none" role="img" aria-label="Tasks shipped per day over the last 30 days">${base}${area}${bars}${line}</svg>`;
+    const ds = buckets.reduce((a, b) => a + b.done, 0);
+    const dp = buckets.reduce((a, b) => a + b.dispatched, 0);
+    pulseMeta.innerHTML = `<span class="pm-done">${fmtNum(ds)} shipped</span> · <span class="pm-disp">${fmtNum(dp)} dispatched</span>`;
+  }
+
+  /* ---------------- attention triage ---------------- */
+  function attnReasons(p) {
+    const r = [];
+    const blocked = Number(p.blocked_tasks) || 0;
+    const total = Number(p.total_tasks) || 0;
+    const done = Number(p.done_tasks) || 0;
+    if (blocked > 0) r.push({ sev: 'red', t: plur(blocked, 'blocked') });
+    const la = p.last_activity ? Date.parse(p.last_activity) : 0;
+    if (la && total > done && (Date.now() - la) >= STALE_MS) {
+      r.push({ sev: 'amber', t: `untouched ${ctx.fmtAgo(la)}` });
+    }
+    return r;
+  }
+  const rank = (rs) => rs.reduce((s, r) => s + (r.sev === 'red' ? 100 : 1), 0);
+
+  function renderFleet() {
+    cardByName.clear();
     if (!projects.length) {
-      bento.innerHTML = '<div class="empty">No projects yet.</div>';
+      attnSection.hidden = true; attnList.innerHTML = '';
+      bento.innerHTML = '<div class="empty">No crews yet.</div>';
+      fleetCount.textContent = '';
       return;
     }
-    cardByName.clear();
-    // Mirror project first and featured; then by activity (online, then active, then tasks).
-    const sorted = projects.slice().sort((a, b) => {
+    const tagged = projects.map((p) => ({ p, reasons: attnReasons(p) }));
+    const attn = tagged.filter((x) => x.reasons.length);
+    const rest = tagged.filter((x) => !x.reasons.length).map((x) => x.p);
+
+    attn.sort((a, b) =>
+      rank(b.reasons) - rank(a.reasons) ||
+      (Number(b.p.blocked_tasks) - Number(a.p.blocked_tasks)) ||
+      ((Date.parse(a.p.last_activity) || Infinity) - (Date.parse(b.p.last_activity) || Infinity)));
+
+    rest.sort((a, b) => {
       const am = ctx.isMirror(a.name) ? 1 : 0, bm = ctx.isMirror(b.name) ? 1 : 0;
       if (am !== bm) return bm - am;
       return (b.online_count - a.online_count) || (b.active_tasks - a.active_tasks) ||
         (b.total_tasks - a.total_tasks) || a.name.localeCompare(b.name);
     });
-    bento.innerHTML = sorted.map(card).join('');
-    bento.querySelectorAll('.proj-card').forEach((el) => {
-      cardByName.set(el.dataset.name, el);
-      const enter = () => { location.hash = el.dataset.href; };
-      el.addEventListener('click', enter);
-      el.addEventListener('keydown', (e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); enter(); } });
-    });
-    // The inner ↗ link opens Linear without entering the project.
-    bento.querySelectorAll('.pc-linear').forEach((a) => a.addEventListener('click', (e) => e.stopPropagation()));
+
+    if (attn.length) {
+      attnSection.hidden = false;
+      attnCount.textContent = String(attn.length);
+      const shown = attn.slice(0, 7);
+      attnList.innerHTML = shown.map((x) => attnRow(x.p, x.reasons)).join('') +
+        (attn.length > shown.length ? `<div class="attn-more">+${attn.length - shown.length} more crew${attn.length - shown.length === 1 ? '' : 's'} need attention</div>` : '');
+      wire(attnList);
+    } else {
+      attnSection.hidden = true; attnList.innerHTML = '';
+    }
+    bento.innerHTML = rest.map((p) => card(p)).join('');
+    fleetCount.textContent = String(rest.length);
+    wire(bento);
+  }
+
+  function attnRow(p, reasons) {
+    const sev = reasons.some((r) => r.sev === 'red') ? 'red' : 'amber';
+    const total = Number(p.total_tasks) || 0, done = Number(p.done_tasks) || 0;
+    const open = Math.max(0, total - done);
+    const chips = reasons.map((r) => `<span class="ar-reason ${r.sev}">${esc(r.t)}</span>`).join('');
+    return `<div class="attn-row sev-${sev}" role="link" tabindex="0" data-name="${esc(p.name)}" data-href="#/p/${encodeURIComponent(p.name)}/overview" aria-label="Enter ${esc(p.name)}">
+      <span class="ar-dot" aria-hidden="true"></span>
+      <span class="ar-proj">${esc(p.name)}</span>
+      <span class="ar-reasons">${chips}</span>
+      <span class="ar-spacer"></span>
+      <span class="ar-meta">${open} open · ${done}/${total}</span>
+      <span class="ar-go" aria-hidden="true">↗</span>
+    </div>`;
+  }
+
+  /* ---------------- fleet cards ---------------- */
+  function crewPips(name) {
+    const list = (agentsByProj.get(name) || []).slice().sort((a, b) =>
+      (b.online ? 1 : 0) - (a.online ? 1 : 0) || (a.status || '').localeCompare(b.status || ''));
+    if (!list.length) return '';
+    const pip = (a) => {
+      const s = a.online ? 'on' : (a.status === 'sleeping' ? 'sleep' : 'off');
+      return `<span class="crew-pip ${s}" title="${esc(a.name)} · ${a.online ? 'online' : esc(a.status || 'offline')}"></span>`;
+    };
+    const pips = list.slice(0, 8).map(pip).join('');
+    const more = list.length > 8 ? `<span class="crew-more">+${list.length - 8}</span>` : '';
+    return `<div class="pc-crew" aria-hidden="true">${pips}${more}</div>`;
+  }
+
+  function segBar(p) {
+    const total = Number(p.total_tasks) || 0;
+    if (!total) return '<div class="pc-bar" aria-hidden="true"></div>';
+    const done = Number(p.done_tasks) || 0, active = Number(p.active_tasks) || 0, blocked = Number(p.blocked_tasks) || 0;
+    const w = (n) => (n / total * 100).toFixed(2) + '%';
+    return `<div class="pc-bar" role="img" aria-label="${done} done, ${active} active, ${blocked} blocked of ${total}">
+      <i class="seg-done" style="width:${w(done)}"></i><i class="seg-active" style="width:${w(active)}"></i><i class="seg-block" style="width:${w(blocked)}"></i>
+    </div>`;
   }
 
   function card(p) {
     const mirror = ctx.isMirror(p.name);
-    const total = Number(p.total_tasks) || 0;
-    const done = Number(p.done_tasks) || 0;
-    const active = Number(p.active_tasks) || 0;
-    const online = Number(p.online_count) || 0;
-    const agents = Number(p.agent_count) || 0;
-    const pct = total ? Math.round(done / total * 100) : 0;
+    const total = Number(p.total_tasks) || 0, done = Number(p.done_tasks) || 0, active = Number(p.active_tasks) || 0;
+    const online = Number(p.online_count) || 0, agents = Number(p.agent_count) || 0;
+    const blocked = Number(p.blocked_tasks) || 0, tokens = Number(p.tokens_24h) || 0;
+    const la = p.last_activity || '';
     const live = online > 0 || active > 0;
-    const tokens = Number(p.tokens_24h) || 0;
-    return `<div class="proj-card${mirror ? ' is-mirror' : ''}${live ? ' is-live' : ''}" role="link" tabindex="0" data-name="${esc(p.name)}" data-href="#/p/${encodeURIComponent(p.name)}/overview" aria-label="Enter project ${esc(p.name)}">
+    const chip = blocked > 0 ? '<span class="pc-chip blk">blocked</span>'
+      : online > 0 ? '<span class="pc-chip live">live</span>'
+        : active > 0 ? '<span class="pc-chip warm">queued</span>'
+          : '<span class="pc-chip idle">idle</span>';
+    const meta = blocked > 0 ? `<span class="m-blk">${plur(blocked, 'blocked')}</span>`
+      : active > 0 ? `${active} active`
+        : la ? `${ctx.fmtAgo(la)} ago`
+          : tokens ? `${fmtNum(tokens)} tok`
+            : 'idle';
+    const linear = mirror
+      ? `<a class="pc-linear" href="${esc(ctx.linearTeamURL())}" target="_blank" rel="noopener" title="Mirrored from Linear — open Linear"><span class="lin-diamond" aria-hidden="true">◆</span>${esc((ctx.settings.linear && ctx.settings.linear.team_key) || 'linear')}<span class="lin-arrow" aria-hidden="true">↗</span></a>`
+      : '';
+    const cls = ['proj-card', mirror ? 'is-mirror' : '', live ? 'is-live' : ''].filter(Boolean).join(' ');
+    return `<div class="${cls}" role="link" tabindex="0" data-name="${esc(p.name)}" data-href="#/p/${encodeURIComponent(p.name)}/overview" aria-label="Enter project ${esc(p.name)}">
       <div class="pc-top">
         <span class="pc-name">${esc(p.name)}</span>
-        ${mirror ? `<a class="pc-linear" href="${esc(ctx.linearTeamURL())}" target="_blank" rel="noopener" title="Mirrored from Linear — open Linear"><span class="lin-diamond" aria-hidden="true">◆</span>${esc((ctx.settings.linear && ctx.settings.linear.team_key) || 'linear')}<span class="lin-arrow" aria-hidden="true">↗</span></a>` : ''}
+        ${chip}
+        <span class="pc-spacer"></span>
+        ${linear}
       </div>
       <div class="pc-agents">
-        <span class="pc-dot${live ? ' on' : ''}" aria-hidden="true"></span>
-        <span class="pc-agents-n">${online ? `${online} online` : `${agents} agent${agents === 1 ? '' : 's'}`}</span>
+        <span class="pc-dot${online ? ' on' : ''}" aria-hidden="true"></span>
+        <span class="pc-agents-n">${online ? `${online} online` : plur(agents, 'agent')}</span>
         ${online && agents !== online ? `<span class="pc-agents-sub">· ${agents} total</span>` : ''}
+        ${crewPips(p.name)}
       </div>
-      <div class="pc-bar" aria-hidden="true"><i style="width:${pct}%"></i></div>
+      ${segBar(p)}
       <div class="pc-foot">
         <span class="pc-foot-tasks">${done}<span class="of">/${total}</span> done</span>
-        <span class="pc-foot-meta">${active ? `${active} active` : (tokens ? `${fmtNum(tokens)} tok` : 'idle')}</span>
+        <span class="pc-foot-meta">${meta}</span>
       </div>
     </div>`;
   }
 
-  function skeleton() {
-    agg.innerHTML = '<div class="agg-stat"><span class="agg-num skel" style="width:42px;height:24px"></span></div>'.repeat(4);
-    bento.innerHTML = '<div class="proj-card skel-card"></div>'.repeat(6);
+  function wire(grid) {
+    grid.querySelectorAll('[data-href]').forEach((el) => {
+      if (el.dataset.name) cardByName.set(el.dataset.name, el);
+      const enter = () => { location.hash = el.dataset.href; };
+      el.addEventListener('click', enter);
+      el.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); enter(); }
+      });
+    });
+    grid.querySelectorAll('.pc-linear').forEach((a) => a.addEventListener('click', (e) => e.stopPropagation()));
   }
 
-  // Live: flash the card of a project that just saw activity.
+  /* ---------------- live ticker — "what just landed" ---------------- */
+  function humanizeEvt(e) {
+    const type = e.type || '', action = e.action || '';
+    const label = e.label || (e.semantic && (e.semantic.title || e.semantic.key)) || '';
+    const verbs = {
+      'task.claimed': 'claimed', 'task.in_progress': 'started', 'task.in_review': 'in review',
+      'task.done': 'landed', 'task.blocked': 'blocked', 'task.dispatch': 'dispatched',
+    };
+    const kindOf = (t, a) => (t === 'task.done' || a === 'complete') ? 'done'
+      : (t === 'task.blocked' || a === 'block') ? 'block' : 'task';
+    if (verbs[type]) return { verb: verbs[type], label, kind: kindOf(type, action) };
+    if (type === 'task') {
+      const m = { dispatch: 'dispatched', claim: 'claimed', complete: 'landed', block: 'blocked', start: 'started', review: 'in review' };
+      return { verb: m[action] || action || 'updated', label, kind: kindOf(type, action) };
+    }
+    if (type.startsWith('message')) return { verb: 'messaged', label: e.target || label, kind: 'msg' };
+    if (type.startsWith('memory')) return { verb: 'memory', label, kind: 'mem' };
+    if (type.startsWith('event:')) return { verb: type.slice(6), label, kind: 'sys' };
+    return { verb: action || type, label, kind: 'sys' };
+  }
+
+  function renderTicker() {
+    if (!ticker) return;
+    if (!ticks.length) { ticker.hidden = true; ticker.innerHTML = ''; return; }
+    ticker.hidden = false;
+    ticker.innerHTML = '<span class="ft-led" aria-hidden="true"></span><span class="ft-tag">live</span>' +
+      ticks.slice(0, 16).map((e, i) => {
+        const h = humanizeEvt(e), agent = e.agent || 'system', ts = Number(e.ts) || Date.now();
+        return `<span class="ft-item${i === 0 ? ' fresh' : ''}">
+          <span class="ft-av" style="background:${ctx.colorFor(agent)}">${esc(ctx.initialFor(agent))}</span>
+          <span class="ft-agt">${esc(agent)}</span>
+          <span class="ft-verb k-${h.kind}">${esc(h.verb)}</span>
+          ${h.label ? `<span class="ft-lbl">${esc(h.label)}</span>` : ''}
+          ${e.project ? `<span class="ft-proj">${esc(e.project)}</span>` : ''}
+          <span class="ft-ago">${ctx.fmtAgo(ts)}</span>
+        </span>`;
+      }).join('');
+  }
+
+  async function seedTicker() {
+    try {
+      const recent = await ctx.api.events('', 24); // '' = every project
+      if (Array.isArray(recent) && recent.length) {
+        ticks = recent.slice().sort((a, b) => (Number(b.ts) || 0) - (Number(a.ts) || 0)).slice(0, 24);
+      }
+    } catch (_) { /* keep */ }
+    renderTicker();
+  }
+
+  function skeleton() {
+    kpisBox.innerHTML = '<div class="mc-kpi"><span class="mck-num skel" style="width:48px;height:30px"></span></div>'.repeat(5);
+    pulseWrap.innerHTML = '<div class="skel" style="height:84px;border-radius:7px"></div>';
+    bento.innerHTML = '<div class="proj-card skel-card"></div>'.repeat(6);
+    attnSection.hidden = true;
+  }
+
   ctx.onEvent((evt) => {
-    if (root.hidden || !evt || !evt.project) return;
-    const el = cardByName.get(evt.project);
-    if (!el) return;
-    el.classList.remove('flash');
-    void el.offsetWidth;
-    el.classList.add('flash');
+    if (!evt || !evt.type) return;
+    ticks.unshift(evt);
+    if (ticks.length > 40) ticks.length = 40;
+    if (!root.hidden) renderTicker();
+    if (!root.hidden && evt.project) {
+      const el = cardByName.get(evt.project);
+      if (el) { el.classList.remove('flash'); void el.offsetWidth; el.classList.add('flash'); }
+    }
   });
 
   return {
-    activate() { refresh(); },
+    activate() { refresh(); seedTicker(); },
   };
 }

--- a/internal/web/static/v2/index.html
+++ b/internal/web/static/v2/index.html
@@ -57,12 +57,38 @@
         <div class="home-hero">
           <div class="home-hero-text">
             <h1 class="home-title">mission control</h1>
-            <p class="home-sub">you're directing a fleet now, not babysitting one chat. every project is a crew — drop in to see who's shipping, who's blocked, and what just landed.</p>
+            <p class="home-sub">direct the fleet — golden signals, live throughput, and the crews that need you, across every project.</p>
             <a class="fleet-comms-link" href="#/messages">fleet comms — message any agent, any project →</a>
           </div>
-          <div class="home-agg" id="homeAgg" aria-label="All-projects summary"></div>
         </div>
-        <div class="bento" id="bento" aria-label="Projects"></div>
+
+        <div class="fleet-ticker" id="fleetTicker" aria-label="Live activity" hidden></div>
+
+        <div class="mc-kpis" id="mcKpis" aria-label="Fleet signals"></div>
+
+        <section class="card mc-pulse" aria-label="Fleet throughput">
+          <div class="card-head">
+            <span class="card-label">fleet throughput · 30d</span>
+            <span class="card-meta" id="pulseMeta"></span>
+          </div>
+          <div class="pulse-wrap" id="pulseWrap"></div>
+        </section>
+
+        <section class="fleet-section" id="attnSection" hidden aria-label="Crews that need attention">
+          <div class="fleet-shead">
+            <span class="fs-title sev-red">needs attention</span>
+            <span class="fs-count" id="attnCount"></span>
+          </div>
+          <div class="attn-list" id="attnList"></div>
+        </section>
+
+        <section class="fleet-section" aria-label="Fleet">
+          <div class="fleet-shead">
+            <span class="fs-title">fleet</span>
+            <span class="fs-count" id="fleetCount"></span>
+          </div>
+          <div class="bento" id="bento" aria-label="Projects"></div>
+        </section>
       </section>
 
       <!-- ============ OVERVIEW ============ -->

--- a/internal/web/static/v2/v2.css
+++ b/internal/web/static/v2/v2.css
@@ -478,6 +478,10 @@ button { font-family: inherit; }
 .lin-arrow { color: var(--text-dim); font-size: 10px; }
 .linear-badge:hover .lin-arrow { color: var(--violet); }
 
+/* hidden attr must win over the display rules below (UA [hidden] loses to a
+   class selector) — these are toggled per route for project vs fleet scope */
+.proj-id[hidden], .proj-tabs[hidden], .linear-strip[hidden] { display: none; }
+
 /* ---------- per-project tabs ---------- */
 .proj-tabs {
   display: flex; align-items: center; gap: 2px; flex-wrap: wrap;
@@ -530,6 +534,10 @@ button { font-family: inherit; }
 .agg-num { font-size: 22px; font-weight: 600; color: var(--text); letter-spacing: -.5px; font-variant-numeric: tabular-nums; }
 .agg-num .of { color: var(--text-dim); font-weight: 400; font-size: 15px; }
 .agg-label { font-size: 9.5px; letter-spacing: 1.1px; text-transform: uppercase; color: var(--text-muted); }
+.agg-stat.good .agg-num { color: var(--accent); }
+.agg-stat.bad .agg-num { color: var(--red); }
+.agg-stat.bad .agg-label { color: var(--red); opacity: .85; }
+.agg-stat.dim .agg-num { color: var(--text-dim); }
 
 .bento {
   display: grid; grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
@@ -553,8 +561,16 @@ button { font-family: inherit; }
 .proj-card.is-mirror::before { background: var(--violet); }
 .proj-card.flash { animation: cardFlash 1.2s ease; }
 @keyframes cardFlash { from { background: rgba(74,222,128,.07); } to { background: var(--bg-card); } }
-.pc-top { display: flex; align-items: center; justify-content: space-between; gap: 8px; }
-.pc-name { font-size: 15px; font-weight: 600; color: var(--text); letter-spacing: .2px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.pc-top { display: flex; align-items: center; gap: 8px; }
+.pc-name { font-size: 15px; font-weight: 600; color: var(--text); letter-spacing: .2px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; flex: 0 1 auto; }
+.pc-spacer { flex: 1 1 auto; }
+.pc-chip {
+  flex: none; font-size: 9px; letter-spacing: .5px; text-transform: uppercase;
+  padding: 1px 6px; border-radius: 5px; font-weight: 600; border: 1px solid transparent;
+}
+.pc-chip.live { color: var(--accent); border-color: var(--accent-dim); background: rgba(74,222,128,.08); }
+.pc-chip.idle { color: var(--text-dim); border-color: var(--border-soft); }
+.pc-chip.blk { color: var(--red); border-color: rgba(248,113,113,.3); background: rgba(248,113,113,.08); }
 .pc-linear {
   display: inline-flex; align-items: center; gap: 4px; flex: none; text-decoration: none;
   font-size: 9.5px; letter-spacing: .5px; color: var(--violet);
@@ -566,14 +582,156 @@ button { font-family: inherit; }
 .pc-dot { width: 7px; height: 7px; border-radius: 50%; background: var(--text-dim); flex: none; }
 .pc-dot.on { background: var(--accent); box-shadow: 0 0 0 3px rgba(74,222,128,.14); animation: pulse 2.6s ease-in-out infinite; }
 .pc-agents-sub { color: var(--text-dim); }
-.pc-bar { height: 6px; border-radius: 3px; background: var(--bg-elev); overflow: hidden; }
-.pc-bar i { display: block; height: 100%; background: var(--accent); transition: width .5s ease; }
+.pc-bar { height: 6px; border-radius: 3px; background: var(--bg-elev); overflow: hidden; display: flex; }
+.pc-bar i { display: block; height: 100%; transition: width .5s ease; }
+.pc-bar .seg-done { background: var(--accent); }
+.pc-bar .seg-active { background: var(--blue); }
+.pc-bar .seg-block { background: var(--red); }
+.pc-reasons { display: flex; flex-wrap: wrap; gap: 6px; margin-top: -2px; }
+.pc-reason {
+  font-size: 9.5px; letter-spacing: .3px; padding: 1px 7px; border-radius: 5px;
+  display: inline-flex; align-items: center; gap: 5px; font-weight: 600;
+}
+.pc-reason::before { content: ''; width: 5px; height: 5px; border-radius: 50%; background: currentColor; }
+.pc-reason.red { color: var(--red); background: rgba(248,113,113,.1); }
+.pc-reason.amber { color: var(--amber); background: rgba(251,191,36,.1); }
+.pc-foot-meta .m-blk { color: var(--red); font-weight: 600; }
 .pc-foot { display: flex; align-items: baseline; justify-content: space-between; gap: 8px; margin-top: auto; }
 .pc-foot-tasks { font-size: 12px; color: var(--text); font-variant-numeric: tabular-nums; }
 .pc-foot-tasks .of { color: var(--text-dim); }
 .pc-foot-meta { font-size: 10.5px; color: var(--text-muted); letter-spacing: .2px; }
 .skel-card { min-height: 132px; border: 1px solid var(--border); border-radius: var(--radius); background: var(--bg-card); }
 .skel-card::after { content: ''; display: block; height: 100%; }
+
+/* ---------- fleet sections (attention / fleet) ---------- */
+.fleet-section { display: flex; flex-direction: column; gap: 12px; }
+.fleet-shead { display: flex; align-items: center; gap: 9px; padding: 0 2px; }
+.fs-title {
+  font-size: 10px; letter-spacing: 1.4px; text-transform: uppercase;
+  color: var(--text-muted); font-weight: 600;
+}
+.fs-title.sev-red { color: var(--red); }
+.fs-title.sev-red::before {
+  content: ''; display: inline-block; width: 6px; height: 6px; border-radius: 50%;
+  background: var(--red); margin-right: 7px; transform: translateY(-1px);
+  box-shadow: 0 0 0 0 rgba(248,113,113,.5); animation: blkpulse 1.8s ease-out infinite;
+}
+.fs-count {
+  font-size: 10px; color: var(--text-dim); font-variant-numeric: tabular-nums;
+  border: 1px solid var(--border-soft); border-radius: 10px; padding: 0 7px; line-height: 16px;
+}
+
+/* attention cards: alert rail + faint tint, never lose the dark-mono calm */
+.proj-card.needs-attn.sev-red { border-color: rgba(248,113,113,.28); background: linear-gradient(180deg, rgba(248,113,113,.045), var(--bg-card) 40%); }
+.proj-card.needs-attn.sev-red::before { background: var(--red); opacity: .95; }
+.proj-card.needs-attn.sev-amber { border-color: rgba(251,191,36,.26); background: linear-gradient(180deg, rgba(251,191,36,.04), var(--bg-card) 40%); }
+.proj-card.needs-attn.sev-amber::before { background: var(--amber); opacity: .9; }
+
+/* ---------- live ticker — "what just landed" ---------- */
+.fleet-ticker {
+  display: flex; align-items: center; gap: 16px; overflow-x: auto; overflow-y: hidden;
+  padding: 9px 12px; margin: -4px 0 2px;
+  background: var(--bg-card); border: 1px solid var(--border); border-radius: var(--radius);
+  scrollbar-width: thin; scrollbar-color: var(--border) transparent;
+  -webkit-mask-image: linear-gradient(90deg, transparent 0, #000 24px, #000 calc(100% - 40px), transparent);
+          mask-image: linear-gradient(90deg, transparent 0, #000 24px, #000 calc(100% - 40px), transparent);
+}
+.fleet-ticker::-webkit-scrollbar { height: 0; }
+.ft-led {
+  flex: none; width: 7px; height: 7px; border-radius: 50%; background: var(--accent);
+  box-shadow: 0 0 0 3px rgba(74,222,128,.14); animation: pulse 2.4s ease-in-out infinite;
+}
+.ft-tag { flex: none; font-size: 9px; letter-spacing: 1.2px; text-transform: uppercase; color: var(--text-dim); }
+.ft-item {
+  flex: none; display: inline-flex; align-items: center; gap: 6px; font-size: 11px;
+  color: var(--text-muted); white-space: nowrap; padding-right: 16px;
+  border-right: 1px solid var(--border-soft);
+}
+.ft-item:last-child { border-right: 0; }
+.ft-item.fresh { animation: tickIn .5s ease; }
+@keyframes tickIn { from { opacity: 0; transform: translateX(-6px); } to { opacity: 1; transform: none; } }
+.ft-av { width: 16px; height: 16px; border-radius: 50%; display: grid; place-items: center; font-size: 8.5px; font-weight: 700; color: #0a0c10; flex: none; }
+.ft-agt { color: var(--text); }
+.ft-verb { color: var(--text-muted); }
+.ft-verb.k-done { color: var(--accent); }
+.ft-verb.k-block { color: var(--red); }
+.ft-lbl { color: var(--text-muted); max-width: 200px; overflow: hidden; text-overflow: ellipsis; }
+.ft-proj { color: var(--violet); font-size: 9.5px; border: 1px solid color-mix(in srgb, var(--violet) 32%, transparent); border-radius: 4px; padding: 0 5px; }
+.ft-ago { color: var(--text-dim); font-variant-numeric: tabular-nums; }
+
+/* ---------- golden-signal KPI tiles ---------- */
+.mc-kpis { display: grid; grid-template-columns: repeat(5, 1fr); gap: 12px; }
+.mc-kpi {
+  background: var(--bg-card); border: 1px solid var(--border); border-radius: var(--radius);
+  padding: 14px 16px; display: flex; flex-direction: column; gap: 5px; position: relative; overflow: hidden;
+}
+.mc-kpi::before { content: ''; position: absolute; left: 0; top: 0; bottom: 0; width: 2px; background: var(--slate); opacity: .5; }
+.mc-kpi.good::before { background: var(--accent); opacity: .9; }
+.mc-kpi.bad::before { background: var(--red); opacity: .95; }
+.mc-kpi.dim::before { opacity: .25; }
+.mck-num { font-size: 30px; line-height: 1; font-weight: 600; color: var(--text); letter-spacing: -1px; font-variant-numeric: tabular-nums; }
+.mck-num .of { font-size: 15px; font-weight: 400; color: var(--text-dim); letter-spacing: 0; margin-left: 3px; }
+.mc-kpi.good .mck-num { color: var(--accent); }
+.mc-kpi.bad .mck-num { color: var(--red); }
+.mc-kpi.dim .mck-num { color: var(--text-muted); }
+.mck-label { font-size: 9.5px; letter-spacing: 1.1px; text-transform: uppercase; color: var(--text-muted); }
+
+/* ---------- pulse chart (fleet throughput) ---------- */
+.mc-pulse { padding: 16px 18px 14px; }
+.pulse-wrap { margin-top: 4px; }
+.pulse-svg { width: 100%; height: 84px; display: block; }
+.pl-bar { fill: var(--accent); opacity: .7; transition: opacity .15s; }
+.pl-bar:hover { opacity: 1; }
+.pl-bar.today { fill: var(--accent); opacity: 1; }
+.pl-area { fill: var(--blue); opacity: .07; }
+.pl-disp { fill: none; stroke: var(--blue); stroke-width: 1.5; opacity: .65; stroke-linejoin: round; stroke-linecap: round; }
+.pl-base { stroke: var(--border); stroke-width: 1; }
+#pulseMeta .pm-done { color: var(--accent); }
+#pulseMeta .pm-disp { color: var(--blue); }
+
+/* ---------- attention rows (triage) ---------- */
+.attn-list { display: flex; flex-direction: column; gap: 8px; }
+.attn-row {
+  display: flex; align-items: center; gap: 11px; cursor: pointer;
+  background: var(--bg-card); border: 1px solid var(--border); border-left-width: 2px;
+  border-radius: var(--radius-sm); padding: 11px 14px;
+  transition: border-color .15s, background .15s, transform .12s;
+}
+.attn-row:hover { transform: translateX(2px); background: var(--bg-elev); }
+.attn-row:focus-visible { outline: none; box-shadow: 0 0 0 1px var(--accent-dim); }
+.attn-row.sev-red { border-left-color: var(--red); }
+.attn-row.sev-amber { border-left-color: var(--amber); }
+.ar-dot { width: 7px; height: 7px; border-radius: 50%; flex: none; }
+.attn-row.sev-red .ar-dot { background: var(--red); box-shadow: 0 0 0 0 rgba(248,113,113,.5); animation: blkpulse 1.8s ease-out infinite; }
+.attn-row.sev-amber .ar-dot { background: var(--amber); }
+.ar-proj { font-size: 13px; font-weight: 600; color: var(--text); white-space: nowrap; }
+.ar-reasons { display: flex; flex-wrap: wrap; gap: 6px; }
+.ar-reason { font-size: 9.5px; letter-spacing: .3px; padding: 1px 7px; border-radius: 5px; font-weight: 600; }
+.ar-reason.red { color: var(--red); background: rgba(248,113,113,.1); }
+.ar-reason.amber { color: var(--amber); background: rgba(251,191,36,.1); }
+.ar-spacer { flex: 1; }
+.ar-meta { font-size: 11px; color: var(--text-muted); font-variant-numeric: tabular-nums; white-space: nowrap; }
+.ar-go { color: var(--text-dim); font-size: 12px; flex: none; }
+.attn-row:hover .ar-go { color: var(--text); }
+.attn-more { font-size: 11px; color: var(--text-dim); letter-spacing: .2px; padding: 4px 2px 0; }
+
+/* ---------- live crew pips on fleet cards ---------- */
+.pc-crew { display: inline-flex; align-items: center; gap: 3px; margin-left: auto; }
+.crew-pip { width: 6px; height: 6px; border-radius: 50%; background: var(--text-dim); flex: none; }
+.crew-pip.on { background: var(--accent); box-shadow: 0 0 0 2px rgba(74,222,128,.16); }
+.crew-pip.sleep { background: var(--amber); opacity: .8; }
+.crew-pip.off { background: var(--slate); }
+.crew-more { font-size: 9px; color: var(--text-dim); margin-left: 2px; }
+.pc-chip.warm { color: var(--amber); border-color: rgba(251,191,36,.28); background: rgba(251,191,36,.07); }
+
+@media (max-width: 1080px) {
+  .mc-kpis { grid-template-columns: repeat(3, 1fr); }
+}
+@media (max-width: 620px) {
+  .mc-kpis { grid-template-columns: repeat(2, 1fr); }
+  .mck-num { font-size: 24px; }
+  .ar-meta { display: none; }
+}
 
 /* ============================================================= *
  *  PHASE 3 — THE MESSAGE CINEMA


### PR DESCRIPTION
Rebuilds the v2 home from a flat grid of equal-weight project cards into a cross-project **fleet-ops console** — urgent-first (F-pattern), grounded in NOC/SRE + multi-agent observability patterns.

## Frontend
- **Golden-signal KPI tiles** — agents online · active · blocked · crews · % shipped, color-coded rails.
- **Fleet throughput pulse chart** — 30d daily shipped (bars) + dispatched (line/area), persistent from the DB (survives restarts, unlike the in-memory event ring).
- **Needs-attention rows** — triage as scannable alert rows, worst-first: blocked (red, pulsing) then stale (amber), with reason chips + open counts.
- **Fleet cards** — live crew pips (online/sleeping/offline), segmented progress (done/active/blocked), last-active meta, status chip.
- **Live ticker** — "what just landed", SSE-fed + seeded from `/api/events/recent`.

## Backend
- `ProjectInfo` += `blocked_tasks`, `last_activity`; `active_tasks` now counts `in-review` (matches the board). One enriched query, no extra round-trips.
- New `FleetThroughput(days)` + `GET /api/fleet/throughput` for the pulse chart.

## Fix
- Project-scoped chrome (tabs, breadcrumb, Linear strip) leaked onto the fleet home — `.proj-tabs{display:flex}` etc. beat the `hidden` attribute. Added `[hidden]` guards so the home header stays fleet-level.

## Verification
- `go build ./...` ✓ · `go test ./internal/db` ✓ · gofmt ✓ · `node --check` ✓
- Visual: rendered on a copy of prod data, screenshotted across iterations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)