### PR TITLE
docs(readme): add tsukumo bridge link (capture OSS top-of-funnel)

### DIFF
--- a/README.md
+++ b/README.md
@@ -941,6 +941,8 @@ CGO_ENABLED=1 go build -tags fts5 -o agent-relay .
 
 Built at [synergix-lab](https://github.com/synergix-lab) · AGPL-3.0 License
 
+Built by [tsukumo](https://tsukumo.ch/?utm_source=wraith&utm_medium=oss-suite&utm_campaign=consulting) — we put AI agents into production for dev teams.
+
 <!-- [![Star History Chart](https://api.star-history.com/svg?repos=synergix-lab/agent-relay&type=Date)](https://star-history.com/#synergix-lab/agent-relay&Date) -->
 
 </div>


### PR DESCRIPTION
WRAI.TH is the biggest top-of-funnel by clones, but the README has **zero tsukumo link** — that developer traffic is unfunneled. Adds **one value-first credit line** (not a banner, not a pitch) in the footer next to the existing synergix-lab/AGPL credit, UTM'd per the funnel contract (`utm_source=wraith&utm_medium=oss-suite&utm_campaign=consulting`). Per the tsukumo `oss-funnel-spec`: OSS surfaces are for developers — a credit line a curious dev can follow to the team behind the tool, nothing salesy.

Not self-merging (cross-repo) — for a WRAI.TH owner to review/merge. 🤖 Generated with [Claude Code](https://claude.com/claude-code)