### PR TITLE
feat(notifications): resolve assignee from routed lane for Linear-sourced tasks (TSU-52 unblock)

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -426,18 +426,19 @@ func migrate(conn *sql.DB) error {
 		"archived_at":      "TEXT",
 
 		// --- Linear zone (read-only, replicated from Linear SSOT) ---
-		"source":          "TEXT NOT NULL DEFAULT 'native'", // 'native' | 'linear'
-		"linear_issue_id": "TEXT",
-		"linear_key":      "TEXT", // e.g. SYN-123
-		"external_url":    "TEXT",
-		"points":          "INTEGER",
-		"labels":          "TEXT NOT NULL DEFAULT '[]'", // json array
-		"linear_state":    "TEXT",
-		"assignee":        "TEXT",
-		"cycle_id":        "TEXT",
-		"cycle_name":      "TEXT",
-		"cycle_start":     "TEXT",
-		"cycle_end":       "TEXT",
+		"source":            "TEXT NOT NULL DEFAULT 'native'", // 'native' | 'linear'
+		"linear_issue_id":   "TEXT",
+		"linear_key":        "TEXT", // e.g. SYN-123
+		"external_url":      "TEXT",
+		"points":            "INTEGER",
+		"labels":            "TEXT NOT NULL DEFAULT '[]'", // json array
+		"linear_state":      "TEXT",
+		"assignee":          "TEXT",
+		"cycle_id":          "TEXT",
+		"cycle_name":        "TEXT",
+		"cycle_start":       "TEXT",
+		"cycle_end":         "TEXT",
+		"linear_project_id": "TEXT", // Linear project UUID — drives project→agent routing
 		// priority already exists on the base table.
 
 		// --- Execution overlay (relay-owned, auto-stamped temporal trail) ---

--- a/internal/db/linear.go
+++ b/internal/db/linear.go
@@ -29,7 +29,7 @@ type LinearMirrorSeed struct {
 	Labels          string // json array; defaults to "[]"
 	LinearState     *string
 	Assignee        *string
-	LinearProjectID *string // Linear project UUID — drives project→agent routing (in-memory; not persisted)
+	LinearProjectID *string // Linear project UUID — persisted; drives project→agent routing
 	CycleID         *string
 	CycleName       *string
 	CycleStart      *string
@@ -95,11 +95,13 @@ func (d *DB) UpsertLinearMirror(s LinearMirrorSeed) (taskID string, created bool
 			   title=?, description=?, priority=?, status=?, source='linear',
 			   linear_key=?, external_url=?, points=?, labels=?, linear_state=?,
 			   assignee=?, cycle_id=?, cycle_name=?, cycle_start=?, cycle_end=?,
+			   linear_project_id=COALESCE(?, linear_project_id),
 			   parent_task_id=COALESCE(?, parent_task_id)
 			 WHERE id=? AND project=?`,
 			s.Title, s.Description, s.Priority, s.Status,
 			s.LinearKey, s.ExternalURL, s.Points, s.Labels, s.LinearState,
 			s.Assignee, s.CycleID, s.CycleName, s.CycleStart, s.CycleEnd,
+			s.LinearProjectID,
 			s.ParentTaskID, existing.ID, s.Project,
 		)
 		if err != nil {
@@ -113,11 +115,11 @@ func (d *DB) UpsertLinearMirror(s LinearMirrorSeed) (taskID string, created bool
 		`INSERT INTO tasks
 		   (id, profile_slug, dispatched_by, title, description, priority, status, project, dispatched_at,
 		    source, linear_issue_id, linear_key, external_url, points, labels, linear_state, assignee,
-		    cycle_id, cycle_name, cycle_start, cycle_end, parent_task_id, blocked_periods)
-		 VALUES (?, '', 'linear', ?, ?, ?, ?, ?, ?, 'linear', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, '[]')`,
+		    cycle_id, cycle_name, cycle_start, cycle_end, parent_task_id, linear_project_id, blocked_periods)
+		 VALUES (?, '', 'linear', ?, ?, ?, ?, ?, ?, 'linear', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, '[]')`,
 		id, s.Title, s.Description, s.Priority, s.Status, s.Project, now,
 		s.LinearIssueID, s.LinearKey, s.ExternalURL, s.Points, s.Labels, s.LinearState, s.Assignee,
-		s.CycleID, s.CycleName, s.CycleStart, s.CycleEnd, s.ParentTaskID,
+		s.CycleID, s.CycleName, s.CycleStart, s.CycleEnd, s.ParentTaskID, s.LinearProjectID,
 	)
 	if err != nil {
 		return "", false, fmt.Errorf("insert linear mirror: %w", err)

--- a/internal/db/tasks.go
+++ b/internal/db/tasks.go
@@ -63,7 +63,7 @@ var validTransitions = map[string][]string{
 
 const taskColumns = "id, profile_slug, assigned_to, dispatched_by, title, description, priority, status, result, blocked_reason, project, dispatched_at, accepted_at, started_at, completed_at, parent_task_id, ack_notified_at, ack_escalated_at, board_id, archived_at, " +
 	"source, linear_issue_id, linear_key, external_url, points, labels, linear_state, assignee, cycle_id, cycle_name, cycle_start, cycle_end, " +
-	"claimed_by, claimed_at, blocked_periods, in_review_at, done_at"
+	"claimed_by, claimed_at, blocked_periods, in_review_at, done_at, linear_project_id"
 
 func scanTask(row interface{ Scan(...any) error }) (models.Task, error) {
 	var t models.Task
@@ -73,7 +73,7 @@ func scanTask(row interface{ Scan(...any) error }) (models.Task, error) {
 		&t.AckNotifiedAt, &t.AckEscalatedAt, &t.BoardID, &t.ArchivedAt,
 		&t.Source, &t.LinearIssueID, &t.LinearKey, &t.ExternalURL, &t.Points, &t.Labels,
 		&t.LinearState, &t.Assignee, &t.CycleID, &t.CycleName, &t.CycleStart, &t.CycleEnd,
-		&t.ClaimedBy, &t.ClaimedAt, &t.BlockedPeriods, &t.InReviewAt, &t.DoneAt)
+		&t.ClaimedBy, &t.ClaimedAt, &t.BlockedPeriods, &t.InReviewAt, &t.DoneAt, &t.LinearProjectID)
 	return t, err
 }
 

--- a/internal/models/task.go
+++ b/internal/models/task.go
@@ -35,6 +35,9 @@ type Task struct {
 	CycleName     *string `json:"cycle_name,omitempty"`
 	CycleStart    *string `json:"cycle_start,omitempty"`
 	CycleEnd      *string `json:"cycle_end,omitempty"`
+	// LinearProjectID drives project→agent routing for Linear-sourced tasks
+	// (e.g. resolving a stale task's assignee from the linear_routing map).
+	LinearProjectID *string `json:"linear_project_id,omitempty"`
 
 	// --- Execution overlay (relay-owned, auto-stamped temporal trail) ---
 	ClaimedBy      *string `json:"claimed_by,omitempty"`

--- a/internal/relay/notifications.go
+++ b/internal/relay/notifications.go
@@ -387,8 +387,15 @@ func (n *Notifier) resolveTargets(project, target string, payload map[string]any
 		}
 		return []string{*a.ReportsTo}
 	case "assignee":
-		// the task's own assignee, from the semantic payload
+		// the task's own assignee. Prefer the explicit payload agent; otherwise
+		// resolve from the task itself — its claimer, or (for Linear-sourced tasks
+		// with an empty profile_slug) the agent routed to its Linear project. This
+		// lets a stale-scanner emit task-stale with just a task_id and still target
+		// the right lead.
 		if a := strVal(payload["agent"]); a != "" {
+			return []string{a}
+		}
+		if a := n.resolveTaskAssignee(project, strVal(payload["task_id"])); a != "" {
 			return []string{a}
 		}
 		return nil
@@ -405,6 +412,35 @@ func (n *Notifier) resolveTargets(project, target string, payload map[string]any
 	}
 	// Fall back to a literal agent name.
 	return []string{target}
+}
+
+// resolveTaskAssignee resolves the agent responsible for a task when the event
+// payload didn't carry one. Order: the task's claimer (assigned_to), then the
+// agent routed to the task's Linear project (linear_routing map) — the path for
+// Linear-sourced tasks whose profile_slug is empty. Returns "" when unresolvable.
+func (n *Notifier) resolveTaskAssignee(project, taskID string) string {
+	if taskID == "" {
+		return ""
+	}
+	task, err := n.db.GetTask(taskID, project)
+	if err != nil || task == nil {
+		return ""
+	}
+	if task.AssignedTo != nil && *task.AssignedTo != "" {
+		return *task.AssignedTo
+	}
+	if task.LinearProjectID == nil || *task.LinearProjectID == "" {
+		return ""
+	}
+	raw := strings.TrimSpace(n.db.GetSetting("linear_routing"))
+	if raw == "" {
+		return ""
+	}
+	var routing map[string]string
+	if err := json.Unmarshal([]byte(raw), &routing); err != nil {
+		return ""
+	}
+	return routing[*task.LinearProjectID]
 }
 
 func matchByRole(database *db.DB, project, role string) []string {

--- a/internal/relay/notifications_assignee_test.go
+++ b/internal/relay/notifications_assignee_test.go
@@ -1,0 +1,93 @@
+package relay
+
+import (
+	"path/filepath"
+	"testing"
+
+	"agent-relay/internal/db"
+)
+
+// TestResolveAssignee_LinearRoutedLane covers the autonomy-loop unblock: a
+// stale-scanner emits task-stale with only a task_id (a Linear-sourced task has
+// no payload.agent and an empty profile_slug). The "assignee" target must still
+// resolve the lead by routing the task's Linear project through linear_routing.
+func TestResolveAssignee_LinearRoutedLane(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	database, err := db.NewTestDB(dbPath)
+	if err != nil {
+		t.Fatalf("create test db: %v", err)
+	}
+	t.Cleanup(func() { _ = database.Close() })
+
+	const project = "trovex-growth"
+	const linearProj = "proj-wraith-uuid"
+
+	// Mirror a Linear-sourced task carrying its Linear project id (and NO assignee).
+	projID := linearProj
+	taskID, _, err := database.UpsertLinearMirror(db.LinearMirrorSeed{
+		Project:         project,
+		LinearIssueID:   "iss-1",
+		Title:           "stale me",
+		Status:          "pending",
+		LinearProjectID: &projID,
+	})
+	if err != nil {
+		t.Fatalf("upsert mirror: %v", err)
+	}
+
+	// The owner-configured routing map: this Linear project → the wraith lead.
+	database.SetSetting("linear_routing", `{"proj-wraith-uuid":"wraith-dev"}`)
+
+	n := &Notifier{db: database}
+
+	// payload.agent empty → must resolve via the task's Linear project → lane.
+	got := n.resolveTargets(project, "assignee", map[string]any{"task_id": taskID})
+	if len(got) != 1 || got[0] != "wraith-dev" {
+		t.Fatalf("want [wraith-dev] from routed lane, got %v", got)
+	}
+
+	// An explicit payload.agent still wins (no DB lookup needed).
+	got = n.resolveTargets(project, "assignee", map[string]any{"agent": "someone-else", "task_id": taskID})
+	if len(got) != 1 || got[0] != "someone-else" {
+		t.Fatalf("explicit agent must win, got %v", got)
+	}
+}
+
+// TestUpsertLinearMirror_ProjectIDBackfill verifies condition (2) of the
+// approved migration: an existing mirror row (linear_project_id NULL) gets it
+// backfilled when reconcile re-upserts the issue with the now-computed seed.
+func TestUpsertLinearMirror_ProjectIDBackfill(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	database, err := db.NewTestDB(dbPath)
+	if err != nil {
+		t.Fatalf("create test db: %v", err)
+	}
+	t.Cleanup(func() { _ = database.Close() })
+
+	const project = "p1"
+
+	// First upsert WITHOUT a project id — simulates a row mirrored before the
+	// column existed.
+	taskID, created, err := database.UpsertLinearMirror(db.LinearMirrorSeed{
+		Project: project, LinearIssueID: "iss-x", Title: "t", Status: "pending",
+	})
+	if err != nil || !created {
+		t.Fatalf("first upsert: created=%v err=%v", created, err)
+	}
+	if got, _ := database.GetTask(taskID, project); got.LinearProjectID != nil {
+		t.Fatalf("expected NULL project id pre-backfill, got %v", *got.LinearProjectID)
+	}
+
+	// Reconcile re-upserts with the computed project id → backfilled.
+	projID := "proj-x"
+	if _, _, err := database.UpsertLinearMirror(db.LinearMirrorSeed{
+		Project: project, LinearIssueID: "iss-x", Title: "t", Status: "in-progress",
+		LinearProjectID: &projID,
+	}); err != nil {
+		t.Fatalf("re-upsert: %v", err)
+	}
+	got, _ := database.GetTask(taskID, project)
+	if got.LinearProjectID == nil || *got.LinearProjectID != "proj-x" {
+		t.Fatalf("want backfilled project id proj-x, got %v", got.LinearProjectID)
+	}
+}


### PR DESCRIPTION
Unblocks the stale-scanner autonomy loop: persist `linear_project_id` on the task mirror (additive nullable column, filled at seed) and resolve the 'assignee' notification target via `linear_routing[linear_project_id]` when payload.agent is empty. Existing rows backfill on the next reconcile. Migration additive-only per cto approval (3 conditions met). Tests: routed resolution + backfill. build+vet+tests green. 🤖 Generated with [Claude Code](https://claude.com/claude-code)