### PR TITLE
feat(linear): relay→Linear backfill (one-shot, dry-run-safe)

### DIFF
--- a/internal/connector/linear/backfill.go
+++ b/internal/connector/linear/backfill.go
@@ -1,0 +1,147 @@
+package linear
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// agentProjectName maps a relay agent/profile to a Linear project NAME (owner's
+// inverse-routing rule). Growth lanes, cto, and unknowns default to the
+// "tsukumo" studio bucket (re-filed later by cmo) — never dropped.
+func agentProjectName(agent string) string {
+	switch strings.ToLower(strings.TrimSpace(agent)) {
+	case "fullstack-trovex":
+		return "trovex"
+	case "wraith-dev":
+		return "wrai.th"
+	case "yoru-dev":
+		return "yoru"
+	case "dokan-core":
+		return "dokan"
+	case "fullstack-lead":
+		return "tsukumo"
+	case "donna-dev":
+		return "donna"
+	default:
+		return "tsukumo"
+	}
+}
+
+// stateIDForType returns the first workflow state id of the given type
+// ("unstarted"/"started"/…), or "" to let Linear pick the team default.
+func (c *Connector) stateIDForType(typ string) string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	for _, s := range c.stateList {
+		if s.Type == typ {
+			return s.ID
+		}
+	}
+	return ""
+}
+
+// BackfillResult summarises a relay→Linear backfill run.
+type BackfillResult struct {
+	DryRun   bool     `json:"dry_run"`
+	Eligible int      `json:"eligible"`
+	Created  int      `json:"created"`
+	Linked   int      `json:"linked"`
+	Errors   []string `json:"errors,omitempty"`
+}
+
+var taskUUIDRe = regexp.MustCompile(`[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}`)
+
+// Backfill mirrors active relay-native tasks INTO Linear as linked issues, so
+// the whole active board shows up in the cockpit. For each eligible task
+// (active, not archived, not already a Linear mirror, not yet linked):
+//   - if an existing open Linear issue's body references this task id (cto's
+//     hand-created TSU-5..12), LINK to it (no duplicate);
+//   - otherwise CREATE an issue in the agent's mapped project, in a state mapped
+//     from the task status (never "started" for a not-started task), and link it.
+//
+// Linking sets linear_issue_id so the next reconcile upsert treats it as a
+// mirror — and because the prior status already matches, the dispatch trigger is
+// skipped (no re-dispatch, the hard invariant). dryRun writes nothing.
+func (c *Connector) Backfill(ctx context.Context, dryRun bool, limit int) (BackfillResult, error) {
+	res := BackfillResult{DryRun: dryRun}
+
+	teamID, projects, err := c.gql.teamMeta(ctx, c.teamKey)
+	if err != nil {
+		return res, fmt.Errorf("team meta: %w", err)
+	}
+
+	// Map relay task id → existing Linear issue (from open-issue descriptions).
+	existing := map[string]gqlIssue{}
+	if issues, err := c.gql.openTeamIssues(ctx, c.teamKey); err == nil {
+		for _, iss := range issues {
+			for _, id := range taskUUIDRe.FindAllString(iss.Description, -1) {
+				if _, dup := existing[id]; !dup {
+					existing[id] = iss
+				}
+			}
+		}
+	}
+
+	tasks, err := c.db.ListBackfillTasks(c.project)
+	if err != nil {
+		return res, err
+	}
+	res.Eligible = len(tasks)
+
+	stateFor := func(status string) string {
+		switch status {
+		case "in-progress", "claimed", "started", "in-review", "review", "blocked":
+			return c.stateIDForType("started")
+		default:
+			return c.stateIDForType("unstarted")
+		}
+	}
+
+	n := 0
+	for _, t := range tasks {
+		if limit > 0 && n >= limit {
+			break
+		}
+		// Link to a pre-existing issue that references this task id.
+		if iss, ok := existing[t.ID]; ok {
+			if !dryRun {
+				if err := c.db.LinkTaskLinear(t.ID, iss.ID, issueKey(iss, c.teamKey)); err != nil {
+					res.Errors = append(res.Errors, t.ID+": link: "+err.Error())
+					continue
+				}
+			}
+			res.Linked++
+			n++
+			continue
+		}
+		// Otherwise create a new linked issue in the mapped project.
+		agent := t.ProfileSlug
+		if t.AssignedTo != nil && *t.AssignedTo != "" {
+			agent = *t.AssignedTo
+		}
+		if dryRun {
+			res.Created++
+			n++
+			continue
+		}
+		title := t.Title
+		if strings.TrimSpace(title) == "" {
+			title = "(untitled relay task)"
+		}
+		desc := strings.TrimSpace(t.Description + "\n\n— relay task " + t.ID)
+		issID, key, err := c.gql.createIssue(ctx, teamID, title, desc, projects[agentProjectName(agent)], stateFor(t.Status))
+		if err != nil {
+			res.Errors = append(res.Errors, t.ID+": create: "+err.Error())
+			continue
+		}
+		if err := c.db.LinkTaskLinear(t.ID, issID, key); err != nil {
+			res.Errors = append(res.Errors, t.ID+": link-after-create: "+err.Error())
+			continue
+		}
+		res.Created++
+		n++
+	}
+	return res, nil
+}

