### PR TITLE
fix(brand): purge Synergix-lab → TsukumoHQ/WRAI.TH (last live public leak + broken install/auto-update)

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,5 +4,5 @@ contact_links:
     url: https://discord.gg/QPq7qfbEk8
     about: Ask questions and discuss ideas with the community
   - name: Documentation
-    url: https://github.com/Synergix-lab/WRAI.TH#readme
+    url: https://github.com/TsukumoHQ/WRAI.TH#readme
     about: Check the README for setup and usage guides

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,10 +141,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versions follow 
 
 Initial public release — MCP relay server with SQLite persistence, canvas UI, pixel art galaxy/colony views, vault indexing, CI/CD with cross-platform binary builds.
 
-[0.7.0]: https://github.com/Synergix-lab/WRAI.TH/compare/v0.5.0...v0.7.0
-[0.5.0]: https://github.com/Synergix-lab/WRAI.TH/compare/v0.4.0...v0.5.0
-[0.4.0]: https://github.com/Synergix-lab/WRAI.TH/compare/v0.3.0...v0.4.0
-[0.3.0]: https://github.com/Synergix-lab/WRAI.TH/compare/v0.2.1...v0.3.0
-[0.2.1]: https://github.com/Synergix-lab/WRAI.TH/compare/v0.2.0...v0.2.1
-[0.2.0]: https://github.com/Synergix-lab/WRAI.TH/compare/v0.1.1...v0.2.0
-[0.1.1]: https://github.com/Synergix-lab/WRAI.TH/releases/tag/v0.1.1
+[0.7.0]: https://github.com/TsukumoHQ/WRAI.TH/compare/v0.5.0...v0.7.0
+[0.5.0]: https://github.com/TsukumoHQ/WRAI.TH/compare/v0.4.0...v0.5.0
+[0.4.0]: https://github.com/TsukumoHQ/WRAI.TH/compare/v0.3.0...v0.4.0
+[0.3.0]: https://github.com/TsukumoHQ/WRAI.TH/compare/v0.2.1...v0.3.0
+[0.2.1]: https://github.com/TsukumoHQ/WRAI.TH/compare/v0.2.0...v0.2.1
+[0.2.0]: https://github.com/TsukumoHQ/WRAI.TH/compare/v0.1.1...v0.2.0
+[0.1.1]: https://github.com/TsukumoHQ/WRAI.TH/releases/tag/v0.1.1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Thanks for your interest in contributing! Here's how to get started.
 
 ```bash
 # Clone
-git clone https://github.com/Synergix-lab/WRAI.TH.git
+git clone https://github.com/TsukumoHQ/WRAI.TH.git
 cd WRAI.TH
 
 # Build (requires Go 1.23+ and a C compiler for CGO/SQLite)
@@ -37,7 +37,7 @@ install.ps1   Windows installer
 
 ### 1. Start with an issue
 
-Before writing code, open a [Feature Request](https://github.com/Synergix-lab/WRAI.TH/issues/new?template=feature.yml). Describe:
+Before writing code, open a [Feature Request](https://github.com/TsukumoHQ/WRAI.TH/issues/new?template=feature.yml). Describe:
 - The problem or friction you're hitting
 - Your proposed solution
 - Which component is affected (MCP tools, UI, memory, tasks, etc.)
@@ -97,7 +97,7 @@ A maintainer will review. We aim for fast turnaround. Once approved, the PR is s
 
 ## What to work on
 
-- Check [open issues](https://github.com/Synergix-lab/WRAI.TH/issues) — look for `good first issue` labels
+- Check [open issues](https://github.com/TsukumoHQ/WRAI.TH/issues) — look for `good first issue` labels
 - Join the [Discord](https://discord.gg/QPq7qfbEk8) to discuss ideas
 - The MCP tools were designed by agents themselves — if you use the relay and hit friction, that's a valid feature request
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Stop babysitting one chat. Run a *fleet* -- agents that remember across sessions
 
 <br>
 
-[![Release](https://img.shields.io/badge/v1.0.0-Stable-2ecc71?style=for-the-badge)](https://github.com/Synergix-lab/WRAI.TH/releases/tag/v1.0.0)
+[![Release](https://img.shields.io/badge/v1.0.0-Stable-2ecc71?style=for-the-badge)](https://github.com/TsukumoHQ/WRAI.TH/releases/tag/v1.0.0)
 [![Go](https://img.shields.io/badge/Go-00ADD8?style=for-the-badge&logo=go&logoColor=white)](https://go.dev)
 [![MCP](https://img.shields.io/badge/MCP-Protocol-8A2BE2?style=for-the-badge)](https://modelcontextprotocol.io)
 [![SQLite](https://img.shields.io/badge/SQLite-FTS5-003B57?style=for-the-badge&logo=sqlite&logoColor=white)](https://www.sqlite.org)
@@ -56,10 +56,10 @@ And you're never flying blind: the **mission-control dashboard** ([below](#-the-
 Don't read the rest of this page. Open **Claude Code** inside the repo you want to manage, paste this, and let it wire everything up:
 
 ```text
