### PR TITLE
feat(notifications): set-membership match — scope stale-rule to active tasks

### DIFF
--- a/internal/relay/notifications.go
+++ b/internal/relay/notifications.go
@@ -119,6 +119,9 @@ func (n *Notifier) handleEvent(evt MCPEvent) {
 //   - assignee_is_agent: bool — payload.assignee_is_agent must equal it
 //   - agent: string         — payload.agent must equal it
 //   - any arbitrary key      — exact equality against the payload value
+//   - any key with an ARRAY value — set membership: matches if the payload value
+//     equals ANY element (OR), e.g. {"status":["in-progress","accepted"]} so a
+//     stale-rule fires only on active tasks, not parked Todo/backlog.
 func matchRule(rule models.NotificationRule, payload map[string]any) bool {
 	if strings.TrimSpace(rule.Match) == "" || rule.Match == "{}" {
 		return true
@@ -132,11 +135,25 @@ func matchRule(rule models.NotificationRule, payload map[string]any) bool {
 		if !ok {
 			return false
 		}
-		if !valuesEqual(want, got) {
+		if !matchValue(want, got) {
 			return false
 		}
 	}
 	return true
+}
+
+// matchValue supports set membership: a JSON array matches if the payload value
+// equals ANY element (OR semantics); otherwise it's exact equality.
+func matchValue(want, got any) bool {
+	if arr, ok := want.([]any); ok {
+		for _, w := range arr {
+			if valuesEqual(w, got) {
+				return true
+			}
+		}
+		return false
+	}
+	return valuesEqual(want, got)
 }
 
 func valuesEqual(want, got any) bool {

--- a/internal/relay/notifications_test.go
+++ b/internal/relay/notifications_test.go
@@ -30,6 +30,17 @@ func TestMatchRule(t *testing.T) {
 			map[string]any{"agent": "alice", "assignee_is_agent": true}, true},
 		{"multi-condition one fails", `{"agent":"alice","assignee_is_agent":true}`,
 			map[string]any{"agent": "alice", "assignee_is_agent": false}, false},
+		// set membership (array value = OR) — scopes the stale-rule to active tasks
+		{"array matches member", `{"status":["in-progress","accepted"]}`,
+			map[string]any{"status": "in-progress"}, true},
+		{"array matches other member", `{"status":["in-progress","accepted"]}`,
+			map[string]any{"status": "accepted"}, true},
+		{"array rejects non-member (parked Todo)", `{"status":["in-progress","accepted"]}`,
+			map[string]any{"status": "pending"}, false},
+		{"array + other condition both pass", `{"status":["in-progress","accepted"],"escalate":true}`,
+			map[string]any{"status": "in-progress", "escalate": true}, true},
+		{"array passes but sibling fails", `{"status":["in-progress","accepted"],"escalate":true}`,
+			map[string]any{"status": "in-progress", "escalate": false}, false},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {


### PR DESCRIPTION
Stale-rule fired P0s on parked Todo/backlog/future tasks (10 false positives/night). matchRule did exact equality only. Add array-value OR semantics so the rule gates on `{"status":["in-progress","accepted"]}` — fires only on stalled active work, excludes parked/pending. ECA-predicate groundwork for TSU-52. Tests added (member/non-member/+sibling). build+vet+tests green. 🤖 Generated with [Claude Code](https://claude.com/claude-code)