--- a/internal/connector/linear/graphql.go
+++ b/internal/connector/linear/graphql.go
@@ -131,33 +131,7 @@ func (c *graphqlClient) teamStates(ctx context.Context, teamKey string) ([]state
 	return out.Teams.Nodes[0].States.Nodes, nil
 }
 
-// --- active cycle issues (reconcile) ---
-
-// The active-cycle pull is split in two queries to stay under Linear's GraphQL
-// complexity budget (10k): one cheap cycle-meta lookup, then paginated issues.
-// A single nested teams→activeCycle→issues{...} query scores ~20k on a 50-issue
-// cycle and is rejected with "Query too complex".
-const activeCycleQuery = `query ActiveCycle($key: String!) {
-  teams(filter: { key: { eq: $key } }) {
-    nodes {
-      activeCycle { id name startsAt endsAt }
-    }
-  }
-}`
-
-const cycleIssuesQuery = `query CycleIssues($cycleId: ID!, $after: String) {
-  issues(filter: { cycle: { id: { eq: $cycleId } } }, first: 25, after: $after) {
-    pageInfo { hasNextPage endCursor }
-    nodes {
-      id identifier number title description priority estimate url
-      state { id name type }
-      assignee { id name displayName }
-      project { id name }
-      parent { id }
-      labels { nodes { name } }
-    }
-  }
-}`
+// --- open team issues (reconcile) ---
 
 // gqlIssue is the shape returned by the reconcile query (and reused for mapping).
 type gqlIssue struct {
@@ -202,32 +176,32 @@ func (i gqlIssue) parentLinearID() string {
 	return i.ParentID
 }
 
-func (c *graphqlClient) activeCycleIssues(ctx context.Context, teamKey string) ([]gqlIssue, error) {
-	var meta struct {
-		Teams struct {
-			Nodes []struct {
-				ActiveCycle *struct {
-					ID       string `json:"id"`
-					Name     string `json:"name"`
-					StartsAt string `json:"startsAt"`
-					EndsAt   string `json:"endsAt"`
-				} `json:"activeCycle"`
-			} `json:"nodes"`
-		} `json:"teams"`
-	}
-	if err := c.do(ctx, activeCycleQuery, map[string]any{"key": teamKey}, &meta); err != nil {
-		return nil, err
-	}
-	if len(meta.Teams.Nodes) == 0 {
-		return nil, fmt.Errorf("team %q not found", teamKey)
-	}
-	ac := meta.Teams.Nodes[0].ActiveCycle
-	if ac == nil {
-		return nil, nil // no active cycle right now — nothing to heal
-	}
+// teamOpenIssuesQuery pulls all NON-closed issues for a team (any cycle or none),
+// so auto-dispatch covers issues that aren't in the active cycle. Flat issues
+// query (not nested through team→cycle) stays under the complexity budget even
+// with per-issue cycle/project expanded.
+const teamOpenIssuesQuery = `query TeamOpenIssues($key: String!, $after: String) {
+  issues(
+    filter: { team: { key: { eq: $key } }, state: { type: { nin: ["completed", "canceled"] } } }
+    first: 50, after: $after
+  ) {
+    pageInfo { hasNextPage endCursor }
+    nodes {
+      id identifier number title description priority estimate url
+      state { id name type }
+      assignee { id name displayName }
+      project { id name }
+      parent { id }
+      cycle { id name startsAt endsAt }
+      labels { nodes { name } }
+    }
+  }
+}`
 
-	// Page through the cycle's issues (25/page keeps each request well under
-	// the complexity budget; bounded to 40 pages = 1000 issues as a backstop).
+// openTeamIssues returns every open (not completed/canceled) issue in the team,
+// paginated. Used by the reconcile poll so dispatch isn't limited to the active
+// cycle. Bounded to 40 pages (2000 issues) as a backstop.
+func (c *graphqlClient) openTeamIssues(ctx context.Context, teamKey string) ([]gqlIssue, error) {
 	var issues []gqlIssue
 	var after *string
 	for page := 0; page < 40; page++ {
@@ -240,11 +214,11 @@ func (c *graphqlClient) activeCycleIssues(ctx context.Context, teamKey string) (
 				Nodes []gqlIssue `json:"nodes"`
 			} `json:"issues"`
 		}
-		vars := map[string]any{"cycleId": ac.ID}
+		vars := map[string]any{"key": teamKey}
 		if after != nil {
 			vars["after"] = *after
 		}
-		if err := c.do(ctx, cycleIssuesQuery, vars, &out); err != nil {
+		if err := c.do(ctx, teamOpenIssuesQuery, vars, &out); err != nil {
 			return nil, err
 		}
 		issues = append(issues, out.Issues.Nodes...)
@@ -253,19 +227,6 @@ func (c *graphqlClient) activeCycleIssues(ctx context.Context, teamKey string) (
 		}
 		cur := out.Issues.PageInfo.EndCursor
 		after = &cur
-	}
-
-	// Backfill cycle fields onto each issue (the paginated query doesn't expand
-	// the per-issue cycle to keep complexity down — they're all in this cycle).
-	for i := range issues {
-		if issues[i].Cycle == nil {
-			issues[i].Cycle = &struct {
-				ID       string `json:"id"`
-				Name     string `json:"name"`
-				StartsAt string `json:"startsAt"`
-				EndsAt   string `json:"endsAt"`
-			}{ID: ac.ID, Name: ac.Name, StartsAt: ac.StartsAt, EndsAt: ac.EndsAt}
-		}
 	}
 	return issues, nil
 }

--- a/internal/connector/linear/graphql.go
+++ b/internal/connector/linear/graphql.go
@@ -231,6 +231,79 @@ func (c *graphqlClient) openTeamIssues(ctx context.Context, teamKey string) ([]g
 	return issues, nil
 }
 
+// --- team meta (id + projects) for backfill routing ---
+
+const teamMetaQuery = `query TeamMeta($key: String!) {
+  teams(filter: { key: { eq: $key } }) {
+    nodes { id projects(first: 100) { nodes { id name } } }
+  }
+}`
+
+// teamMeta returns the team's id and a name→id map of its projects.
+func (c *graphqlClient) teamMeta(ctx context.Context, teamKey string) (teamID string, projects map[string]string, err error) {
+	var out struct {
+		Teams struct {
+			Nodes []struct {
+				ID       string `json:"id"`
+				Projects struct {
+					Nodes []struct {
+						ID   string `json:"id"`
+						Name string `json:"name"`
+					} `json:"nodes"`
+				} `json:"projects"`
+			} `json:"nodes"`
+		} `json:"teams"`
+	}
+	if err = c.do(ctx, teamMetaQuery, map[string]any{"key": teamKey}, &out); err != nil {
+		return "", nil, err
+	}
+	if len(out.Teams.Nodes) == 0 {
+		return "", nil, fmt.Errorf("team %q not found", teamKey)
+	}
+	projects = map[string]string{}
+	for _, p := range out.Teams.Nodes[0].Projects.Nodes {
+		projects[strings.ToLower(strings.TrimSpace(p.Name))] = p.ID
+	}
+	return out.Teams.Nodes[0].ID, projects, nil
+}
+
+// --- issue create (relay→Linear backfill) ---
+
+const issueCreateMutation = `mutation IssueCreate($input: IssueCreateInput!) {
+  issueCreate(input: $input) { success issue { id identifier } }
+}`
+
+// createIssue creates a Linear issue and returns its id + identifier. teamID is
+// required; projectID/stateID/description are optional (empty omitted).
+func (c *graphqlClient) createIssue(ctx context.Context, teamID, title, description, projectID, stateID string) (id, identifier string, err error) {
+	input := map[string]any{"teamId": teamID, "title": title}
+	if description != "" {
+		input["description"] = description
+	}
+	if projectID != "" {
+		input["projectId"] = projectID
+	}
+	if stateID != "" {
+		input["stateId"] = stateID
+	}
+	var out struct {
+		IssueCreate struct {
+			Success bool `json:"success"`
+			Issue   struct {
+				ID         string `json:"id"`
+				Identifier string `json:"identifier"`
+			} `json:"issue"`
+		} `json:"issueCreate"`
+	}
+	if err = c.do(ctx, issueCreateMutation, map[string]any{"input": input}, &out); err != nil {
+		return "", "", err
+	}
+	if !out.IssueCreate.Success || out.IssueCreate.Issue.ID == "" {
+		return "", "", fmt.Errorf("issueCreate returned success=false")
+	}
+	return out.IssueCreate.Issue.ID, out.IssueCreate.Issue.Identifier, nil
+}
+
 // --- write-back mutations ---
 
 const issueUpdateMutation = `mutation IssueUpdate($id: String!, $stateId: String!) {

--- a/internal/connector/linear/linear_test.go
+++ b/internal/connector/linear/linear_test.go
@@ -315,9 +315,7 @@ func TestReconcileCycle(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		query := readQuery(r)
 		switch {
-		case strings.Contains(query, "ActiveCycle"):
-			writeData(w, `{"teams":{"nodes":[{"activeCycle":{"id":"cyc-1","name":"Cycle 7","startsAt":"2026-06-01T00:00:00Z","endsAt":"2026-06-14T00:00:00Z"}}]}}`)
-		case strings.Contains(query, "CycleIssues"):
+		case strings.Contains(query, "TeamOpenIssues"):
 			writeData(w, `{"issues":{"pageInfo":{"hasNextPage":false,"endCursor":""},"nodes":[
 				{"id":"i-parent","identifier":"SYN-1","number":1,"title":"Parent","priority":2,"estimate":3,"url":"u1","state":{"id":"s1","name":"In Progress","type":"started"},"assignee":{"id":"u1","name":"lead","displayName":"Lead"},"labels":{"nodes":[{"name":"x"}]}},
 				{"id":"i-child","identifier":"SYN-2","number":2,"title":"Child","priority":3,"url":"u2","state":{"id":"s2","name":"Todo","type":"unstarted"},"parent":{"id":"i-parent"},"labels":{"nodes":[]}}

--- a/internal/connector/linear/reconcile.go
+++ b/internal/connector/linear/reconcile.go
@@ -9,15 +9,16 @@ import (
 
 const reconcileTimeout = 30 * time.Second
 
-// ReconcileCycle pulls the team's active cycle and upserts every issue into the
-// mirror, healing missed webhooks. It is idempotent and never touches the relay
-// overlay. The project argument is advisory; rows are stored under the
+// ReconcileCycle pulls all OPEN issues of the team and upserts every issue into
+// the mirror, healing missed webhooks and (without a public webhook endpoint)
+// driving auto-dispatch for ANY open issue — not just the active cycle. It is
+// idempotent and never touches the relay overlay. Rows are stored under the
 // connector's configured project so they stay consistent with webhook upserts.
 func (c *Connector) ReconcileCycle(_ string) (int, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), reconcileTimeout)
 	defer cancel()
 
-	issues, err := c.gql.activeCycleIssues(ctx, c.teamKey)
+	issues, err := c.gql.openTeamIssues(ctx, c.teamKey)
 	if err != nil {
 		return 0, err
 	}
@@ -124,7 +125,7 @@ func (c *Connector) runReconcile() {
 		return
 	}
 	if n > 0 {
-		log.Printf("[linear] reconcile healed %d issue(s) in active cycle", n)
+		log.Printf("[linear] reconcile healed %d open team issue(s)", n)
 	}
 }
 

--- a/internal/db/linear.go
+++ b/internal/db/linear.go
@@ -125,6 +125,48 @@ func (d *DB) UpsertLinearMirror(s LinearMirrorSeed) (taskID string, created bool
 	return id, true, nil
 }
 
+// ListBackfillTasks returns native relay tasks eligible for relay→Linear
+// backfill: active (not done/cancelled), not archived, not already a Linear
+// mirror, and not yet linked to a Linear issue.
+func (d *DB) ListBackfillTasks(project string) ([]models.Task, error) {
+	rows, err := d.ro().Query(
+		"SELECT "+taskColumns+" FROM tasks WHERE project = ? AND archived_at IS NULL "+
+			"AND status NOT IN ('done','cancelled') AND COALESCE(source,'native') != 'linear' "+
+			"AND (linear_issue_id IS NULL OR linear_issue_id = '') ORDER BY dispatched_at ASC",
+		project,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list backfill tasks: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	var tasks []models.Task
+	for rows.Next() {
+		t, err := scanTask(rows)
+		if err != nil {
+			return nil, fmt.Errorf("scan backfill task: %w", err)
+		}
+		tasks = append(tasks, t)
+	}
+	return tasks, rows.Err()
+}
+
+// LinkTaskLinear links an existing native task to a Linear issue (sets the
+// mirror key) without otherwise touching it — the next reconcile upsert then
+// reconciles content. linear_key is only overwritten when non-empty.
+func (d *DB) LinkTaskLinear(taskID, linearIssueID, linearKey string) error {
+	if taskID == "" || linearIssueID == "" {
+		return fmt.Errorf("link task linear: empty id")
+	}
+	_, err := d.conn.Exec(
+		"UPDATE tasks SET linear_issue_id = ?, linear_key = COALESCE(NULLIF(?, ''), linear_key) WHERE id = ?",
+		linearIssueID, linearKey, taskID,
+	)
+	if err != nil {
+		return fmt.Errorf("link task linear: %w", err)
+	}
+	return nil
+}
+
 // MarkLinearDone stamps the overlay's done_at / completed_at when a Done webhook
 // echoes back (the one inbound exception that touches the overlay — Linear owns
 // Done via the GitHub PR-merge auto-close). Idempotent: only stamps if unset.

--- a/internal/relay/api.go
+++ b/internal/relay/api.go
@@ -180,6 +180,8 @@ func (r *Relay) ServeAPI(w http.ResponseWriter, req *http.Request) {
 	case path == "/notification-events" && req.Method == http.MethodPost:
 		r.apiEmitNotificationEvent(w, req)
 	// Linear connector inbound webhook (404s unless the connector is active).
+	case path == "/connectors/linear/backfill" && req.Method == http.MethodPost:
+		r.apiLinearBackfill(w, req)
 	case path == "/connectors/linear/webhook" && req.Method == http.MethodPost:
 		r.apiLinearWebhook(w, req)
 	case path == "/linear/teams" && req.Method == http.MethodGet:

--- a/internal/relay/linear_webhook.go
+++ b/internal/relay/linear_webhook.go
@@ -4,12 +4,32 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"strconv"
 	"strings"
 
 	"agent-relay/internal/connector"
 	linearconn "agent-relay/internal/connector/linear"
 	"agent-relay/internal/models"
 )
+
+// apiLinearBackfill triggers the one-shot relay→Linear backfill (creates linked
+// issues for active relay-native tasks). Safe by default: DRY-RUN unless
+// ?dry_run=0 is passed. Loopback/admin only (behind the auth chain).
+func (r *Relay) apiLinearBackfill(w http.ResponseWriter, req *http.Request) {
+	conn := r.LinearConnector()
+	if conn == nil {
+		apiError(w, http.StatusBadRequest, "linear connector not active", nil)
+		return
+	}
+	dryRun := req.URL.Query().Get("dry_run") != "0" // default true
+	limit, _ := strconv.Atoi(req.URL.Query().Get("limit"))
+	res, err := conn.Backfill(req.Context(), dryRun, limit)
+	if err != nil {
+		apiError(w, http.StatusInternalServerError, "backfill failed", err)
+		return
+	}
+	writeJSON(w, res)
+}
 
 // apiLinearWebhook handles POST /api/connectors/linear/webhook.
 //


### PR DESCRIPTION
PR-to-CTO. Backfills active relay-native tasks into Linear as LINKED issues (owner's full-cockpit). New issueCreate + teamMeta; agent→project inverse-routing (growth/cto→tsukumo); state mapped from status (no re-dispatch invariant); links to pre-existing TSU-5..12 by task-id-in-body, no dupes; idempotent. Trigger POST /api/connectors/linear/backfill — **dry-run by default**, ?dry_run=0 to write. Dry-run verified live: 24 eligible. RUN gated on the rotated full-API key in ENV. Build+vet+tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)