### PR TITLE
docs: low-key consulting handoff to tsukumo (UTM'd)

### DIFF
--- a/README.md
+++ b/README.md
@@ -939,6 +939,8 @@ CGO_ENABLED=1 go build -tags fts5 -o agent-relay .
 
 <div align="center">
 
+Running agents across a team? [tsukumo](https://tsukumo.ch/consulting?utm_source=wraith&utm_medium=oss-suite&utm_campaign=consulting) consults on doing it well in production.
+
 Built at [synergix-lab](https://github.com/synergix-lab) · AGPL-3.0 License
 
 <!-- [![Star History Chart](https://api.star-history.com/svg?repos=synergix-lab/agent-relay&type=Date)](https://star-history.com/#synergix-lab/agent-relay&Date) -->


### PR DESCRIPTION
Task `a60d7dfd` — replicate the trovex E2 suite→agency handoff (trovex #178) on WRAI.TH.

WRAI.TH is a Go CLI (no marketing web landing like trovex), so the honest public surface is the **README footer**: one quiet line pointing teams to tsukumo consulting, UTM'd `?utm_source=wraith&utm_medium=oss-suite&utm_campaign=consulting` so tsukumo reads it as `source=suite` (closes the loop to `assessment_request`).

No brand change, not a sales pitch (OSS surface stays useful-first). README-only. **Left for review — not self-merged** (cross-repo guardrail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)