### PR TITLE
fix(security): harden relay defaults — 1 MiB body cap + opt-in identity gate

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -114,7 +114,7 @@ buffering **off** and a long read timeout.
 | `RELAY_API_KEY` | _(unset)_ | Bearer token. Required to bind non-loopback. Loopback exempt. |
 | `RELAY_TRUST_LOOPBACK` | `1` | `0` requires the token even from loopback. |
 | `RELAY_CORS_ORIGINS` | _(none)_ | Comma-separated allowed origins (else same-origin only). |
-| `RELAY_MAX_BODY` | _(unlimited)_ | Max request body, bytes. |
+| `RELAY_MAX_BODY` | `1048576` (1 MiB) | Max request body, bytes. Set `0` to disable the cap. |
 | `RELAY_RATE_LIMIT` | _(off)_ | Requests/minute per IP. |
 | `RELAY_DB` | `~/.agent-relay/relay.db` | DB file path (set in dev/CI so a local run never migrates prod). |
 | `RELAY_LINEAR_MODE` | `false` | `1`/`true` enables the Linear mirror (needs `LINEAR_API_KEY`). |

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -116,6 +116,7 @@ buffering **off** and a long read timeout.
 | `RELAY_CORS_ORIGINS` | _(none)_ | Comma-separated allowed origins (else same-origin only). |
 | `RELAY_MAX_BODY` | `1048576` (1 MiB) | Max request body, bytes. Set `0` to disable the cap. |
 | `RELAY_RATE_LIMIT` | _(off)_ | Requests/minute per IP. |
+| `RELAY_REQUIRE_REGISTERED` | _(off)_ | `1`/`true` rejects mutating tool calls from an anonymous or unregistered agent (reads + `register_agent` stay open). |
 | `RELAY_DB` | `~/.agent-relay/relay.db` | DB file path (set in dev/CI so a local run never migrates prod). |
 | `RELAY_LINEAR_MODE` | `false` | `1`/`true` enables the Linear mirror (needs `LINEAR_API_KEY`). |
 | `LINEAR_API_KEY` | _(unset)_ | Linear GraphQL personal key (mirror mode). |

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -7,13 +7,19 @@ import (
 	"time"
 )
 
+// DefaultMaxBody is the request body cap applied when RELAY_MAX_BODY is unset.
+// 1 MiB comfortably exceeds any legitimate tool call (messages are capped at
+// max_context_bytes) while blocking memory-exhaustion via oversized payloads.
+const DefaultMaxBody int64 = 1 << 20
+
 // Config holds server security settings loaded from environment variables.
-// All settings are opt-in — zero values preserve backward-compatible behavior.
+// MaxBody defaults to DefaultMaxBody; the rest are opt-in (zero values preserve
+// backward-compatible behavior).
 type Config struct {
 	APIKey      string   // RELAY_API_KEY: shared secret for Bearer auth
 	CORSOrigins []string // RELAY_CORS_ORIGINS: allowed origins (comma-separated)
-	MaxBody     int64    // RELAY_MAX_BODY: max request body in bytes
-	RateLimit   int      // RELAY_RATE_LIMIT: requests/minute per IP
+	MaxBody     int64    // RELAY_MAX_BODY: max request body in bytes (default 1 MiB; 0 disables)
+	RateLimit   int      // RELAY_RATE_LIMIT: requests/minute per IP (opt-in; 0 = off)
 
 	// LinearMode toggles Linear-SSOT mirror mode. Default false = degraded/native
 	// mode (tasks live in the relay DB, kanban is writable). Surfaced via
@@ -58,8 +64,10 @@ func Load() Config {
 		}
 	}
 
