### PR TITLE
docs(readme): low-key tsukumo consulting bridge (UTM'd)

### DIFF
--- a/README.md
+++ b/README.md
@@ -918,6 +918,16 @@ API endpoints: `GET /api/token-usage` (per-project), `/api/token-usage/project` 
 
 <br>
 
+## Who builds this
+
+wrai.th is built and run by the team behind **[tsukumo](https://tsukumo.ch/?utm_source=wraith&utm_medium=oss-suite&utm_campaign=consulting&utm_content=readme)** -- we help engineering teams run fleets of AI coding agents in production. wrai.th is the orchestration layer we run ourselves; free and open source (AGPL).
+
+Pairs with **trovex** (one canonical doc per query, fewer tokens) and **yoru** (see what the fleet did).
+
+> Standing up an agent fleet across a team? We do that hands-on -- [talk to us](https://tsukumo.ch/?utm_source=wraith&utm_medium=oss-suite&utm_campaign=consulting&utm_content=readme).
+
+<br>
+
 ## &#x1F91D; Contributing
 
 Opinionated tooling built for a specific workflow. Moves fast.
@@ -940,6 +950,8 @@ CGO_ENABLED=1 go build -tags fts5 -o agent-relay .
 <div align="center">
 
 Built at [synergix-lab](https://github.com/synergix-lab) · AGPL-3.0 License
+
+Built by the team behind [tsukumo](https://tsukumo.ch/?utm_source=wraith&utm_medium=oss-suite&utm_campaign=consulting&utm_content=footer) -- consulting for teams running AI agent fleets.
 
 <!-- [![Star History Chart](https://api.star-history.com/svg?repos=synergix-lab/agent-relay&type=Date)](https://star-history.com/#synergix-lab/agent-relay&Date) -->
 


### PR DESCRIPTION
## What
WRAI.TH is the suite's widest top-of-funnel (~1.3k clones) but its README had **zero** path to the consulting funnel — that traffic was unfunneled. Adds a low-key `Who builds this` block + footer one-liner linking to tsukumo.

## Attribution
Every link carries the ratified suite→consulting contract:
`utm_source=wraith&utm_medium=oss-suite&utm_campaign=consulting` (+ `utm_content=readme|footer`). tsukumo.ch reads the UTM on arrival → captures `source=suite`, closes the funnel loop. GitHub is static so no repo-side analytics (UTM only, correct per spec).

## Decisions
- Applies launch's ratified copy (trovex#171 `oss-agency-bridge.md` §3), tuned to wraith's orchestration voice + house `--` style.
- Footnote, not a pitch — one block + one footer, no prices, no fabricated proof, lowercase wordmarks.
- Links to tsukumo.ch root (per the dispatched URL + launch spec). Could be deepened to /assessment later — cmo/analytics call.

## Gate
✅ tsukumo.ch live (HTTP 200).

Leaving for review — not self-merging (cross-repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)