-Set up wrai.th (https://github.com/Synergix-lab/WRAI.TH) in this repo, end to end:
+Set up wrai.th (https://github.com/TsukumoHQ/WRAI.TH) in this repo, end to end:
 
 1. Install it — run:
-   curl -fsSL https://raw.githubusercontent.com/Synergix-lab/WRAI.TH/main/install.sh | bash
+   curl -fsSL https://raw.githubusercontent.com/TsukumoHQ/WRAI.TH/main/install.sh | bash
    (builds the binary, starts the relay on localhost:8090, installs the /relay skill)
 2. Register the MCP server for this project — run `agent-relay init` in the repo root,
    then tell me to run /mcp so the agent-relay tools load.
@@ -79,7 +79,7 @@ A couple of minutes later: relay running, your codebase analyzed, and a crew of 
 ## &#x1F4E6; Install
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/Synergix-lab/WRAI.TH/main/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/TsukumoHQ/WRAI.TH/main/install.sh | bash
 ```
 
 The installer checks dependencies, builds from source (Go + GCC) or falls back to prebuilt, sets up auto-start, installs the `/relay` skill, and configures your projects. Existing `.mcp.json` files are merged (never overwritten) with a `.bak` backup.
@@ -88,7 +88,7 @@ The installer checks dependencies, builds from source (Go + GCC) or falls back t
 <summary><b>Build from source</b></summary>
 
 ```bash
-git clone https://github.com/Synergix-lab/WRAI.TH.git && cd WRAI.TH
+git clone https://github.com/TsukumoHQ/WRAI.TH.git && cd WRAI.TH
 CGO_ENABLED=1 go build -tags fts5 -o agent-relay .
 ./agent-relay serve
 ```
@@ -185,7 +185,7 @@ create_project({ name: "my-app", cwd: "/path/to/repo", interactive: true })
 
 ## &#x2728; How It Works
 
-Most of the 58 MCP tools weren't designed by a human. Multiple teams of agents at [synergix-lab](https://github.com/synergix-lab) ran Q&A sessions directly on the wrai.th codebase -- identifying what they needed to work better as a team. Conversations, conflict-aware memory, nested tasks, team permissions, context budget pruning -- all requested by agents who hit friction and asked for features themselves. The relay is shaped by its own users.
+Most of the 58 MCP tools weren't designed by a human. Multiple teams of agents at [TsukumoHQ](https://github.com/TsukumoHQ) ran Q&A sessions directly on the wrai.th codebase -- identifying what they needed to work better as a team. Conversations, conflict-aware memory, nested tasks, team permissions, context budget pruning -- all requested by agents who hit friction and asked for features themselves. The relay is shaped by its own users.
 
 <table>
 <tr>
@@ -932,12 +932,12 @@ Pairs with **trovex** (one canonical doc per query, fewer tokens) and **yoru** (
 
 Opinionated tooling built for a specific workflow. Moves fast.
 
-Something breaks? [Open an issue](https://github.com/Synergix-lab/WRAI.TH/issues). Want to contribute? [Open a PR](https://github.com/Synergix-lab/WRAI.TH/pulls).
+Something breaks? [Open an issue](https://github.com/TsukumoHQ/WRAI.TH/issues). Want to contribute? [Open a PR](https://github.com/TsukumoHQ/WRAI.TH/pulls).
 
 **Stack:** Go 1.25+, SQLite FTS5 (`github.com/mattn/go-sqlite3`, CGO), `mcp-go`, Vanilla JS ES modules (v2 dashboard SPA + legacy canvas)
 
 ```bash
-git clone https://github.com/Synergix-lab/WRAI.TH.git
+git clone https://github.com/TsukumoHQ/WRAI.TH.git
 cd WRAI.TH
 CGO_ENABLED=1 go build -tags fts5 -o agent-relay .
 ./agent-relay serve
@@ -963,10 +963,10 @@ Built and run in production by [tsukumo](https://tsukumo.ch), a developer studio
 
 <div align="center">
 
-Built at [synergix-lab](https://github.com/synergix-lab) · AGPL-3.0 License
+Built at [TsukumoHQ](https://github.com/TsukumoHQ) · AGPL-3.0 License
 
 Built by the team behind [tsukumo](https://tsukumo.ch/?utm_source=wraith&utm_medium=oss-suite&utm_campaign=consulting&utm_content=footer) -- consulting for teams running AI agent fleets.
 
-<!-- [![Star History Chart](https://api.star-history.com/svg?repos=synergix-lab/agent-relay&type=Date)](https://star-history.com/#synergix-lab/agent-relay&Date) -->
+<!-- [![Star History Chart](https://api.star-history.com/svg?repos=TsukumoHQ/WRAI.TH&type=Date)](https://star-history.com/#TsukumoHQ/WRAI.TH&Date) -->
 
 </div>

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,7 +13,7 @@
 
 Use one of these channels:
 
-1. **GitHub Security Advisories** (preferred) — use the "Report a vulnerability" button on the [Security tab](https://github.com/Synergix-lab/WRAI.TH/security/advisories/new)
+1. **GitHub Security Advisories** (preferred) — use the "Report a vulnerability" button on the [Security tab](https://github.com/TsukumoHQ/WRAI.TH/security/advisories/new)
 2. **Email** — security@wrai.th
 
 Please include:

--- a/install.ps1
+++ b/install.ps1
@@ -14,7 +14,7 @@
 .PARAMETER Uninstall
     Remove relay, service, and skill
 .EXAMPLE
-    irm https://raw.githubusercontent.com/Synergix-lab/WRAI.TH/main/install.ps1 | iex
+    irm https://raw.githubusercontent.com/TsukumoHQ/WRAI.TH/main/install.ps1 | iex
     .\install.ps1 -Port 9000 -SkipProjects
     .\install.ps1 -Uninstall
 #>
@@ -27,7 +27,7 @@ param(
 
 $ErrorActionPreference = "Stop"
 
-$Repo = "Synergix-lab/WRAI.TH"
+$Repo = "TsukumoHQ/WRAI.TH"
 $BinaryName = "agent-relay.exe"
 $TaskName = "AgentRelay"
 $InstallDir = Join-Path $env:LOCALAPPDATA "AgentRelay"

--- a/install.sh
+++ b/install.sh
@@ -3,11 +3,11 @@ set -euo pipefail
 
 # Claude Agentic Relay — Cross-platform installer (macOS + Linux)
 # Usage:
-#   curl -fsSL https://raw.githubusercontent.com/Synergix-lab/WRAI.TH/main/install.sh | bash
+#   curl -fsSL https://raw.githubusercontent.com/TsukumoHQ/WRAI.TH/main/install.sh | bash
 #   curl -fsSL ... | bash -s -- --port 9000 --skip-projects --no-service
 #   ./install.sh --uninstall
 
-REPO="Synergix-lab/WRAI.TH"
+REPO="TsukumoHQ/WRAI.TH"
 BINARY_NAME="agent-relay"
 SERVICE_LABEL="com.agent-relay"
 DEFAULT_PORT=8090
@@ -967,7 +967,7 @@ EOF
 $relay_marker
 ## Agent Relay
 
-This project uses [Agent Relay](https://github.com/Synergix-lab/WRAI.TH) for multi-agent coordination.
+This project uses [Agent Relay](https://github.com/TsukumoHQ/WRAI.TH) for multi-agent coordination.
 
 - Use \`/relay\` to check inbox, send messages, dispatch tasks, and run autonomous work loops
 - Use \`/relay create_project\` to set up the full colony (teams, goals, profiles, sprint tasks)

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -25,7 +25,7 @@ type githubRelease struct {
 }
 
 const (
-	repo         = "Synergix-lab/WRAI.TH"
+	repo         = "TsukumoHQ/WRAI.TH"
 	releaseAPI   = "https://api.github.com/repos/" + repo + "/releases/latest"
 	serviceLabel = "com.agent-relay"
 	binaryName   = "agent-relay"

--- a/internal/relay/handlers.go
+++ b/internal/relay/handlers.go
@@ -701,7 +701,7 @@ func (h *Handlers) buildSessionContext(project, agentName string, profileSlug *s
 		result["memories_omitted"] = len(memories) - len(projectedMems)
 	}
 
-	// Vault/doc context is served externally (ctx.prod.synergix.ch), not injected here.
+	// Vault/doc context is served externally (the doc-context host), not injected here.
 
 	return result
 }

--- a/llms.txt
+++ b/llms.txt
@@ -14,8 +14,8 @@
 - MCP server: works with any MCP client; local-first (Go, SQLite FTS5).
 
 ## Links
-- [Repository](https://github.com/Synergix-lab/WRAI.TH): source (AGPL-3.0).
-- [Releases](https://github.com/Synergix-lab/WRAI.TH/releases): install the CLI.
+- [Repository](https://github.com/TsukumoHQ/WRAI.TH): source (AGPL-3.0).
+- [Releases](https://github.com/TsukumoHQ/WRAI.TH/releases): install the CLI.
 - [Discord](https://discord.gg/QPq7qfbEk8): community.
 
 ## Part of the suite (built by tsukumo)


### PR DESCRIPTION
Repo moved org; README/docs + **install.sh / install.ps1 / the auto-updater** still pointed at the dead `Synergix-lab` org. Public brand leak on the flagship repo + functional break (install fetched wrong org, self-updater checked wrong releases). Repointed all 31 refs → `TsukumoHQ/WRAI.TH`, neutralized stale `ctx.prod.synergix.ch` comment. Zero synergix left. Build+vet green. Single-lane (wraith), self-merge v2. 🤖 Generated with [Claude Code](https://claude.com/claude-code)