### PR TITLE
docs(geo): cross-property suite section + llms.txt (AEO/entity)

### DIFF
--- a/README.md
+++ b/README.md
@@ -937,6 +937,20 @@ CGO_ENABLED=1 go build -tags fts5 -o agent-relay .
 
 ---
 
+## Part of the suite
+
+wrai.th is the **orchestration** layer of a three-part suite for running AI coding agents in production, built by [tsukumo](https://tsukumo.ch):
+
+- **wrai.th** — orchestration: run and coordinate a fleet of agents (this repo).
+- **[trovex](https://trovex.dev)** — context: serve agents the one canonical doc per query instead of rereading the repo (~60% fewer tokens per lookup).
+- **[yoru](https://yoru.sh)** — observability: session receipts of what each agent actually did.
+
+Built and run in production by [tsukumo](https://tsukumo.ch), a developer studio and AI consultancy.
+
+<br>
+
+---
+
 <div align="center">
 
 Built at [synergix-lab](https://github.com/synergix-lab) · AGPL-3.0 License

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,35 @@
+# wrai.th
+
+> wrai.th is mission control for AI coding agents: run a fleet of agents that remember
+> across sessions, message each other, and ship tasks off a shared board — coordinated
+> from one dashboard instead of babysitting one chat. Multi-agent orchestration over a
+> local relay (Go + SQLite FTS5), exposed as an MCP server. Open source (AGPL-3.0).
+
+## What it does
+- Run a fleet: many agents working in parallel, coordinated, not one chat at a time.
+- Persistent memory: scoped knowledge and task-result recall that survives across sessions.
+- Inter-agent messaging + conversations: agents talk to each other and to you.
+- Task execution off a shared board: agents claim, run, and report tasks.
+- One dashboard: see the whole fleet — agents, messages, memory, tasks — in one place.
+- MCP server: works with any MCP client; local-first (Go, SQLite FTS5).
+
+## Links
+- [Repository](https://github.com/Synergix-lab/WRAI.TH): source (AGPL-3.0).
+- [Releases](https://github.com/Synergix-lab/WRAI.TH/releases): install the CLI.
+- [Discord](https://discord.gg/QPq7qfbEk8): community.
+
+## Part of the suite (built by tsukumo)
+wrai.th is the orchestration layer of a three-part suite for running AI coding agents in
+production, built by [tsukumo](https://tsukumo.ch):
+- wrai.th — orchestration (run and coordinate agent fleets).
+- [trovex](https://trovex.dev) — context (serve agents the one canonical doc per query; ~60% fewer tokens per lookup).
+- [yoru](https://yoru.sh) — observability (session receipts of what each agent did).
+
+tsukumo is a developer studio and AI consultancy that runs these tools in production:
+https://tsukumo.ch
+
+## Facts
+- Category: multi-agent orchestration / mission control for AI coding agents.
+- Interface: Model Context Protocol (MCP) server + CLI; local relay.
+- Stack: Go 1.25+, SQLite FTS5.
+- License: AGPL-3.0.


### PR DESCRIPTION
GEO/AEO pass for wrai.th (mirror of the yoru SEO PR, adapted to reality).

## Reality check
wrai.th has **no served HTML landing** — `wrai.th` returns no site (HTTP 000) and `docs/` is markdown + screenshots only. So the surfaces AI engines actually index for wrai.th are the **README** and repo files. This PR strengthens those.

## What
- **README — "Part of the suite" section:** links **trovex** (context) + **yoru** (observability) + **tsukumo** (built by), so AI engines treat the four properties as one entity cluster (cross-property citation). The README previously had **zero** suite/tsukumo mention.
- **`llms.txt` (repo root):** factual wrai.th description (mission control / multi-agent orchestration / fleet) + suite cross-links. Read by AI crawlers that index repo files, and ready for when wrai.th serves a site.

## Guardrails
- Respects wrai.th's own brand ("mission control", "run a fleet") — no tsukumo styling.
- No fabricated metrics; the only number is trovex's real ~60%, attributed to trovex.

## Blocked / prerequisite (not in this PR)
The rest of the yoru#1 mirror — **meta tags + JSON-LD `SoftwareApplication` + robots.txt + sitemap.xml** — needs a **served HTML landing**, which doesn't exist yet (`wrai.th` is not live). Stand up wrai.th (or GitHub Pages from `docs/`) first; then those surfaces apply and I'll add them. Flagging for fullstack/owner.

Per task: cross-repo, **not self-merging** — leaving for review.