### PR TITLE
fix(linear): poll only mirrors issues in a routed project

### DIFF
--- a/internal/connector/linear/linear_test.go
+++ b/internal/connector/linear/linear_test.go
@@ -312,13 +312,16 @@ func TestReconcileCycle(t *testing.T) {
 	database := newTestDB(t)
 	c := newTestConn(t, database)
 
+	// Issues must be in a ROUTED project to be mirrored (scope guard).
+	database.SetSetting("linear_routing", `{"proj-1":"lead"}`)
+
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		query := readQuery(r)
 		switch {
 		case strings.Contains(query, "TeamOpenIssues"):
 			writeData(w, `{"issues":{"pageInfo":{"hasNextPage":false,"endCursor":""},"nodes":[
-				{"id":"i-parent","identifier":"SYN-1","number":1,"title":"Parent","priority":2,"estimate":3,"url":"u1","state":{"id":"s1","name":"In Progress","type":"started"},"assignee":{"id":"u1","name":"lead","displayName":"Lead"},"labels":{"nodes":[{"name":"x"}]}},
-				{"id":"i-child","identifier":"SYN-2","number":2,"title":"Child","priority":3,"url":"u2","state":{"id":"s2","name":"Todo","type":"unstarted"},"parent":{"id":"i-parent"},"labels":{"nodes":[]}}
+				{"id":"i-parent","identifier":"SYN-1","number":1,"title":"Parent","priority":2,"estimate":3,"url":"u1","state":{"id":"s1","name":"In Progress","type":"started"},"assignee":{"id":"u1","name":"lead","displayName":"Lead"},"project":{"id":"proj-1","name":"wrai.th"},"labels":{"nodes":[{"name":"x"}]}},
+				{"id":"i-child","identifier":"SYN-2","number":2,"title":"Child","priority":3,"url":"u2","state":{"id":"s2","name":"Todo","type":"unstarted"},"parent":{"id":"i-parent"},"project":{"id":"proj-1","name":"wrai.th"},"labels":{"nodes":[]}}
 			]}}`)
 		default:
 			writeData(w, `{}`)

--- a/internal/connector/linear/reconcile.go
+++ b/internal/connector/linear/reconcile.go
@@ -37,6 +37,12 @@ func (c *Connector) ReconcileCycle(_ string) (int, error) {
 		if iss.ID == "" {
 			continue
 		}
+		// Scope: only mirror/dispatch issues in a ROUTED project. Skips Linear's
+		// project-less team defaults (onboarding TSU-1..4) and any unrouted
+		// project — they were polluting the relay board as noise.
+		if !c.hasRoute(iss) {
+			continue
+		}
 		prior, _ := c.db.GetTaskByLinearIssueID(c.project, iss.ID)
 		seed := c.seedFromIssue(iss)
 		taskID, _, err := c.db.UpsertLinearMirror(seed)


### PR DESCRIPTION
Reconcile skipped project-less onboarding issues (TSU-1..4) that #76 was mirroring as noise — now only issues in a routed project (hasRoute) mirror+dispatch. Test updated. 🤖 Generated with [Claude Code](https://claude.com/claude-code)