### PR TITLE
feat(board): team-grid layout, readable transcript, conversations, corporate type

### DIFF
--- a/internal/web/static/v2/api.js
+++ b/internal/web/static/v2/api.js
@@ -47,6 +47,10 @@ export const api = {
   // messages (comms)
   messages: (project) => getJSON(`/api/messages?${q({ project })}`),
   messagesAll: () => getJSON('/api/messages/all-projects'),
+  // conversations (multi-agent threads)
+  conversations: (project) => getJSON(`/api/conversations?${q({ project })}`),
+  conversationsAll: () => getJSON('/api/conversations/all'),
+  conversationMessages: (id) => getJSON(`/api/conversations/${encodeURIComponent(id)}/messages`),
   sendMessage: (project, to, content, replyTo) =>
     sendJSON('POST', '/api/user-response', { project, to, content, reply_to: replyTo || '' }),
   // memory (curate)

--- a/internal/web/static/v2/messages.js
+++ b/internal/web/static/v2/messages.js
@@ -19,10 +19,13 @@ export function initMessages(root, ctx) {
   const SKIP = new Set(['', '*', 'system']);
 
   let msgs = [];
+  let convs = [];                 // [{id,title,members[],message_count,...}]
+  const convCache = new Map();    // conv id → messages[]
   let scopeMode = 'project';   // 'project' | 'all'
   let selected = ALL;
   let railFilter = '';
   let loadTok = 0;
+  const isConv = (k) => typeof k === 'string' && k.startsWith('conv:');
 
   const projScope = () => ctx.selection; // current project, or 'all'
   const canProjectScope = () => ctx.selection && ctx.selection !== 'all';
@@ -34,9 +37,32 @@ export function initMessages(root, ctx) {
     try {
       list = scopeMode === 'all' ? await ctx.api.messagesAll() : await ctx.api.messages(projScope());
     } catch (_) { list = []; }
+    let clist;
+    try {
+      clist = scopeMode === 'all' ? await ctx.api.conversationsAll() : await ctx.api.conversations(projScope());
+    } catch (_) { clist = []; }
     if (tok !== loadTok) return;
     msgs = Array.isArray(list) ? list : [];
+    convs = Array.isArray(clist) ? clist : [];
+    convCache.clear();
     render();
+  }
+
+  // Lazily fetch + cache a conversation's full message thread, then re-render.
+  async function selectKey(key) {
+    selected = key;
+    renderRail();
+    if (isConv(key)) {
+      const id = key.slice(5);
+      if (!convCache.has(id)) {
+        renderThread();                       // shows a loading/empty state meanwhile
+        try {
+          const m = await ctx.api.conversationMessages(id);
+          convCache.set(id, Array.isArray(m) ? m : []);
+        } catch (_) { convCache.set(id, []); }
+      }
+    }
+    renderThread();
   }
 
   // Distinct agents seen in traffic, newest-active first.
@@ -55,6 +81,7 @@ export function initMessages(root, ctx) {
   function threadFor(key) {
     if (key === ALL) return msgs;
     if (key === BROADCAST) return msgs.filter((m) => m.to === '*');
+    if (isConv(key)) return convCache.get(key.slice(5)) || [];
     return msgs.filter((m) => m.from === key || m.to === key);
   }
 
@@ -81,8 +108,16 @@ export function initMessages(root, ctx) {
       const bc = threadFor(BROADCAST).length;
       items.push(railRow(BROADCAST, 'broadcast', bc ? `${bc} sent` : 'message all', '*'));
     }
+    // Conversations (multi-agent named threads) — their own group above the DMs.
+    let cl = convs;
+    if (railFilter) cl = cl.filter((c) => (c.title || '').toLowerCase().includes(railFilter));
+    if (cl.length) {
+      items.push('<div class="msg-rail-group">conversations</div>');
+      for (const c of cl) items.push(convRow(c));
+    }
     let list = agents();
     if (railFilter) list = list.filter((a) => a.toLowerCase().includes(railFilter));
+    if (list.length) items.push('<div class="msg-rail-group">agents</div>');
     for (const a of list) {
       const th = threadFor(a);
       const lastMsg = th[0];
@@ -91,7 +126,22 @@ export function initMessages(root, ctx) {
     }
     railList.innerHTML = items.join('') || '<div class="empty">No agents in traffic</div>';
     railList.querySelectorAll('.msg-rail-row').forEach((el) =>
-      el.addEventListener('click', () => { selected = el.dataset.key; renderRail(); renderThread(); }));
+      el.addEventListener('click', () => selectKey(el.dataset.key)));
+  }
+
+  function convRow(c) {
+    const key = 'conv:' + c.id;
+    const title = c.title || 'untitled';
+    const members = (c.members || []).length;
+    const sub = `${members} member${members === 1 ? '' : 's'} · ${c.message_count || 0} msg`;
+    return `<div class="msg-rail-row${selected === key ? ' on' : ''}" data-key="${esc(key)}" role="button" tabindex="0">
+      <span class="msg-rail-glyph conv" aria-hidden="true">◇</span>
+      <span class="msg-rail-main">
+        <span class="msg-rail-name">${esc(title)}</span>
+        <span class="msg-rail-sub">${esc(sub)}</span>
+      </span>
+      <span class="msg-rail-right"></span>
+    </div>`;
   }
 
   function railRow(key, label, sub, avatarSeed, lastMsg, count) {
@@ -112,21 +162,25 @@ export function initMessages(root, ctx) {
   }
 
   function renderThread() {
-    const isAgent = selected !== ALL && selected !== BROADCAST;
-    const title = selected === ALL ? 'all traffic' : selected === BROADCAST ? 'broadcast to fleet' : selected;
-    const sub = selected === ALL ? 'every message in scope (read-only)'
-      : selected === BROADCAST ? 'goes to every agent in this project'
-        : (scopeMode === 'all' ? `in ${esc(lastProjectForAgent(selected))}` : 'direct message');
+    const conv = isConv(selected) ? convs.find((c) => 'conv:' + c.id === selected) : null;
+    const isAgent = selected !== ALL && selected !== BROADCAST && !isConv(selected);
+    let title; let sub;
+    if (isConv(selected)) {
+      title = (conv && conv.title) || 'conversation';
+      sub = conv && conv.members && conv.members.length ? conv.members.join(', ') : 'conversation thread';
+    } else if (selected === ALL) { title = 'all traffic'; sub = 'every message in scope (read-only)'; }
+    else if (selected === BROADCAST) { title = 'broadcast to fleet'; sub = 'goes to every agent in this project'; }
+    else { title = selected; sub = scopeMode === 'all' ? `in ${esc(lastProjectForAgent(selected))}` : 'direct message'; }
     threadHead.innerHTML = `<div class="msg-th-title">${esc(title)}</div><div class="msg-th-sub">${sub}</div>`;
 
     const list = threadFor(selected).slice().sort((a, b) => (Date.parse(a.created_at) || 0) - (Date.parse(b.created_at) || 0)).slice(-300);
     if (!list.length) {
-      threadBody.innerHTML = '<div class="empty">No messages yet</div>';
+      threadBody.innerHTML = `<div class="empty">${isConv(selected) ? 'Loading…' : 'No messages yet'}</div>`;
     } else {
       threadBody.innerHTML = list.map(bubble).join('');
       threadBody.scrollTop = threadBody.scrollHeight;
     }
-    // composer: agent DM or broadcast; all-traffic is read-only
+    // composer: agent DM or broadcast; all-traffic + conversations are read-only here.
     const showComposer = selected === BROADCAST || isAgent;
     composer.hidden = !showComposer;
     if (showComposer) input.placeholder = selected === BROADCAST ? 'broadcast to all agents…' : `message ${selected}…`;

--- a/internal/web/static/v2/team.js
+++ b/internal/web/static/v2/team.js
@@ -25,13 +25,20 @@ export function initTeam(root, ctx) {
   const emptyEl = root.querySelector('#stageEmpty');
   const transcriptBody = root.querySelector('#transcriptBody');
   const transcriptMeta = root.querySelector('#transcriptMeta');
+  // Background layer for the per-team tinted zones + section labels (behind nodes).
+  const zonesEl = document.createElement('div');
+  zonesEl.className = 'stage-zones';
+  if (stage) stage.insertBefore(zonesEl, stage.firstChild);
 
   let agents = [];
   let nameSet = new Set();
   const pos = new Map();           // name → {nx, ny} normalized
   const nodeEl = new Map();        // name → element
   const heat = new Map();          // name → [ts, ...]
-  let transcript = [];             // {from, to, line, ts}
+  let transcript = [];             // {from, to, subject, content, ts}
+  let hubsMeta = [];               // [{name,cx,cy,rx,ry,label,count}] for team zones
+  let curProject = null;           // last loaded project (for transcript reseed)
+  let reseedTimer = null;
   let loadedFor = null;
   let W = 0, H = 0;
   let live = 0;
@@ -44,6 +51,7 @@ export function initTeam(root, ctx) {
   /* ----------------------------- data ----------------------------- */
   async function load() {
     const project = ctx.selection;
+    curProject = project;
     const t = ++token;
     skeleton();
     let list = [];
@@ -67,9 +75,8 @@ export function initTeam(root, ctx) {
         const sorted = msgs.slice().sort((a, b) => Date.parse(a.created_at) - Date.parse(b.created_at));
         for (const m of sorted) {
           const ts = Date.parse(m.created_at) || Date.now();
-          const line = m.subject || excerpt(m.content);
           recordHeat(m.from, ts); for (const to of resolveTargets(m.to)) recordHeat(to, ts);
-          transcript.unshift({ from: m.from, to: m.to, line, ts });
+          transcript.unshift({ from: m.from, to: m.to, subject: m.subject || '', content: m.content || '', ts });
         }
         transcript = transcript.slice(0, MAX_TRANSCRIPT);
       }
@@ -88,88 +95,66 @@ export function initTeam(root, ctx) {
   // reports fan out on concentric rings; each branch owns an angular wedge sized
   // by its leaf count, so a hub with many direct reports spreads collision-free
   // instead of cramming into one row. Disconnected roots park along the top.
+  // Group by TEAM membership (agents carry teams[] — far more reliable than
+  // reports_to, whose targets are often inactive execs). Each team becomes a
+  // tinted zone + section label, its members arranged on a ring inside it, so the
+  // teams read at a glance. Agents with no team land in an "unassigned" cluster.
+  const TEAM_COLOR = { engineering: '#22c55e', growth: '#6e6bf2', leads: '#38bdf8', unassigned: '#64748b' };
+  // an agent's primary team: first non-"leads" team (leads is a cross-cutting hat).
+  function primaryTeam(a) {
+    const ts = a.teams || [];
+    const t = ts.find((x) => x.slug !== 'leads') || ts[0];
+    return t ? t.slug : 'unassigned';
+  }
   function computeLayout() {
     pos.clear();
+    hubsMeta = [];
     if (!agents.length) return;
-    const byName = new Map(agents.map((a) => [a.name, a]));
-    const parentOf = (a) =>
-      (a.reports_to && byName.has(a.reports_to) && a.reports_to !== a.name) ? a.reports_to : null;
 
-    const kids = new Map(agents.map((a) => [a.name, []]));
-    const roots = [];
+    const groups = new Map();
     for (const a of agents) {
-      const p = parentOf(a);
-      if (p) kids.get(p).push(a.name);
-      else roots.push(a.name);
+      const s = primaryTeam(a);
+      if (!groups.has(s)) groups.set(s, []);
+      groups.get(s).push(a.name);
     }
-    for (const arr of kids.values()) arr.sort((x, y) => rank(byName.get(x), byName.get(y)));
+    // unassigned last, otherwise larger teams first.
+    const list = [...groups.entries()]
+      .map(([slug, members]) => ({ slug, members }))
+      .sort((x, y) =>
+        (x.slug === 'unassigned' ? 1 : 0) - (y.slug === 'unassigned' ? 1 : 0)
+        || y.members.length - x.members.length);
 
-    // Leaf count per node (min 1), cycle-guarded — drives angular wedge size.
-    const leaves = new Map();
-    const counting = new Set();
-    const leafCount = (name) => {
-      if (leaves.has(name)) return leaves.get(name);
-      if (counting.has(name)) return 1;
-      counting.add(name);
-      const c = kids.get(name) || [];
-      const n = c.length ? c.reduce((s, ch) => s + leafCount(ch), 0) : 1;
-      leaves.set(name, n);
-      return n;
-    };
-    roots.forEach(leafCount);
-    roots.sort((a, b) => leafCount(b) - leafCount(a));
+    // Bounded grid of team cards — never overlapping, scales to N teams. Members
+    // pack in a mini-grid inside each card (all maths in normalized 0..1 space).
+    const N = list.length;
+    const cols = Math.min(3, N);
+    const rows = Math.ceil(N / cols);
+    const PADX = 0.02, PADY = 0.025, GAP = 0.014;
+    const cw = (1 - PADX * 2 - GAP * (cols - 1)) / cols;
+    const ch = (1 - PADY * 2 - GAP * (rows - 1)) / rows;
 
-    const TAU = Math.PI * 2;
-    // Recursively place a subtree: node at (depth·step) along the mid-angle of its
-    // wedge [a0,a1); children split the wedge by leaf share.
-    const fan = (name, a0, a1, depth, cx, cy, rx, ry, step, placed) => {
-      const ang = (a0 + a1) / 2;
-      if (depth > 0) {
-        const rr = depth * step;
-        pos.set(name, { nx: cx + rx * rr * Math.cos(ang), ny: cy + ry * rr * Math.sin(ang) });
-      } else {
-        pos.set(name, { nx: cx, ny: cy });
-      }
-      const c = kids.get(name) || [];
-      if (!c.length || placed.has(name)) return;
-      placed.add(name);
-      const total = c.reduce((s, ch) => s + leafCount(ch), 0) || 1;
-      let a = a0;
-      for (const ch of c) {
-        const w = (a1 - a0) * (leafCount(ch) / total);
-        fan(ch, a, a + w, depth + 1, cx, cy, rx, ry, step, placed);
-        a += w;
-      }
-    };
-
-    const subtreeDepth = (name, seen = new Set()) => {
-      if (seen.has(name)) return 0;
-      seen.add(name);
-      const c = kids.get(name) || [];
-      return c.length ? 1 + Math.max(...c.map((ch) => subtreeDepth(ch, seen))) : 0;
-    };
-
-    const primary = roots[0];
-    const secondary = roots.slice(1);
-    const placed = new Set();
-
-    // Primary tree → centred, fills the canvas. Reserve a top seam for parked roots.
-    const md = Math.max(1, subtreeDepth(primary));
-    const seam = secondary.length ? 0.18 : 0.04;     // fraction of the circle kept clear at top
-    const start = -Math.PI / 2 + (seam / 2) * TAU;    // begin just past 12 o'clock, sweep clockwise
-    fan(primary, start, start + (1 - seam) * TAU, 0, 0.5, 0.54, 0.38, 0.34, 1 / md, placed);
-
-    // Disconnected roots (and any small trees under them) park in a top row, each
-    // fanning its own children downward so nothing collides with the central hub.
-    secondary.forEach((nm, i) => {
-      const f = secondary.length === 1 ? 0.5 : i / (secondary.length - 1);
-      const cx = 0.22 + f * 0.56;
-      pos.set(nm, { nx: cx, ny: 0.08 });
-      const kc = kids.get(nm) || [];
-      if (kc.length) {
-        const dmd = Math.max(1, subtreeDepth(nm));
-        fan(nm, Math.PI * 0.18, Math.PI * 0.82, 0, cx, 0.08, 0.13, 0.16, 1 / dmd, placed);
-      }
+    list.forEach((g, gi) => {
+      const c = gi % cols, r = Math.floor(gi / cols);
+      const x0 = PADX + c * (cw + GAP);
+      const y0 = PADY + r * (ch + GAP);
+      const m = g.members;
+      const n = m.length;
+      const mcols = n <= 1 ? 1 : n <= 2 ? 2 : 3;
+      const mrows = Math.ceil(n / mcols);
+      const gx = cw / (mcols + 1);
+      const top = y0 + ch * 0.22;            // reserve the top of the card for the label
+      const usable = ch * 0.70;
+      const gy = usable / (mrows + 1);
+      m.forEach((name, i) => {
+        const cc = i % mcols, rr = Math.floor(i / mcols);
+        pos.set(name, { nx: x0 + gx * (cc + 1), ny: top + gy * (rr + 1) });
+      });
+      hubsMeta.push({
+        slug: g.slug, x0, y0, cw, ch,
+        color: TEAM_COLOR[g.slug] || colorFor(g.slug),
+        label: g.slug === 'unassigned' ? 'UNASSIGNED' : g.slug.toUpperCase(),
+        count: n,
+      });
     });
   }
   // Leaders / executives first, then by heat-ish role, then name.
@@ -184,6 +169,16 @@ export function initTeam(root, ctx) {
     W = r.width; H = r.height;
     svg.setAttribute('viewBox', `0 0 ${Math.max(1, W)} ${Math.max(1, H)}`);
     drawLinks();
+    renderZones();
+  }
+  // Tinted region + section label behind each hub's team, so teams read at a glance.
+  function renderZones() {
+    if (!zonesEl || !W) return;
+    zonesEl.innerHTML = hubsMeta.map((m) => {
+      const x = m.x0 * W, y = m.y0 * H, w = m.cw * W, h = m.ch * H, c = m.color;
+      return `<div class="zone" style="left:${x}px;top:${y}px;width:${w}px;height:${h}px;--zc:${c}"></div>`
+        + `<div class="hublabel" style="left:${x + 14}px;top:${y + 13}px;--zc:${c}">${esc(m.label)} <span class="cnt">${m.count}</span></div>`;
+    }).join('');
   }
   const centerOf = (name) => {
     const p = pos.get(name);
@@ -251,11 +246,15 @@ export function initTeam(root, ctx) {
   function nodeHTML(a) {
     const state = a.online ? (a.activity && a.activity !== 'idle' ? 'active' : 'online') : 'idle';
     const role = a.profile_slug || shortRole(a.role);
-    return `<div class="agent-node" data-name="${esc(a.name)}" data-state="${state}" style="--c:${colorFor(a.name)}" tabindex="0" aria-label="${esc(a.name)}${role ? ' · ' + esc(role) : ''}">
+    // one dot per team the agent belongs to → shows multi-team membership at a glance.
+    const teams = (a.teams || []);
+    const dots = teams.map((t) =>
+      `<span class="an-team" style="background:${TEAM_COLOR[t.slug] || colorFor(t.slug)}" title="${esc(t.name || t.slug)}"></span>`).join('');
+    return `<div class="agent-node" data-name="${esc(a.name)}" data-state="${state}" style="--c:${colorFor(a.name)}" tabindex="0" aria-label="${esc(a.name)}${role ? ' · ' + esc(role) : ''}${teams.length ? ' · teams: ' + esc(teams.map((t) => t.slug).join(', ')) : ''}">
       <span class="an-orbit" aria-hidden="true"></span>
       <span class="an-heat" aria-hidden="true"></span>
       <span class="an-avatar">${a.avatar_url ? `<img class="an-img" src="${esc(a.avatar_url)}" alt="" loading="lazy" onerror="this.remove()">` : esc(initialFor(a.name))}<span class="an-status" aria-hidden="true"></span></span>
-      <span class="an-label"><span class="an-name">${esc(a.name)}</span>${role ? `<span class="an-role">${esc(role)}</span>` : ''}</span>
+      <span class="an-label"><span class="an-name">${esc(a.name)}</span>${role ? `<span class="an-role">${esc(role)}</span>` : ''}${dots ? `<span class="an-teams">${dots}</span>` : ''}</span>
     </div>`;
   }
   const shortRole = (r) => String(r || '').split(/[.—-]/)[0].trim().split(/\s+/).slice(0, 3).join(' ');
@@ -326,9 +325,12 @@ export function initTeam(root, ctx) {
     for (const to of targets) recordHeat(to, ts);
     refreshHeat();
 
-    transcript.unshift({ from, to: rawTo, line, ts });
+    // Live event carries only the subject (label); prepend it now for instant
+    // feedback, then reseed shortly to backfill the full body from the API.
+    transcript.unshift({ from, to: rawTo, subject: line, content: '', ts });
     if (transcript.length > MAX_TRANSCRIPT) transcript.length = MAX_TRANSCRIPT;
     renderTranscript(true);
+    reseedSoon();
     toggleEmpty();
 
     if (root.hidden) return;                      // accrue silently when off-screen
@@ -395,7 +397,35 @@ export function initTeam(root, ctx) {
   }
 
   /* ------------------------- transcript --------------------------- */
-  function renderTranscript(flashFirst = false) {
+  // Refetch recent messages (which carry the full body) and rebuild the
+  // transcript, so live entries that arrived subject-only get their content
+  // backfilled. Debounced so a burst of messages triggers one fetch.
+  function reseedSoon() {
+    clearTimeout(reseedTimer);
+    reseedTimer = setTimeout(reseed, 1500);
+  }
+  async function reseed() {
+    if (!curProject) return;
+    let msgs;
+    try { msgs = await ctx.api.messagesLatest(curProject, isoSince(3 * 3600e3)); }
+    catch (_) { return; }
+    if (!Array.isArray(msgs)) return;
+    const open = new Set(
+      [...transcriptBody.querySelectorAll('.tr-row.open')].map((el) => el.dataset.key),
+    );
+    transcript = msgs
+      .map((m) => ({
+        from: m.from, to: m.to, subject: m.subject || '', content: m.content || '',
+        ts: Date.parse(m.created_at) || Date.now(),
+      }))
+      .sort((a, b) => b.ts - a.ts)
+      .slice(0, MAX_TRANSCRIPT);
+    renderTranscript(false, open);
+  }
+
+  const trKey = (m) => `${m.from}|${m.ts}`;
+
+  function renderTranscript(flashFirst = false, keepOpen = null) {
     transcriptMeta.textContent = transcript.length ? `${transcript.length} exchanges` : 'live';
     if (!transcript.length) {
       transcriptBody.innerHTML = '<div class="empty">No messages yet — they will appear here as agents talk.</div>';
@@ -403,27 +433,55 @@ export function initTeam(root, ctx) {
     }
     transcriptBody.innerHTML = transcript.map((m, i) => {
       const toLabel = m.to === '*' ? 'all' : m.to.startsWith('team:') ? m.to.slice(5) : m.to;
-      return `<div class="tr-row${flashFirst && i === 0 ? ' flash' : ''}">
-        <span class="tr-discs">
-          <span class="tr-disc" style="background:${colorFor(m.from)}" title="${esc(m.from)}">${esc(initialFor(m.from))}</span>
-          <span class="tr-arrow" aria-hidden="true">→</span>
-          <span class="tr-disc" style="background:${colorFor(toLabel)}" title="${esc(m.to)}">${esc(initialFor(toLabel))}</span>
-        </span>
-        <span class="tr-line">${m.line ? esc(m.line) : '<i class="text-dim">(no subject)</i>'}</span>
-        <span class="tr-ts">${fmtAgo(m.ts)}</span>
+      const toFull = m.to === '*' ? 'all agents' : m.to.startsWith('team:') ? `team ${m.to.slice(5)}` : m.to;
+      const head = m.subject || excerpt(m.content) || '(no subject)';
+      const key = trKey(m);
+      const isOpen = keepOpen && keepOpen.has(key);
+      const when = new Date(m.ts).toLocaleString();
+      const body = m.content
+        ? `<div class="tr-body">${esc(m.content)}</div>`
+        : (m.subject ? '' : '<div class="tr-body text-dim">(corps non disponible)</div>');
+      return `<div class="tr-row${isOpen ? ' open' : ''}${flashFirst && i === 0 ? ' flash' : ''}" data-key="${esc(key)}" role="button" tabindex="0" aria-expanded="${isOpen ? 'true' : 'false'}">
+        <div class="tr-head">
+          <span class="tr-discs">
+            <span class="tr-disc" style="background:${colorFor(m.from)}" title="${esc(m.from)}">${esc(initialFor(m.from))}</span>
+            <span class="tr-arrow" aria-hidden="true">→</span>
+            <span class="tr-disc" style="background:${colorFor(toLabel)}" title="${esc(m.to)}">${esc(initialFor(toLabel))}</span>
+          </span>
+          <span class="tr-line">${esc(head)}</span>
+          <span class="tr-ts">${fmtAgo(m.ts)}</span>
+        </div>
+        <div class="tr-full">
+          <div class="tr-meta">${esc(m.from)} → ${esc(toFull)} · ${esc(when)}</div>
+          ${m.subject ? `<div class="tr-subj">${esc(m.subject)}</div>` : ''}
+          ${body}
+        </div>
       </div>`;
     }).join('');
   }
 
+  // Click / keyboard toggles a row open to reveal the full message.
+  function toggleRow(row) {
+    if (!row) return;
+    const open = row.classList.toggle('open');
+    row.setAttribute('aria-expanded', open ? 'true' : 'false');
+  }
+  transcriptBody.addEventListener('click', (e) => toggleRow(e.target.closest('.tr-row')));
+  transcriptBody.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      const row = e.target.closest('.tr-row');
+      if (row) { e.preventDefault(); toggleRow(row); }
+    }
+  });
+
   function toggleEmpty() {
+    // Only a true empty board (no agents) gets the overlay. The old "silent"
+    // hint rendered a dark bar across the grid whenever the transcript was
+    // momentarily empty (e.g. just after a relay restart) — dropped.
     if (!agents.length) {
       emptyEl.hidden = false;
       emptyEl.dataset.kind = 'none';
       emptyEl.innerHTML = '<span class="se-title">no agents here yet</span><span class="se-sub">this project has no registered agents</span>';
-    } else if (!transcript.length) {
-      emptyEl.hidden = false;
-      emptyEl.dataset.kind = 'silent';      // constellation stays rendered behind this hint
-      emptyEl.innerHTML = '<span class="se-title">agents silencieux</span><span class="se-sub">the constellation is quiet — live messages will fly through</span>';
     } else {
       emptyEl.hidden = true;
     }

--- a/internal/web/static/v2/v2.css
+++ b/internal/web/static/v2/v2.css
@@ -1,4 +1,7 @@
+@import url('https://fonts.googleapis.com/css2?family=Lexend:wght@300;400;500;600;700&display=swap');
 :root {
+  /* corporate UI sans (Trust & Authority); --mono kept for data/code/timestamps */
+  --font: "Lexend", system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
   --bg: #0a0c10;
   --bg-card: #10131a;
   --bg-elev: #161a23;
@@ -25,7 +28,7 @@ html, body { margin: 0; padding: 0; }
 body {
   background: var(--bg);
   color: var(--text);
-  font-family: var(--mono);
+  font-family: var(--font);
   font-size: 13px;
   line-height: 1.45;
   -webkit-font-smoothing: antialiased;
@@ -751,6 +754,18 @@ button { font-family: inherit; }
 .pulse-comet { mix-blend-mode: screen; }
 
 .stage-nodes, .stage-captions { position: absolute; inset: 0; pointer-events: none; }
+/* per-team tinted zone + section label (behind nodes) */
+.stage-zones { position: absolute; inset: 0; pointer-events: none; z-index: 0; }
+.stage-zones .zone { position: absolute; border-radius: 14px;
+  background: linear-gradient(160deg, color-mix(in srgb, var(--zc) 9%, transparent), color-mix(in srgb, var(--zc) 3%, transparent));
+  border: 1px solid color-mix(in srgb, var(--zc) 22%, transparent);
+  box-shadow: inset 0 0 40px color-mix(in srgb, var(--zc) 6%, transparent); }
+.stage-zones .hublabel { position: absolute;
+  display: inline-flex; align-items: center; gap: 7px; padding: 3px 10px; border-radius: 7px;
+  font-size: 10px; font-weight: 600; letter-spacing: 1.4px; text-transform: uppercase;
+  color: var(--zc); background: color-mix(in srgb, var(--zc) 12%, var(--bg-card));
+  border: 1px solid color-mix(in srgb, var(--zc) 32%, transparent); }
+.stage-zones .hublabel .cnt { color: var(--text-dim); font-weight: 500; letter-spacing: .5px; }
 .agent-node {
   /* anchored so the AVATAR CENTRE (≈20px below the node top) sits exactly on the
      constellation point — that's where comets land and captions float from */
@@ -792,6 +807,9 @@ button { font-family: inherit; }
    It reveals on hover/focus/active, and the node lifts above its neighbours so
    the extra line isn't clipped. */
 .an-role { font-size: 9px; color: var(--text-muted); letter-spacing: .3px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 92px; max-height: 0; opacity: 0; transition: max-height .15s ease, opacity .15s ease; }
+/* team-membership dots — one per team the agent belongs to (multi-team aware) */
+.an-teams { display: inline-flex; gap: 3px; justify-content: center; margin-top: 2px; }
+.an-team { width: 6px; height: 6px; border-radius: 50%; box-shadow: 0 0 0 1px rgba(0,0,0,.35); }
 .agent-node { z-index: 1; }
 .agent-node:hover, .agent-node:focus-visible, .agent-node[data-state="active"] { z-index: 6; }
 .agent-node:hover .an-label, .agent-node:focus-visible .an-label, .agent-node[data-state="active"] .an-label { opacity: 1; }
@@ -827,14 +845,26 @@ button { font-family: inherit; }
 /* transcript column */
 .transcript { display: flex; flex-direction: column; background: var(--bg-card); border: 1px solid var(--border); border-radius: var(--radius); padding: var(--pad); min-width: 0; }
 .transcript-body { display: flex; flex-direction: column; overflow-y: auto; scrollbar-width: thin; scrollbar-color: var(--border) transparent; }
-.tr-row { display: grid; grid-template-columns: auto 1fr auto; align-items: center; gap: 9px; padding: 8px 0; border-top: 1px solid var(--border-soft); }
+.tr-row { padding: 7px 0; border-top: 1px solid var(--border-soft); cursor: pointer; transition: background .12s ease; }
 .tr-row:first-child { border-top: 0; }
+.tr-row:hover { background: color-mix(in srgb, var(--text) 4%, transparent); }
+.tr-row:focus-visible { outline: none; background: color-mix(in srgb, var(--accent) 12%, transparent); }
 .tr-row.flash { animation: flash 1.1s ease; }
+.tr-head { display: grid; grid-template-columns: auto 1fr auto; align-items: center; gap: 9px; }
 .tr-discs { display: inline-flex; align-items: center; gap: 4px; }
 .tr-disc { width: 18px; height: 18px; border-radius: 50%; display: grid; place-items: center; font-size: 9px; font-weight: 600; color: #0a0c10; flex: none; }
 .tr-arrow { color: var(--text-dim); font-size: 10px; }
 .tr-line { min-width: 0; font-size: 11.5px; color: var(--text); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.tr-row.open .tr-line { white-space: normal; overflow: visible; font-weight: 600; }
 .tr-ts { font-size: 10px; color: var(--text-dim); white-space: nowrap; font-variant-numeric: tabular-nums; }
+/* full message — revealed on click. Wrapped, readable, never truncated. */
+.tr-full { display: none; margin: 7px 0 3px 27px; padding: 9px 11px; border-left: 2px solid var(--accent);
+  background: color-mix(in srgb, var(--text) 3%, transparent); border-radius: 0 6px 6px 0; }
+.tr-row.open .tr-full { display: block; }
+.tr-meta { font-size: 10px; color: var(--text-dim); font-variant-numeric: tabular-nums; margin-bottom: 5px; }
+.tr-subj { font-size: 12.5px; font-weight: 600; color: var(--text); margin-bottom: 5px; }
+.tr-body { font-size: 12px; line-height: 1.55; color: var(--text); white-space: pre-wrap; word-break: break-word;
+  max-height: 320px; overflow-y: auto; scrollbar-width: thin; font-family: ui-monospace, "SF Mono", Menlo, monospace; }
 
 /* ---------- phase 3 responsive ---------- */
 @media (max-width: 1080px) {
@@ -903,10 +933,13 @@ button { font-family: inherit; }
 .msg-rail-list { flex: 1; overflow-y: auto; scrollbar-width: thin; scrollbar-color: var(--border) transparent; }
 .msg-rail-row { display: flex; align-items: center; gap: 9px; padding: 9px 12px; cursor: pointer; border-left: 2px solid transparent; }
 .msg-rail-row:hover { background: var(--bg-elev); }
+.msg-rail-row:focus-visible { outline: none; background: var(--bg-elev); border-left-color: var(--accent); }
 .msg-rail-row.on { background: var(--bg-elev); border-left-color: var(--accent); }
 .msg-rail-av, .msg-rail-glyph { width: 26px; height: 26px; flex-shrink: 0; border-radius: 50%; display: inline-flex; align-items: center; justify-content: center; font-size: 11px; font-weight: 700; }
 .msg-rail-av { color: #06120c; }
 .msg-rail-glyph { background: var(--bg-elev); color: var(--text-muted); border: 1px solid var(--border); }
+.msg-rail-glyph.conv { color: var(--accent); border-color: color-mix(in srgb, var(--accent) 40%, transparent); }
+.msg-rail-group { padding: 9px 6px 4px; font-size: 9px; font-weight: 600; letter-spacing: 1.2px; text-transform: uppercase; color: var(--text-dim); }
 .msg-rail-main { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 2px; }
 .msg-rail-name { font-size: 12.5px; color: var(--text); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .msg-rail-n { color: var(--text-dim); font-weight: 600; font-size: 10px; }
@@ -930,7 +963,7 @@ button { font-family: inherit; }
 .msg-pr { font-size: 9px; font-weight: 700; border-radius: 4px; padding: 0 4px; }
 .msg-pr.p0 { color: var(--red); border: 1px solid color-mix(in srgb, var(--red) 40%, transparent); }
 .msg-pr.p1 { color: var(--amber); border: 1px solid color-mix(in srgb, var(--amber) 40%, transparent); }
-.msg-b-body { font-size: 12.5px; color: var(--text); white-space: pre-wrap; word-break: break-word; line-height: 1.5; }
+.msg-b-body { font-size: 12.5px; color: var(--text); white-space: pre-wrap; word-break: break-word; line-height: 1.5; font-family: var(--mono); }
 .msg-composer { display: flex; gap: 8px; padding: 12px 16px; border-top: 1px solid var(--border-soft); align-items: flex-end; }
 .msg-input { flex: 1; resize: none; background: var(--bg-elev); border: 1px solid var(--border); color: var(--text); border-radius: 8px; padding: 9px 11px; font-family: inherit; font-size: 12.5px; line-height: 1.4; max-height: 140px; }
 .msg-input:focus-visible { outline: none; border-color: var(--accent-dim); }


### PR DESCRIPTION
Corporate, demo-ready rework of the team board (deployed live to the obs relay during iteration, owner-validated).

## What
- **Layout**: agents grouped by **team membership** into a bounded grid of team cards (tinted zone + label + count); members in a mini-grid per card. Scales to N teams, no overlap (old reports_to hub-and-spoke crammed at 6+ teams). Multi-team agents show one dot per team.
- **Transcript**: rows expand on click → **full message** (from→to, time, subject, body, wrapped, never truncated); live entries backfill body via debounced reseed. Removed the stray empty-state bar.
- **Messages tab**: new **conversations** rail group (relay multi-agent threads), lazy-loads the thread on select.
- **Type/a11y**: UI chrome → Lexend (corporate sans), `--mono` kept for message bodies/data; focus-visible on message rows; `prefers-reduced-motion` already global.

Pulse/heat/SSE engine untouched — comets still fly between cards.

## Self-review (per standing workflow)
Ran ui-ux-pro-max as the lane review (design-system: Trust & Authority corporate, dark+green WCAG AAA, Lexend). Verified each layout iteration via headless screenshots of a static mock before deploying. No backend/schema/release changes — single-lane frontend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)