### PR TITLE
fix(tasks): close transitionTask TOCTOU — CAS on status guards double-claim

### DIFF
--- a/internal/db/tasks.go
+++ b/internal/db/tasks.go
@@ -171,9 +171,15 @@ func (d *DB) transitionTask(taskID, agentName, project, newStatus string, result
 	// blocked closes the open blocked window in the auto-stamped trail.
 	leavingBlocked := task.Status == "blocked" && newStatus != "blocked"
 
+	// oldStatus is the value we validated against; every UPDATE below carries a
+	// compare-and-swap guard (AND status = oldStatus) so the write only lands if
+	// the row hasn't changed since GetTask read it.
+	oldStatus := task.Status
+
 	// Build update. Every transition auto-stamps its temporal trail with zero
 	// manual input.
 	task.Status = newStatus
+	var res sql.Result
 	switch newStatus {
 	case "pending":
 		task.AssignedTo = nil
@@ -187,9 +193,9 @@ func (d *DB) transitionTask(taskID, agentName, project, newStatus string, result
 		task.InReviewAt = nil
 		task.DoneAt = nil
 		task.BlockedPeriods = "[]"
-		_, err = d.conn.Exec(
-			"UPDATE tasks SET status = ?, assigned_to = NULL, accepted_at = NULL, started_at = NULL, completed_at = NULL, result = NULL, blocked_reason = NULL, claimed_by = NULL, claimed_at = NULL, in_review_at = NULL, done_at = NULL, blocked_periods = '[]' WHERE id = ? AND project = ?",
-			newStatus, taskID, project,
+		res, err = d.conn.Exec(
+			"UPDATE tasks SET status = ?, assigned_to = NULL, accepted_at = NULL, started_at = NULL, completed_at = NULL, result = NULL, blocked_reason = NULL, claimed_by = NULL, claimed_at = NULL, in_review_at = NULL, done_at = NULL, blocked_periods = '[]' WHERE id = ? AND project = ? AND status = ?",
+			newStatus, taskID, project, oldStatus,
 		)
 	case "accepted":
 		// claim → claimed_at + claimed_by (also sets assigned_to + accepted_at)
@@ -197,9 +203,9 @@ func (d *DB) transitionTask(taskID, agentName, project, newStatus string, result
 		task.AcceptedAt = &now
 		task.ClaimedBy = &agentName
 		task.ClaimedAt = &now
-		_, err = d.conn.Exec(
-			"UPDATE tasks SET status = ?, assigned_to = ?, accepted_at = ?, claimed_by = ?, claimed_at = ? WHERE id = ? AND project = ?",
-			newStatus, agentName, now, agentName, now, taskID, project,
+		res, err = d.conn.Exec(
+			"UPDATE tasks SET status = ?, assigned_to = ?, accepted_at = ?, claimed_by = ?, claimed_at = ? WHERE id = ? AND project = ? AND status = ?",
+			newStatus, agentName, now, agentName, now, taskID, project, oldStatus,
 		)
 	case "in-progress":
 		// start → started_at (and close any open blocked window on resume)
@@ -207,14 +213,14 @@ func (d *DB) transitionTask(taskID, agentName, project, newStatus string, result
 		task.StartedAt = &now
 		if leavingBlocked {
 			task.BlockedPeriods = closeBlockedPeriod(task.BlockedPeriods, now)
-			_, err = d.conn.Exec(
-				"UPDATE tasks SET status = ?, assigned_to = ?, started_at = ?, blocked_periods = ? WHERE id = ? AND project = ?",
-				newStatus, agentName, now, task.BlockedPeriods, taskID, project,
+			res, err = d.conn.Exec(
+				"UPDATE tasks SET status = ?, assigned_to = ?, started_at = ?, blocked_periods = ? WHERE id = ? AND project = ? AND status = ?",
+				newStatus, agentName, now, task.BlockedPeriods, taskID, project, oldStatus,
 			)
 		} else {
-			_, err = d.conn.Exec(
-				"UPDATE tasks SET status = ?, assigned_to = ?, started_at = ? WHERE id = ? AND project = ?",
-				newStatus, agentName, now, taskID, project,
+			res, err = d.conn.Exec(
+				"UPDATE tasks SET status = ?, assigned_to = ?, started_at = ? WHERE id = ? AND project = ? AND status = ?",
+				newStatus, agentName, now, taskID, project, oldStatus,
 			)
 		}
 	case "in-review":
@@ -225,14 +231,14 @@ func (d *DB) transitionTask(taskID, agentName, project, newStatus string, result
 		}
 		if leavingBlocked {
 			task.BlockedPeriods = closeBlockedPeriod(task.BlockedPeriods, now)
-			_, err = d.conn.Exec(
-				"UPDATE tasks SET status = ?, assigned_to = COALESCE(assigned_to, ?), in_review_at = ?, blocked_periods = ? WHERE id = ? AND project = ?",
-				newStatus, agentName, now, task.BlockedPeriods, taskID, project,
+			res, err = d.conn.Exec(
+				"UPDATE tasks SET status = ?, assigned_to = COALESCE(assigned_to, ?), in_review_at = ?, blocked_periods = ? WHERE id = ? AND project = ? AND status = ?",
+				newStatus, agentName, now, task.BlockedPeriods, taskID, project, oldStatus,
 			)
 		} else {
-			_, err = d.conn.Exec(
-				"UPDATE tasks SET status = ?, assigned_to = COALESCE(assigned_to, ?), in_review_at = ? WHERE id = ? AND project = ?",
-				newStatus, agentName, now, taskID, project,
+			res, err = d.conn.Exec(
+				"UPDATE tasks SET status = ?, assigned_to = COALESCE(assigned_to, ?), in_review_at = ? WHERE id = ? AND project = ? AND status = ?",
+				newStatus, agentName, now, taskID, project, oldStatus,
 			)
 		}
 	case "done":
@@ -243,42 +249,49 @@ func (d *DB) transitionTask(taskID, agentName, project, newStatus string, result
 		task.Result = result
 		if leavingBlocked {
 			task.BlockedPeriods = closeBlockedPeriod(task.BlockedPeriods, now)
-			_, err = d.conn.Exec(
-				"UPDATE tasks SET status = ?, result = ?, completed_at = ?, done_at = ?, blocked_periods = ? WHERE id = ? AND project = ?",
-				newStatus, result, now, now, task.BlockedPeriods, taskID, project,
+			res, err = d.conn.Exec(
+				"UPDATE tasks SET status = ?, result = ?, completed_at = ?, done_at = ?, blocked_periods = ? WHERE id = ? AND project = ? AND status = ?",
+				newStatus, result, now, now, task.BlockedPeriods, taskID, project, oldStatus,
 			)
 		} else {
-			_, err = d.conn.Exec(
-				"UPDATE tasks SET status = ?, result = ?, completed_at = ?, done_at = ? WHERE id = ? AND project = ?",
-				newStatus, result, now, now, taskID, project,
+			res, err = d.conn.Exec(
+				"UPDATE tasks SET status = ?, result = ?, completed_at = ?, done_at = ? WHERE id = ? AND project = ? AND status = ?",
+				newStatus, result, now, now, taskID, project, oldStatus,
 			)
 		}
 	case "blocked":
 		// block → append {start: now} to blocked_periods
 		task.BlockedReason = blockedReason
 		task.BlockedPeriods = openBlockedPeriod(task.BlockedPeriods, now)
-		_, err = d.conn.Exec(
-			"UPDATE tasks SET status = ?, blocked_reason = ?, blocked_periods = ? WHERE id = ? AND project = ?",
-			newStatus, blockedReason, task.BlockedPeriods, taskID, project,
+		res, err = d.conn.Exec(
+			"UPDATE tasks SET status = ?, blocked_reason = ?, blocked_periods = ? WHERE id = ? AND project = ? AND status = ?",
+			newStatus, blockedReason, task.BlockedPeriods, taskID, project, oldStatus,
 		)
 	case "cancelled":
 		task.CompletedAt = &now
 		task.BlockedReason = blockedReason // reuse as cancellation reason
 		if leavingBlocked {
 			task.BlockedPeriods = closeBlockedPeriod(task.BlockedPeriods, now)
-			_, err = d.conn.Exec(
-				"UPDATE tasks SET status = ?, blocked_reason = ?, completed_at = ?, blocked_periods = ? WHERE id = ? AND project = ?",
-				newStatus, blockedReason, now, task.BlockedPeriods, taskID, project,
+			res, err = d.conn.Exec(
+				"UPDATE tasks SET status = ?, blocked_reason = ?, completed_at = ?, blocked_periods = ? WHERE id = ? AND project = ? AND status = ?",
+				newStatus, blockedReason, now, task.BlockedPeriods, taskID, project, oldStatus,
 			)
 		} else {
-			_, err = d.conn.Exec(
-				"UPDATE tasks SET status = ?, blocked_reason = ?, completed_at = ? WHERE id = ? AND project = ?",
-				newStatus, blockedReason, now, taskID, project,
+			res, err = d.conn.Exec(
+				"UPDATE tasks SET status = ?, blocked_reason = ?, completed_at = ? WHERE id = ? AND project = ? AND status = ?",
+				newStatus, blockedReason, now, taskID, project, oldStatus,
 			)
 		}
 	}
 	if err != nil {
 		return nil, fmt.Errorf("update task status: %w", err)
+	}
+	// CAS check: 0 rows affected means the row changed (or vanished) between the
+	// read and the write — a concurrent transition won. Report the conflict
+	// instead of returning a task the caller never actually transitioned. This is
+	// what stops two agents double-claiming the same task.
+	if n, raErr := res.RowsAffected(); raErr == nil && n == 0 {
+		return nil, fmt.Errorf("concurrent transition on task %s: status changed from %q before %q could apply", taskID, oldStatus, newStatus)
 	}
 	return task, nil
 }

--- a/internal/db/tasks_concurrency_test.go
+++ b/internal/db/tasks_concurrency_test.go
@@ -1,0 +1,68 @@
+package db
+
+import (
+	"sync"
+	"testing"
+)
+
+// TestClaimTask_NoDoubleClaim is the TOCTOU regression guard. transitionTask
+// used to read the task, validate in Go, then UPDATE with only id+project in the
+// WHERE — so N concurrent claims all read "pending", all validated, and all
+// overwrote each other (double-claim). The fix adds a compare-and-swap guard
+// (AND status = oldStatus) + a RowsAffected check. This test fires many claims
+// at one pending task and asserts EXACTLY ONE wins.
+func TestClaimTask_NoDoubleClaim(t *testing.T) {
+	d := testDB(t)
+	const project = "p1"
+
+	task, err := d.DispatchTask(project, "", "dispatcher", "race me", "", "P1", nil, nil)
+	if err != nil {
+		t.Fatalf("dispatch: %v", err)
+	}
+
+	const racers = 12
+	var (
+		wg       sync.WaitGroup
+		mu       sync.Mutex
+		winners  []string
+		failures int
+	)
+	start := make(chan struct{})
+	for i := 0; i < racers; i++ {
+		wg.Add(1)
+		agent := "agent-" + string(rune('a'+i))
+		go func() {
+			defer wg.Done()
+			<-start // line everyone up so the claims truly overlap
+			got, err := d.ClaimTask(task.ID, agent, project)
+			mu.Lock()
+			defer mu.Unlock()
+			if err == nil && got != nil {
+				winners = append(winners, agent)
+			} else {
+				failures++
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	if len(winners) != 1 {
+		t.Fatalf("want exactly 1 winner, got %d (%v) — double-claim regression", len(winners), winners)
+	}
+	if failures != racers-1 {
+		t.Fatalf("want %d losers to get a conflict error, got %d", racers-1, failures)
+	}
+
+	// The persisted row must reflect the single winner.
+	final, err := d.GetTask(task.ID, project)
+	if err != nil {
+		t.Fatalf("get task: %v", err)
+	}
+	if final.Status != "accepted" {
+		t.Fatalf("want status accepted, got %q", final.Status)
+	}
+	if final.ClaimedBy == nil || *final.ClaimedBy != winners[0] {
+		t.Fatalf("claimed_by must be the winner %q, got %v", winners[0], final.ClaimedBy)
+	}
+}


### PR DESCRIPTION
transitionTask validated in Go then UPDATEd with only id+project in the WHERE → concurrent claims double-claimed (second overwrote first) on the dispatch core. Fix: CAS guard `AND status = oldStatus` + RowsAffected check → loser gets a conflict error. Regression test: 12 concurrent claims under -race → exactly 1 winner. Single-lane wraith, build+vet+tests(+race) green. 🤖 Generated with [Claude Code](https://claude.com/claude-code)