### PR TITLE
fix(serve): exit on bind failure instead of hanging as a zombie

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,9 +2,11 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"net"
+	"net/http"
 	"os"
 	"os/signal"
 	"strings"
@@ -138,14 +140,26 @@ func startServer() {
 	log.Printf("  auth: %s | cors: %s | max body: %s | rate limit: %s | require-registered: %s",
 		authStatus, corsStatus, bodyStatus, rateLimitStatus, requireReg)
 
+	// serveErr surfaces a bind/listen failure (e.g. EADDRINUSE when a stale
+	// relay still holds the port after sleep/wake) so we exit non-zero instead
+	// of hanging idle while an old process keeps serving the UI.
+	serveErr := make(chan error, 1)
 	go func() {
 		log.Printf("listening on %s (UI: http://localhost:%s)", addr, port)
-		if err := r.ListenAndServe(addr); err != nil {
-			log.Printf("server stopped: %v", err)
+		if err := r.ListenAndServe(addr); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			serveErr <- err
 		}
 	}()
 
-	<-ctx.Done()
+	select {
+	case err := <-serveErr:
+		if isAddrInUse(err) {
+			log.Fatalf("cannot bind %s: address already in use — another agent-relay is still running. "+
+				"Stop it first: lsof -ti tcp:%s | xargs kill -9", addr, port)
+		}
+		log.Fatalf("server failed: %v", err)
+	case <-ctx.Done():
+	}
 	close(cleanupDone)
 	log.Println("shutting down...")
 	// Bound the shutdown: Shutdown cancels SSE streams so they unblock, but cap
@@ -155,6 +169,12 @@ func startServer() {
 	if err := r.Shutdown(shutdownCtx); err != nil {
 		log.Printf("shutdown error: %v", err)
 	}
+}
+
+// isAddrInUse reports whether err is an EADDRINUSE listen failure — the case
+// where a stale relay (often surviving a sleep/wake cycle) still holds the port.
+func isAddrInUse(err error) bool {
+	return errors.Is(err, syscall.EADDRINUSE)
 }
 
 // isLoopbackHost reports whether a bind host is loopback-only (safe to serve

--- a/main_test.go
+++ b/main_test.go
@@ -32,9 +32,10 @@ func TestIsAddrInUse(t *testing.T) {
 	if err != nil {
 		t.Fatalf("listen: %v", err)
 	}
-	defer l.Close()
-	_, err2 := net.Listen("tcp", l.Addr().String())
+	defer func() { _ = l.Close() }()
+	l2, err2 := net.Listen("tcp", l.Addr().String())
 	if err2 == nil {
+		_ = l2.Close()
 		t.Fatal("expected second listen to fail")
 	}
 	if !isAddrInUse(err2) {

--- a/main_test.go
+++ b/main_test.go
@@ -1,6 +1,11 @@
 package main
 
-import "testing"
+import (
+	"errors"
+	"net"
+	"syscall"
+	"testing"
+)
 
 func TestIsLoopbackHost(t *testing.T) {
 	cases := map[string]bool{
@@ -18,5 +23,29 @@ func TestIsLoopbackHost(t *testing.T) {
 		if got := isLoopbackHost(host); got != want {
 			t.Errorf("isLoopbackHost(%q) = %v, want %v", host, got, want)
 		}
+	}
+}
+
+func TestIsAddrInUse(t *testing.T) {
+	// Real EADDRINUSE: bind a port twice.
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer l.Close()
+	_, err2 := net.Listen("tcp", l.Addr().String())
+	if err2 == nil {
+		t.Fatal("expected second listen to fail")
+	}
+	if !isAddrInUse(err2) {
+		t.Errorf("isAddrInUse(%v) = false, want true", err2)
+	}
+
+	// Unrelated errors must not match.
+	if isAddrInUse(errors.New("boom")) {
+		t.Error("isAddrInUse(generic) = true, want false")
+	}
+	if isAddrInUse(syscall.ECONNREFUSED) {
+		t.Error("isAddrInUse(ECONNREFUSED) = true, want false")
 	}
 }


### PR DESCRIPTION
## Problem (reported by relay user)

After a sleep/wake cycle: v2 UI stops loading, v1 loses its assets (galaxy / robot-agent images), and `agent-relay serve` does not recover. Killing "the process" doesn't help.

## Root cause

`ListenAndServe` ran in a goroutine whose error was only `log.Printf`'d (`main.go:141`). On a failed bind (`EADDRINUSE`) the process stayed alive and idle after printing `agent-relay starting` / `listening on ...` — so it looked healthy.

After sleep, a stale relay still holds `:8090`. The new `serve` silently fails to bind and hangs, while the **old binary keeps serving** — predating v2, so no v2 and missing embedded (`go:embed`) assets. Killing "the process" kills the new zombie, not the old listener, so a plain restart never recovers.

### Reproduced (before)
```
server stopped: listen tcp 127.0.0.1:8391: bind: address already in use
RESULT: STILL-RUNNING   <-- zombie, never exits
```

## Fix

Surface the listen error on a channel; `select` on it alongside the signal context. On `EADDRINUSE`, `log.Fatal` with the exact recovery command and exit non-zero. `http.ErrServerClosed` from graceful shutdown is filtered so SIGTERM still exits 0.

### Reproduced (after)
```
cannot bind 127.0.0.1:8391: address already in use — another agent-relay is
still running. Stop it first: lsof -ti tcp:8391 | xargs kill -9
RESULT: EXITED rc=1
```

## Verification
- Bind conflict → exits rc=1 with recovery hint (was: hung alive)
- Clean start → UI returns 200
- SIGTERM → graceful shutdown, rc=0
- New unit test `TestIsAddrInUse`; full suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)