+	cfg.MaxBody = DefaultMaxBody
 	if v := os.Getenv("RELAY_MAX_BODY"); v != "" {
-		if n, err := strconv.ParseInt(v, 10, 64); err == nil && n > 0 {
+		// Explicit 0 opts out of the cap (unlimited); negatives are ignored.
+		if n, err := strconv.ParseInt(v, 10, 64); err == nil && n >= 0 {
 			cfg.MaxBody = n
 		}
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,6 +21,13 @@ type Config struct {
 	MaxBody     int64    // RELAY_MAX_BODY: max request body in bytes (default 1 MiB; 0 disables)
 	RateLimit   int      // RELAY_RATE_LIMIT: requests/minute per IP (opt-in; 0 = off)
 
+	// RequireRegistered (RELAY_REQUIRE_REGISTERED) rejects mutating tool calls
+	// whose acting agent is "anonymous" or not registered in the project. Opt-in
+	// (default off) — the loopback trust model still treats the declared `as`/
+	// ?agent= identity as authoritative; this only stops silent anonymous and
+	// typo'd writes from polluting the bus. Reads and register_agent stay open.
+	RequireRegistered bool // RELAY_REQUIRE_REGISTERED
+
 	// LinearMode toggles Linear-SSOT mirror mode. Default false = degraded/native
 	// mode (tasks live in the relay DB, kanban is writable). Surfaced via
 	// /api/health and /api/settings so the web UI can detect the mode.
@@ -80,6 +87,10 @@ func Load() Config {
 
 	if v := strings.ToLower(strings.TrimSpace(os.Getenv("RELAY_LINEAR_MODE"))); v == "1" || v == "true" || v == "yes" {
 		cfg.LinearMode = true
+	}
+
+	if v := strings.ToLower(strings.TrimSpace(os.Getenv("RELAY_REQUIRE_REGISTERED"))); v == "1" || v == "true" || v == "yes" {
+		cfg.RequireRegistered = true
 	}
 
 	cfg.LinearAPIKey = os.Getenv("LINEAR_API_KEY")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -30,6 +30,23 @@ func TestMaxBodyNegativeIgnored(t *testing.T) {
 	}
 }
 
+func TestRequireRegisteredOptIn(t *testing.T) {
+	t.Setenv("RELAY_REQUIRE_REGISTERED", "")
+	if Load().RequireRegistered {
+		t.Error("RequireRegistered should default to false")
+	}
+	for _, v := range []string{"1", "true", "yes", "TRUE"} {
+		t.Setenv("RELAY_REQUIRE_REGISTERED", v)
+		if !Load().RequireRegistered {
+			t.Errorf("RequireRegistered should be true for %q", v)
+		}
+	}
+	t.Setenv("RELAY_REQUIRE_REGISTERED", "0")
+	if Load().RequireRegistered {
+		t.Error("RequireRegistered should be false for \"0\"")
+	}
+}
+
 func TestRateLimitOptIn(t *testing.T) {
 	t.Setenv("RELAY_RATE_LIMIT", "")
 	if got := Load().RateLimit; got != 0 {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,42 @@
+package config
+
+import "testing"
+
+func TestMaxBodyDefault(t *testing.T) {
+	t.Setenv("RELAY_MAX_BODY", "")
+	if got := Load().MaxBody; got != DefaultMaxBody {
+		t.Errorf("default MaxBody = %d, want %d", got, DefaultMaxBody)
+	}
+}
+
+func TestMaxBodyOverride(t *testing.T) {
+	t.Setenv("RELAY_MAX_BODY", "4096")
+	if got := Load().MaxBody; got != 4096 {
+		t.Errorf("MaxBody = %d, want 4096", got)
+	}
+}
+
+func TestMaxBodyExplicitZeroDisables(t *testing.T) {
+	t.Setenv("RELAY_MAX_BODY", "0")
+	if got := Load().MaxBody; got != 0 {
+		t.Errorf("MaxBody = %d, want 0 (unlimited)", got)
+	}
+}
+
+func TestMaxBodyNegativeIgnored(t *testing.T) {
+	t.Setenv("RELAY_MAX_BODY", "-5")
+	if got := Load().MaxBody; got != DefaultMaxBody {
+		t.Errorf("MaxBody = %d, want default %d on negative input", got, DefaultMaxBody)
+	}
+}
+
+func TestRateLimitOptIn(t *testing.T) {
+	t.Setenv("RELAY_RATE_LIMIT", "")
+	if got := Load().RateLimit; got != 0 {
+		t.Errorf("default RateLimit = %d, want 0 (off)", got)
+	}
+	t.Setenv("RELAY_RATE_LIMIT", "600")
+	if got := Load().RateLimit; got != 600 {
+		t.Errorf("RateLimit = %d, want 600", got)
+	}
+}

--- a/internal/relay/guard_test.go
+++ b/internal/relay/guard_test.go
@@ -1,0 +1,80 @@
+package relay
+
+import (
+	"context"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+func ctxWith(agent, project string) context.Context {
+	ctx := context.WithValue(context.Background(), agentNameKey, agent)
+	return context.WithValue(ctx, projectKey, project)
+}
+
+// TestGuardRegistered verifies the RELAY_REQUIRE_REGISTERED gate: anonymous and
+// unregistered identities are rejected before the wrapped handler runs, while a
+// registered agent passes through.
+func TestGuardRegistered(t *testing.T) {
+	h := testHandlers(t)
+	h.requireRegistered = true
+
+	ran := false
+	next := func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		ran = true
+		return mcp.NewToolResultText("ok"), nil
+	}
+	guarded := h.guardRegistered(next)
+
+	// anonymous → rejected, next never runs
+	res, _ := guarded(ctxWith("anonymous", "p1"), call(nil))
+	if !res.IsError {
+		t.Fatal("anonymous identity should be rejected")
+	}
+	if ran {
+		t.Fatal("wrapped handler must not run for anonymous")
+	}
+
+	// unregistered name → rejected
+	ran = false
+	res, _ = guarded(ctxWith("ghost", "p1"), call(nil))
+	if !res.IsError {
+		t.Fatal("unregistered agent should be rejected")
+	}
+	if ran {
+		t.Fatal("wrapped handler must not run for unregistered agent")
+	}
+
+	// register bob, then the same call passes and runs the handler
+	if r, _ := h.HandleRegisterAgent(ctxWith("", "p1"), call(map[string]any{"name": "bob", "role": "dev"})); r.IsError {
+		t.Fatalf("register bob failed: %s", expectError(t, r))
+	}
+	ran = false
+	res, _ = guarded(ctxWith("bob", "p1"), call(nil))
+	if res != nil && res.IsError {
+		t.Fatalf("registered agent should pass: %s", res.Content[0].(mcp.TextContent).Text)
+	}
+	if !ran {
+		t.Fatal("wrapped handler should run for a registered agent")
+	}
+
+	// registration is project-scoped: bob in p1 is unknown in p2
+	ran = false
+	res, _ = guarded(ctxWith("bob", "p2"), call(nil))
+	if !res.IsError {
+		t.Fatal("agent registered in p1 should be rejected in p2")
+	}
+}
+
+// TestGuardDisabledByDefault confirms toolRegistry leaves handlers unwrapped
+// when the flag is off (no identity enforcement).
+func TestToolRegistryNoWrapByDefault(t *testing.T) {
+	h := testHandlers(t)
+	// requireRegistered defaults false
+	for _, rt := range h.toolRegistry() {
+		_ = rt // handlers are the bare h.HandleX; nothing to assert beyond no panic
+	}
+	if h.requireRegistered {
+		t.Fatal("requireRegistered should default to false")
+	}
+}

--- a/internal/relay/handlers.go
+++ b/internal/relay/handlers.go
@@ -26,6 +26,10 @@ type Handlers struct {
 	notifier  *Notifier
 	connMu    sync.RWMutex
 	connector connector.TaskConnector
+
+	// requireRegistered gates mutating tools behind a registered acting agent
+	// (RELAY_REQUIRE_REGISTERED). Set from config in relay.New before dispatch.
+	requireRegistered bool
 }
 
 // SetNotifier connects the notifications subsystem so handlers can emit custom

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -66,6 +66,7 @@ func New(database *db.DB, ingester *ingest.Ingester, cfg config.Config) *Relay {
 	events := NewEventBus()
 	registry := NewSessionRegistry(mcpSrv)
 	handlers := NewHandlers(database, registry, ingester, events)
+	handlers.requireRegistered = cfg.RequireRegistered
 
 	// Register every tool from the registry (single source of truth in
 	// toolset.go), plus the discovery pair used by ?tools=discovery

--- a/internal/relay/toolset.go
+++ b/internal/relay/toolset.go
@@ -36,7 +36,7 @@ var toolCategories = []struct{ name, summary string }{
 // serves: relay.New registers from it, discover_tools/call_tool index it,
 // and the schema budget test measures it.
 func (h *Handlers) toolRegistry() []registeredTool {
-	return []registeredTool{
+	tools := []registeredTool{
 		{server.ServerTool{Tool: whoamiTool(), Handler: h.HandleWhoami}, "session"},
 		{server.ServerTool{Tool: registerAgentTool(), Handler: h.HandleRegisterAgent}, "session"},
 		{server.ServerTool{Tool: getSessionContextTool(), Handler: h.HandleGetSessionContext}, "session"},
@@ -112,6 +112,60 @@ func (h *Handlers) toolRegistry() []registeredTool {
 
 		{server.ServerTool{Tool: createProjectTool(), Handler: h.HandleCreateProject}, "projects"},
 		{server.ServerTool{Tool: deleteProjectTool(), Handler: h.HandleDeleteProject}, "projects"},
+	}
+	// When RELAY_REQUIRE_REGISTERED is on, wrap the actor-attributed write tools
+	// so an unregistered/anonymous identity is rejected before the write. Reads
+	// and the bootstrap tools (register_agent, whoami, get_session_context …)
+	// are never wrapped, so an agent can always register and orient first.
+	if h.requireRegistered {
+		for i := range tools {
+			if mutatingTools[tools[i].Tool.Name] {
+				tools[i].Handler = h.guardRegistered(tools[i].Handler)
+			}
+		}
+	}
+	return tools
+}
+
+// mutatingTools are the write tools gated by RELAY_REQUIRE_REGISTERED — those
+// that record or act under an agent identity. Pure reads and identity bootstrap
+// tools are intentionally absent so registration and orientation stay open.
+var mutatingTools = map[string]bool{
+	"send_message": true, "ack_delivery": true, "mark_read": true,
+	"dispatch_task": true, "claim_task": true, "start_task": true,
+	"review_task": true, "comment": true, "complete_task": true,
+	"block_task": true, "resume_task": true, "cancel_task": true,
+	"update_task": true, "archive_tasks": true, "move_task": true,
+	"batch_complete_tasks": true, "batch_dispatch_tasks": true,
+	"create_board": true, "archive_board": true, "delete_board": true,
+	"set_memory": true, "delete_memory": true, "resolve_conflict": true,
+	"register_profile": true,
+	"deactivate_agent": true, "delete_agent": true, "sleep_agent": true,
+	"create_org": true, "create_team": true, "add_team_member": true,
+	"remove_team_member": true, "add_notify_channel": true,
+	"create_conversation": true, "invite_to_conversation": true,
+	"leave_conversation": true, "archive_conversation": true,
+	"create_project": true, "delete_project": true,
+}
+
+// guardRegistered wraps a tool handler to reject calls whose acting agent is
+// anonymous or not registered in the project. Only installed when
+// RELAY_REQUIRE_REGISTERED is on (see toolRegistry).
+func (h *Handlers) guardRegistered(next server.ToolHandlerFunc) server.ToolHandlerFunc {
+	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		from := strings.ToLower(resolveAgent(ctx, req))
+		project := ProjectFromContext(ctx)
+		if from == "" || from == "anonymous" {
+			return mcp.NewToolResultError("RELAY_REQUIRE_REGISTERED is on: no agent identity. Set ?agent=<name> on the MCP URL (or pass `as`) after calling register_agent."), nil
+		}
+		agent, err := h.db.GetAgent(project, from)
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("identity check failed: %v", err)), nil
+		}
+		if agent == nil {
+			return mcp.NewToolResultError(fmt.Sprintf("RELAY_REQUIRE_REGISTERED is on: agent %q is not registered in project %q — call register_agent first.", from, project)), nil
+		}
+		return next(ctx, req)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -130,9 +130,13 @@ func startServer() {
 	if cfg.MaxBody > 0 {
 		bodyStatus = fmt.Sprintf("%dKB", cfg.MaxBody/1024)
 	}
+	requireReg := "off"
+	if cfg.RequireRegistered {
+		requireReg = "on"
+	}
 	log.Printf("agent-relay starting on %s", addr)
-	log.Printf("  auth: %s | cors: %s | max body: %s | rate limit: %s",
-		authStatus, corsStatus, bodyStatus, rateLimitStatus)
+	log.Printf("  auth: %s | cors: %s | max body: %s | rate limit: %s | require-registered: %s",
+		authStatus, corsStatus, bodyStatus, rateLimitStatus, requireReg)
 
 	go func() {
 		log.Printf("listening on %s (UI: http://localhost:%s)", addr, port)

--- a/main.go
+++ b/main.go
@@ -126,9 +126,13 @@ func startServer() {
 	if cfg.RateLimit > 0 {
 		rateLimitStatus = fmt.Sprintf("%d/min", cfg.RateLimit)
 	}
+	bodyStatus := "unlimited"
+	if cfg.MaxBody > 0 {
+		bodyStatus = fmt.Sprintf("%dKB", cfg.MaxBody/1024)
+	}
 	log.Printf("agent-relay starting on %s", addr)
-	log.Printf("  auth: %s | cors: %s | max body: %dB | rate limit: %s",
-		authStatus, corsStatus, cfg.MaxBody, rateLimitStatus)
+	log.Printf("  auth: %s | cors: %s | max body: %s | rate limit: %s",
+		authStatus, corsStatus, bodyStatus, rateLimitStatus)
 
 	go func() {
 		log.Printf("listening on %s (UI: http://localhost:%s)", addr, port)


### PR DESCRIPTION
Two security hardening defaults surfaced by stress-testing the relay (isolated instance, prod untouched). Both are independent, low-risk, and shaped to avoid regressions.

## 1. Body cap (1 MiB default)

No body limit unless `RELAY_MAX_BODY` was set (`0` = unlimited). A single client stored a **20 MB message in 0.29s** — the whole body is read before handling → trivial memory-exhaustion DoS.

- **`MaxBody` defaults to 1 MiB.** Exceeds any legit tool call (messages capped at `max_context_bytes`); oversized requests rejected before storage.
- `RELAY_MAX_BODY=0` opts out (unlimited); positive = custom; negative ignored.

## 2. Opt-in identity gate (`RELAY_REQUIRE_REGISTERED`)

Identity is declared, never verified: `from` = `as` param / `?agent=` / `"anonymous"`, unchecked against registered agents. Writes silently record as `anonymous`, and `as:"x"` is accepted for any name. By-design on loopback (no per-agent secrets) but pollutes the bus/audit.

- **`RELAY_REQUIRE_REGISTERED=1`** (default off) wraps the 38 actor-attributed write tools to reject anonymous/unregistered senders with a clear `call register_agent first` error.
- Reads + bootstrap tools (`register_agent`, `whoami`, `get_session_context` …) stay open. Covers both `tools/call` and the discovery `call_tool` path (wrap lives in `toolRegistry`).
- Default off = byte-identical to current behavior. Connectors / pre-register flows unaffected unless an operator turns it on.

## Why rate limit is left opt-in
The single SQLite writer sustains ~5–6k writes/s with graceful queueing (0 errors to 256 concurrent; 8000 held SSE streams = ~350 MB). A default throttle would harm legitimate hot agent loops — operators enable `RELAY_RATE_LIMIT` per deployment. The writer ceiling itself is architectural, not a defect.

## Verify
```
small msg → 200 ; 5MB body → rejected (not stored)
flag on:  anonymous send → rejected ; as=ghost → rejected ; as=bob (registered) → 200 ; get_inbox (read) → 200
startup log: max body: 1024KB | require-registered: on
```
`go build ./...`, `go vet`, `go test ./...` all green. New unit tests: config env parse (body/rate/require), guard accept/reject + project scoping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)