### PR TITLE
feat(relay): host relay-send forwarder + loopback /api/send

### DIFF
--- a/internal/cli/forward.go
+++ b/internal/cli/forward.go
@@ -1,0 +1,74 @@
+package cli
+
+import (
+	"bytes"
+	"crypto/subtle"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+// RunForwarder is the minimal HOST relay-send forwarder. dokan monitors run in
+// containers and can't reach the relay's loopback bind; instead of opening the
+// relay to the network, this tiny 2-verb, token-gated proxy listens on a
+// docker-bridge-reachable address and forwards to the loopback relay. Surface is
+// intentionally minimal — only /send and /event — so the backbone stays closed.
+//
+// Env: FORWARDER_TOKEN (required), FORWARDER_PORT (default 8092),
+// RELAY_URL (default http://127.0.0.1:8090).
+func RunForwarder() {
+	token := strings.TrimSpace(os.Getenv("FORWARDER_TOKEN"))
+	if token == "" {
+		log.Fatal("FORWARDER_TOKEN is required (the shared secret monitors must present)")
+	}
+	port := os.Getenv("FORWARDER_PORT")
+	if port == "" {
+		port = "8092"
+	}
+	relay := os.Getenv("RELAY_URL")
+	if relay == "" {
+		relay = "http://127.0.0.1:8090"
+	}
+	client := &http.Client{Timeout: 10 * time.Second}
+
+	authed := func(r *http.Request) bool {
+		got := strings.TrimSpace(strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer "))
+		return subtle.ConstantTimeCompare([]byte(got), []byte(token)) == 1
+	}
+	// forward maps a forwarder verb to a relay loopback endpoint.
+	forward := func(relayPath string) http.HandlerFunc {
+		return func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodPost {
+				http.Error(w, `{"error":"POST only"}`, http.StatusMethodNotAllowed)
+				return
+			}
+			if !authed(r) {
+				http.Error(w, `{"error":"unauthorized"}`, http.StatusUnauthorized)
+				return
+			}
+			body, _ := io.ReadAll(io.LimitReader(r.Body, 1<<20))
+			resp, err := client.Post(relay+relayPath, "application/json", bytes.NewReader(body))
+			if err != nil {
+				http.Error(w, `{"error":"relay unreachable"}`, http.StatusBadGateway)
+				return
+			}
+			defer func() { _ = resp.Body.Close() }()
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(resp.StatusCode)
+			_, _ = io.Copy(w, resp.Body)
+		}
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/send", forward("/api/send"))                 // {from,to,priority,content}
+	mux.HandleFunc("/event", forward("/api/notification-events")) // {event,payload}
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) { _, _ = w.Write([]byte("ok\n")) })
+
+	addr := "0.0.0.0:" + port
+	log.Printf("[forwarder] relay-send forwarder on %s → %s (verbs: /send, /event)", addr, relay)
+	srv := &http.Server{Addr: addr, Handler: mux, ReadHeaderTimeout: 10 * time.Second}
+	log.Fatal(srv.ListenAndServe())
+}

--- a/internal/relay/api.go
+++ b/internal/relay/api.go
@@ -73,6 +73,8 @@ func (r *Relay) ServeAPI(w http.ResponseWriter, req *http.Request) {
 		r.apiGetLatestMessages(w, req)
 	case path == "/user-response" && req.Method == http.MethodPost:
 		r.apiPostUserResponse(w, req)
+	case path == "/send" && req.Method == http.MethodPost:
+		r.apiPostSend(w, req)
 	// Memory endpoints
 	case path == "/memories" && req.Method == http.MethodGet:
 		r.apiGetMemories(w, req)
@@ -758,6 +760,49 @@ func (r *Relay) apiPostUserResponse(w http.ResponseWriter, req *http.Request) {
 	// Push notification to the target agent
 	r.Registry.Notify(body.Project, body.To, "user", "User response", msg.ID)
 
+	writeJSON(w, map[string]any{"ok": true, "message_id": msg.ID})
+}
+
+// apiPostSend is a generic loopback send (from/to/priority/content) used by the
+// host relay-send forwarder so dokan monitors can deliver messages without
+// reaching the loopback relay directly. Single recipient (the monitor→agent
+// case); broadcast/team can be added if needed.
+func (r *Relay) apiPostSend(w http.ResponseWriter, req *http.Request) {
+	var body struct {
+		Project  string `json:"project"`
+		From     string `json:"from"`
+		To       string `json:"to"`
+		Priority string `json:"priority"`
+		Subject  string `json:"subject"`
+		Content  string `json:"content"`
+	}
+	if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
+		http.Error(w, `{"error":"invalid json"}`, http.StatusBadRequest)
+		return
+	}
+	if body.To == "" || body.Content == "" {
+		http.Error(w, `{"error":"to and content are required"}`, http.StatusBadRequest)
+		return
+	}
+	if body.Project == "" {
+		body.Project = "trovex-growth"
+	}
+	if body.From == "" {
+		body.From = "monitor"
+	}
+	if body.Priority == "" {
+		body.Priority = "P2"
+	}
+	subject := body.Subject
+	if subject == "" {
+		subject = body.Content
+	}
+	msg, err := r.DB.InsertMessageWithDeliveries(body.Project, body.From, body.To, "notification", subject, body.Content, "{}", body.Priority, 14400, nil, nil, []string{body.To})
+	if err != nil {
+		apiError(w, http.StatusInternalServerError, "send failed", err)
+		return
+	}
+	r.Registry.Notify(body.Project, body.To, body.From, subject, msg.ID)
 	writeJSON(w, map[string]any{"ok": true, "message_id": msg.ID})
 }
 

--- a/main.go
+++ b/main.go
@@ -39,6 +39,9 @@ func main() {
 		case "mcp":
 			startStdioMCP()
 			return
+		case "forward":
+			cli.RunForwarder()
+			return
 		case "init", "update", "status", "agents", "inbox", "send", "thread", "stats", "conversations", "memories":
 			cli.Run(os.Args[1:])
 			return


### PR DESCRIPTION
Minimal HOST forwarder ('agent-relay forward'): 2-verb token-gated proxy (docker-bridge-reachable) → loopback relay. /send→/api/send, /event→/api/notification-events. Backbone stays loopback-only. + generic loopback /api/send. One bridge for all dokan monitors. Build+vet+tests green. 🤖 Generated with [Claude Code](https://claude.com/claude-code)