### PR TITLE
fix(routing): skill→profile dispatch dead from column/scan mismatch

### DIFF
--- a/internal/db/skills.go
+++ b/internal/db/skills.go
@@ -123,9 +123,13 @@ func (d *DB) GetSkillByName(project, name string) (*models.Skill, error) {
 
 // FindProfilesBySkill returns profiles linked to a specific skill via the structured registry.
 func (d *DB) FindProfilesBySkill(project, skillName string) ([]models.Profile, error) {
+	// Column list MUST match scanProfile's destinations. It previously selected a
+	// richer 15-column set (context_pack, soul_keys, …) that scanProfile doesn't
+	// read, so every row failed to scan and was silently skipped — making the
+	// structured skill→profile routing dead-on-arrival the moment any profile_skills
+	// link existed. Select exactly profileColumns, aliased to p.
 	rows, err := d.ro().Query(
-		`SELECT p.id, p.slug, p.name, p.role, p.context_pack, p.soul_keys, p.skills, p.vault_paths,
-		 p.allowed_tools, p.pool_size, COALESCE(p.exit_prompt, ''), p.project, p.org_id, p.created_at, p.updated_at
+		`SELECT p.id, p.slug, p.name, p.role, p.skills, p.project, p.org_id, p.created_at, p.updated_at
 		 FROM profiles p
 		 JOIN profile_skills ps ON ps.profile_id = p.id
 		 JOIN skills s ON s.id = ps.skill_id
@@ -142,7 +146,9 @@ func (d *DB) FindProfilesBySkill(project, skillName string) ([]models.Profile, e
 	for rows.Next() {
 		p, err := scanProfile(rows)
 		if err != nil {
-			continue
+			// Surface scan errors instead of silently skipping — a swallowed
+			// mismatch here is exactly what killed routing before.
+			return nil, fmt.Errorf("scan profile by skill: %w", err)
 		}
 		profiles = append(profiles, p)
 	}

--- a/internal/db/skills_test.go
+++ b/internal/db/skills_test.go
@@ -1,0 +1,58 @@
+package db
+
+import "testing"
+
+// TestFindBestProfileForSkill_StructuredRegistry guards the skill→profile routing
+// regression: FindProfilesBySkill once selected a 15-column set that scanProfile
+// couldn't scan, so every joined row was silently skipped and structured
+// dispatch-by-skill returned nothing the moment a profile_skills link existed.
+// This test creates real links and asserts the expert profile is picked.
+func TestFindBestProfileForSkill_StructuredRegistry(t *testing.T) {
+	d := testDB(t)
+	const project = "p1"
+
+	capable, err := d.RegisterProfile(project, "capable-agent", "Capable", "eng", "[]")
+	if err != nil {
+		t.Fatalf("register capable: %v", err)
+	}
+	expert, err := d.RegisterProfile(project, "expert-agent", "Expert", "eng", "[]")
+	if err != nil {
+		t.Fatalf("register expert: %v", err)
+	}
+
+	skill, err := d.UpsertSkill(project, "go", "Go programming", `["go","backend"]`)
+	if err != nil {
+		t.Fatalf("upsert skill: %v", err)
+	}
+
+	if err := d.LinkProfileSkill(capable.ID, skill.ID, "capable"); err != nil {
+		t.Fatalf("link capable: %v", err)
+	}
+	if err := d.LinkProfileSkill(expert.ID, skill.ID, "expert"); err != nil {
+		t.Fatalf("link expert: %v", err)
+	}
+
+	// Structured registry must return BOTH, expert ordered first.
+	profiles, err := d.FindProfilesBySkill(project, "go")
+	if err != nil {
+		t.Fatalf("FindProfilesBySkill: %v", err)
+	}
+	if len(profiles) != 2 {
+		t.Fatalf("want 2 profiles linked to skill, got %d (the column/scan mismatch swallows rows)", len(profiles))
+	}
+	if profiles[0].Slug != "expert-agent" {
+		t.Fatalf("want expert-agent first (expert > capable ordering), got %q", profiles[0].Slug)
+	}
+
+	// FindBestProfileForSkill is what the dispatch handler calls.
+	best, err := d.FindBestProfileForSkill(project, "go")
+	if err != nil {
+		t.Fatalf("FindBestProfileForSkill: %v", err)
+	}
+	if best == nil {
+		t.Fatal("dispatch-by-skill returned nil — structured routing is dead")
+	}
+	if best.Slug != "expert-agent" {
+		t.Fatalf("want expert-agent, got %q", best.Slug)
+	}
+}


### PR DESCRIPTION
FindProfilesBySkill selected 15 columns but scanProfile scans 9 → every row failed to scan and was silently `continue`d → structured dispatch-by-skill returned empty the moment a profile_skills link existed (latent only because profile_skills is empty today). Fix: select profileColumns (p.-aliased) + return scan errors instead of swallowing. Regression test (expert > capable routing) added — fails pre-fix, passes post. Single-lane wraith, build+vet+test green. 🤖 Generated with [Claude Code](https://claude.com/claude-code)