### PR TITLE
feat(linear): project→agent auto-dispatch routing (configurable backend)

### DIFF
--- a/internal/connector/linear/graphql.go
+++ b/internal/connector/linear/graphql.go
@@ -152,6 +152,7 @@ const cycleIssuesQuery = `query CycleIssues($cycleId: ID!, $after: String) {
       id identifier number title description priority estimate url
       state { id name type }
       assignee { id name displayName }
+      project { id name }
       parent { id }
       labels { nodes { name } }
     }
@@ -178,7 +179,12 @@ type gqlIssue struct {
 		ID string `json:"id"`
 	} `json:"parent"`
 	ParentID string `json:"parentId"` // webhook flat fallback when parent is not expanded
-	Cycle    *struct {
+	Project  *struct {
+		ID   string `json:"id"`
+		Name string `json:"name"`
+	} `json:"project"`
+	ProjectID string `json:"projectId"` // webhook flat fallback
+	Cycle     *struct {
 		ID       string `json:"id"`
 		Name     string `json:"name"`
 		StartsAt string `json:"startsAt"`

--- a/internal/connector/linear/reconcile.go
+++ b/internal/connector/linear/reconcile.go
@@ -55,9 +55,9 @@ func (c *Connector) ReconcileCycle(_ string) (int, error) {
 		// an agent assignee (first sight in-progress counts: boot-time pickup).
 		if c.onEvent != nil &&
 			iss.State != nil && iss.State.Type == "started" && !looksLikeReview(iss.State.Name) &&
-			isAgent(issueAssignee(iss)) &&
+			(c.hasRoute(iss) || isAgent(issueAssignee(iss))) &&
 			(prior == nil || prior.Status != "in-progress") {
-			c.onEvent(dispatchEvent(c.project, taskID, iss.Title, seed))
+			c.onEvent(c.dispatchEvent(taskID, iss.Title, seed))
 		}
 	}
 

--- a/internal/connector/linear/webhook.go
+++ b/internal/connector/linear/webhook.go
@@ -185,27 +185,27 @@ func (c *Connector) Ingest(payload []byte, sig string) ([]connector.TaskEvent, e
 	// emit when the state actually changed in this update.
 	var events []connector.TaskEvent
 	if c.shouldDispatch(env, iss) {
-		events = append(events, dispatchEvent(c.project, taskID, iss.Title, seed))
+		events = append(events, c.dispatchEvent(taskID, iss.Title, seed))
 	}
 	return events, nil
 }
 
 // dispatchEvent builds the semantic task.in_progress launch event. Shared by
 // the webhook path (Ingest) and the reconcile poll (transition detection).
-func dispatchEvent(project, taskID, title string, seed db.LinearMirrorSeed) connector.TaskEvent {
-	assignee := seedAssignee(seed)
+func (c *Connector) dispatchEvent(taskID, title string, seed db.LinearMirrorSeed) connector.TaskEvent {
+	agent := c.routedAgent(seed)
 	return connector.TaskEvent{
 		Type:    "task.in_progress",
-		Project: project,
-		Agent:   assignee,
+		Project: c.project,
+		Agent:   agent,
 		Payload: map[string]any{
-			"agent":             assignee,
+			"agent":             agent,
 			"task_id":           taskID,
 			"linear_key":        seedLinearKey(seed),
 			"title":             title,
 			"line":              "In progress: " + title,
 			"priority":          seed.Priority,
-			"assignee_is_agent": isAgent(assignee),
+			"assignee_is_agent": isAgent(agent),
 		},
 	}
 }
@@ -227,9 +227,9 @@ func (c *Connector) shouldDispatch(env webhookEnvelope, iss gqlIssue) bool {
 	if !stateChanged(env.UpdatedFrom) {
 		return false
 	}
-	// Must be assigned to an agent (not a human/user).
-	assignee := issueAssignee(iss)
-	return isAgent(assignee)
+	// Dispatch when the issue's project has a configured route (owner-chosen
+	// agent per project) OR it's directly assigned to an agent.
+	return c.hasRoute(iss) || isAgent(issueAssignee(iss))
 }
 
 // stateChanged reports whether updatedFrom carries a prior state (the transition
@@ -275,6 +275,9 @@ func (c *Connector) seedFromIssue(iss gqlIssue) db.LinearMirrorSeed {
 	}
 	if a := issueAssignee(iss); a != "" {
 		seed.Assignee = strptr(a)
+	}
+	if pid := issueProjectID(iss); pid != "" {
+		seed.LinearProjectID = strptr(pid)
 	}
 	if iss.Cycle != nil && iss.Cycle.ID != "" {
 		seed.CycleID = strptr(iss.Cycle.ID)
@@ -324,6 +327,45 @@ func issueAssignee(iss gqlIssue) string {
 		name = iss.Assignee.Name
 	}
 	return strings.ToLower(strings.TrimSpace(name))
+}
+
+func issueProjectID(iss gqlIssue) string {
+	if iss.Project != nil && iss.Project.ID != "" {
+		return iss.Project.ID
+	}
+	return strings.TrimSpace(iss.ProjectID)
+}
+
+// linearRouting reads the owner-configured project→agent map (setting
+// "linear_routing", JSON {linearProjectId: agentName}). Empty when unset.
+func (c *Connector) linearRouting() map[string]string {
+	raw := strings.TrimSpace(c.db.GetSetting("linear_routing"))
+	if raw == "" {
+		return nil
+	}
+	var m map[string]string
+	if err := json.Unmarshal([]byte(raw), &m); err != nil {
+		return nil
+	}
+	return m
+}
+
+// routedAgent resolves the dispatch target: the agent configured for the issue's
+// Linear project (owner-chosen, one per project), falling back to the issue's
+// own assignee when that project has no routing entry.
+func (c *Connector) routedAgent(seed db.LinearMirrorSeed) string {
+	if seed.LinearProjectID != nil {
+		if a := c.linearRouting()[*seed.LinearProjectID]; a != "" {
+			return strings.ToLower(strings.TrimSpace(a))
+		}
+	}
+	return seedAssignee(seed)
+}
+
+// hasRoute reports whether the issue's project has a configured routing target.
+func (c *Connector) hasRoute(iss gqlIssue) bool {
+	pid := issueProjectID(iss)
+	return pid != "" && c.linearRouting()[pid] != ""
 }
 
 func issueKey(iss gqlIssue, teamKey string) string {

--- a/internal/db/linear.go
+++ b/internal/db/linear.go
@@ -17,23 +17,24 @@ import (
 // connector resolves the relay row by linear_issue_id before writing so the
 // stable relay task id is preserved across updates.
 type LinearMirrorSeed struct {
-	Project       string
-	LinearIssueID string // Linear issue UUID — the mirror key
-	LinearKey     *string
-	Title         string
-	Description   string
-	Priority      string
-	Status        string // coarse relay status mapped from the Linear state type
-	ExternalURL   *string
-	Points        *int
-	Labels        string // json array; defaults to "[]"
-	LinearState   *string
-	Assignee      *string
-	CycleID       *string
-	CycleName     *string
-	CycleStart    *string
-	CycleEnd      *string
-	ParentTaskID  *string // relay task id of the parent issue's mirror row
+	Project         string
+	LinearIssueID   string // Linear issue UUID — the mirror key
+	LinearKey       *string
+	Title           string
+	Description     string
+	Priority        string
+	Status          string // coarse relay status mapped from the Linear state type
+	ExternalURL     *string
+	Points          *int
+	Labels          string // json array; defaults to "[]"
+	LinearState     *string
+	Assignee        *string
+	LinearProjectID *string // Linear project UUID — drives project→agent routing (in-memory; not persisted)
+	CycleID         *string
+	CycleName       *string
+	CycleStart      *string
+	CycleEnd        *string
+	ParentTaskID    *string // relay task id of the parent issue's mirror row
 }
 
 // GetTaskByLinearIssueID returns the mirror row for a Linear issue id, or

--- a/internal/relay/api.go
+++ b/internal/relay/api.go
@@ -350,6 +350,7 @@ var writableSettings = map[string]bool{
 	setLinearTeamKey:  true,
 	setLinearProject:  true,
 	setLinearInterval: true,
+	setLinearRouting:  true,
 }
 
 func (r *Relay) apiPutSetting(w http.ResponseWriter, req *http.Request) {

--- a/internal/relay/linear_manager.go
+++ b/internal/relay/linear_manager.go
@@ -17,6 +17,7 @@ const (
 	setLinearTeamKey  = "linear_team_key" // e.g. SYN
 	setLinearProject  = "linear_project"  // relay project hosting the mirror (default: lowercased team key)
 	setLinearInterval = "linear_reconcile_interval"
+	setLinearRouting  = "linear_routing" // JSON {linearProjectId: agentName} — project→agent auto-dispatch
 )
 
 // effectiveLinearConfig resolves the Linear connector configuration: env wins


### PR DESCRIPTION
Backend half of the Linear↔relay auto-dispatch (owner dev strategy). **PR-to-CTO** per merge policy — touches the live Linear connector + cross-surface (not self-merge).

## What
Linear issues auto-dispatch to a relay agent chosen **per project** (owner-configurable), not only by assignee:
- `gqlIssue` + `LinearMirrorSeed` carry the issue's Linear **project id** (GraphQL query + flat webhook fallback).
- New setting **`linear_routing`** = JSON `{linearProjectId: agentName}` (allowlisted). Connector resolves dispatch target = `routing[projectId]`, falling back to the issue assignee when a project has no route.
- `shouldDispatch` / reconcile fire on a started-state transition when the project **has a route** OR the issue is agent-assigned — so project routing works without a per-issue assignee.
- `dispatchEvent` is now a `Connector` method (reads routing via db).

## Not in this PR
- **UI panel** to pick the agent per project (next — needs a `/api/linear/projects` list endpoint + a settings panel).
- **Live wiring**: setting the TSU API key + repointing the connector SYN→TSU (runtime config, done at deploy after review).

Build + vet + connector/db tests green. Engine/SSE untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)