### PR TITLE
feat(events): TSU-52 slice-A — durable outbox + replay log

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -860,6 +860,26 @@ func migrate(conn *sql.DB) error {
 	)`)
 	_, _ = conn.Exec(`CREATE INDEX IF NOT EXISTS idx_notification_deliveries_created ON notification_deliveries(created_at)`)
 
+	// events — the durable outbox + replay log for the event bus (TSU-52). Every
+	// semantic event is persisted here; delivery_id is the idempotency key
+	// (UNIQUE) so an at-least-once source — e.g. a retried GitHub webhook — is
+	// deduped via INSERT OR IGNORE. delivered_at/attempts/last_error are owned by
+	// the sweeper (slice-B): NULL delivered_at = not yet processed.
+	_, _ = conn.Exec(`CREATE TABLE IF NOT EXISTS events (
+		id           TEXT PRIMARY KEY,
+		delivery_id  TEXT NOT NULL UNIQUE,
+		project      TEXT NOT NULL DEFAULT 'default',
+		event_type   TEXT NOT NULL,
+		agent        TEXT NOT NULL DEFAULT '',
+		payload      TEXT NOT NULL DEFAULT '{}',
+		created_at   TEXT NOT NULL,
+		delivered_at TEXT,
+		attempts     INTEGER NOT NULL DEFAULT 0,
+		last_error   TEXT NOT NULL DEFAULT ''
+	)`)
+	_, _ = conn.Exec(`CREATE INDEX IF NOT EXISTS idx_events_undelivered ON events(delivered_at) WHERE delivered_at IS NULL`)
+	_, _ = conn.Exec(`CREATE INDEX IF NOT EXISTS idx_events_created ON events(id DESC)`)
+
 	// Lowercase all agent names for case-insensitive matching
 	migrateLowercaseAgentNames(conn)
 

--- a/internal/db/events.go
+++ b/internal/db/events.go
@@ -1,0 +1,122 @@
+package db
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Event is one row of the durable event outbox / replay log (TSU-52).
+type Event struct {
+	ID          string  `json:"id"`
+	DeliveryID  string  `json:"delivery_id"`
+	Project     string  `json:"project"`
+	EventType   string  `json:"event_type"`
+	Agent       string  `json:"agent"`
+	Payload     string  `json:"payload"` // JSON object
+	CreatedAt   string  `json:"created_at"`
+	DeliveredAt *string `json:"delivered_at,omitempty"`
+	Attempts    int     `json:"attempts"`
+	LastError   string  `json:"last_error,omitempty"`
+}
+
+// InsertEvent appends an event to the outbox, deduping on delivery_id via INSERT
+// OR IGNORE. deliveryID is the idempotency key — pass a stable one for
+// at-least-once sources (e.g. a webhook's delivery GUID) so a retry is a no-op;
+// pass "" for internally-generated events and a fresh UUID is used (always
+// inserts). Returns (eventID, inserted): inserted=false means a duplicate
+// delivery_id was ignored. Best-effort persistence must never block the caller's
+// hot path — callers log and continue on error.
+func (d *DB) InsertEvent(deliveryID, project, eventType, agent, payloadJSON string) (string, bool, error) {
+	if eventType == "" {
+		return "", false, fmt.Errorf("insert event: empty event_type")
+	}
+	if project == "" {
+		project = "default"
+	}
+	if payloadJSON == "" {
+		payloadJSON = "{}"
+	}
+	id := uuid.New().String()
+	if deliveryID == "" {
+		deliveryID = id
+	}
+	now := time.Now().UTC().Format(memoryTimeFmt)
+
+	res, err := d.conn.Exec(
+		`INSERT OR IGNORE INTO events (id, delivery_id, project, event_type, agent, payload, created_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		id, deliveryID, project, eventType, agent, payloadJSON, now,
+	)
+	if err != nil {
+		return "", false, fmt.Errorf("insert event: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	return id, n > 0, nil
+}
+
+// RecentEvents returns the newest events (newest first) for replay / inspection.
+func (d *DB) RecentEvents(project string, limit int) ([]Event, error) {
+	if limit <= 0 {
+		limit = 50
+	}
+	q := `SELECT id, delivery_id, project, event_type, agent, payload, created_at, delivered_at, attempts, last_error
+	      FROM events`
+	args := []any{}
+	if project != "" {
+		q += ` WHERE project = ?`
+		args = append(args, project)
+	}
+	q += ` ORDER BY id DESC LIMIT ?`
+	args = append(args, limit)
+
+	rows, err := d.ro().Query(q, args...)
+	if err != nil {
+		return nil, fmt.Errorf("recent events: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	return scanEvents(rows)
+}
+
+// UndeliveredEvents returns events the sweeper (slice-B) hasn't processed yet,
+// oldest first, capped. delivered_at IS NULL is the work queue.
+func (d *DB) UndeliveredEvents(limit int) ([]Event, error) {
+	if limit <= 0 {
+		limit = 100
+	}
+	rows, err := d.ro().Query(
+		`SELECT id, delivery_id, project, event_type, agent, payload, created_at, delivered_at, attempts, last_error
+		 FROM events WHERE delivered_at IS NULL ORDER BY id ASC LIMIT ?`,
+		limit,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("undelivered events: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	return scanEvents(rows)
+}
+
+// MarkEventDelivered stamps delivered_at so the sweeper won't reprocess the row.
+func (d *DB) MarkEventDelivered(id string) error {
+	now := time.Now().UTC().Format(memoryTimeFmt)
+	_, err := d.conn.Exec(`UPDATE events SET delivered_at = ? WHERE id = ?`, now, id)
+	return err
+}
+
+func scanEvents(rows interface {
+	Next() bool
+	Scan(...any) error
+	Err() error
+}) ([]Event, error) {
+	var out []Event
+	for rows.Next() {
+		var e Event
+		if err := rows.Scan(&e.ID, &e.DeliveryID, &e.Project, &e.EventType, &e.Agent,
+			&e.Payload, &e.CreatedAt, &e.DeliveredAt, &e.Attempts, &e.LastError); err != nil {
+			return nil, fmt.Errorf("scan event: %w", err)
+		}
+		out = append(out, e)
+	}
+	return out, rows.Err()
+}

--- a/internal/db/events_test.go
+++ b/internal/db/events_test.go
@@ -1,0 +1,57 @@
+package db
+
+import "testing"
+
+// TestInsertEvent_DedupAndReplay covers the outbox foundation (TSU-52 slice-A):
+// dedup on delivery_id (INSERT OR IGNORE), the replay log, and the
+// undelivered→delivered sweeper queue.
+func TestInsertEvent_DedupAndReplay(t *testing.T) {
+	d := testDB(t)
+	const project = "p1"
+
+	// A stable delivery_id (e.g. a webhook GUID) inserts once, then dedupes.
+	id1, ins1, err := d.InsertEvent("deliv-1", project, "event:task-stale", "wraith-dev", `{"task_id":"t1"}`)
+	if err != nil || !ins1 {
+		t.Fatalf("first insert: ins=%v err=%v", ins1, err)
+	}
+	id2, ins2, err := d.InsertEvent("deliv-1", project, "event:task-stale", "wraith-dev", `{"task_id":"t1"}`)
+	if err != nil {
+		t.Fatalf("second insert err: %v", err)
+	}
+	if ins2 {
+		t.Fatalf("duplicate delivery_id must be ignored (inserted=false)")
+	}
+	if id1 == "" || id2 == "" {
+		t.Fatalf("expected ids returned")
+	}
+
+	// Empty delivery_id → always inserts (fresh UUID).
+	if _, ins, err := d.InsertEvent("", project, "task.done", "bob", `{}`); err != nil || !ins {
+		t.Fatalf("empty delivery_id should insert: ins=%v err=%v", ins, err)
+	}
+
+	// Replay log: 2 distinct events (the dup didn't add a row).
+	recent, err := d.RecentEvents(project, 10)
+	if err != nil {
+		t.Fatalf("recent: %v", err)
+	}
+	if len(recent) != 2 {
+		t.Fatalf("want 2 events in replay log (dup ignored), got %d", len(recent))
+	}
+
+	// Sweeper queue: both undelivered until marked.
+	undel, err := d.UndeliveredEvents(10)
+	if err != nil {
+		t.Fatalf("undelivered: %v", err)
+	}
+	if len(undel) != 2 {
+		t.Fatalf("want 2 undelivered, got %d", len(undel))
+	}
+	if err := d.MarkEventDelivered(id1); err != nil {
+		t.Fatalf("mark delivered: %v", err)
+	}
+	undel, _ = d.UndeliveredEvents(10)
+	if len(undel) != 1 {
+		t.Fatalf("want 1 undelivered after marking one, got %d", len(undel))
+	}
+}

--- a/internal/relay/notifications.go
+++ b/internal/relay/notifications.go
@@ -94,6 +94,16 @@ func (n *Notifier) handleEvent(evt MCPEvent) {
 	if evt.Semantic == nil {
 		return
 	}
+	// Persist to the durable outbox / replay log (TSU-52 slice-A). Best-effort:
+	// a logging failure never blocks rule firing. delivery_id is left empty here
+	// (internal event → fresh UUID); external sources pass a stable key for
+	// dedup. The synchronous firing below is unchanged; the sweeper (slice-B)
+	// will later drive delivery from this table.
+	if payload, err := json.Marshal(evt.Semantic); err == nil {
+		if _, _, err := n.db.InsertEvent("", evt.Project, evt.Type, strVal(evt.Semantic["agent"]), string(payload)); err != nil {
+			log.Printf("notifier: persist event %s: %v", evt.Type, err)
+		}
+	}
 	rules, err := n.db.ListEnabledNotificationRulesForEvent(evt.Type)
 	if err != nil {
 		log.Printf("notifier: list rules for %s: %v", evt.Type, err)


### PR DESCRIPTION
First slice of the event bus. `events` table = transactional outbox + replay log; every semantic event is persisted (best-effort, doesn't block firing). `delivery_id` UNIQUE = idempotency key → at-least-once sources dedupe via INSERT OR IGNORE. `delivered_at IS NULL` = the sweeper queue (slice-B). Synchronous firing unchanged — purely additive. DB API + test (dedup/replay/queue). build+vet+tests green. Next: slice-B sweeper. 🤖 Generated with [Claude Code](https://claude.com/claude-code)