### PR TITLE
feat(events): TSU-52 slice-B — outbox sweeper drives delivery (durable + DLQ)

### DIFF
--- a/internal/db/events.go
+++ b/internal/db/events.go
@@ -104,6 +104,36 @@ func (d *DB) MarkEventDelivered(id string) error {
 	return err
 }
 
+// IncrementEventAttempt bumps the retry counter and records the last error,
+// leaving delivered_at NULL so the sweeper retries the row next tick.
+func (d *DB) IncrementEventAttempt(id, lastErr string) error {
+	_, err := d.conn.Exec(`UPDATE events SET attempts = attempts + 1, last_error = ? WHERE id = ?`, lastErr, id)
+	return err
+}
+
+// MarkEventDead dead-letters an event: stamps delivered_at (so it leaves the
+// sweeper queue) and records why. attempts is bumped for the audit trail.
+func (d *DB) MarkEventDead(id, lastErr string) error {
+	now := time.Now().UTC().Format(memoryTimeFmt)
+	_, err := d.conn.Exec(`UPDATE events SET delivered_at = ?, attempts = attempts + 1, last_error = ? WHERE id = ?`, now, lastErr, id)
+	return err
+}
+
+// PruneDeliveredEvents caps the replay log: keeps the newest `keep` delivered
+// rows, deletes older delivered ones. Undelivered (queued) rows are never
+// pruned. Best-effort maintenance against unbounded growth.
+func (d *DB) PruneDeliveredEvents(keep int) {
+	if keep < 1 {
+		keep = 1000
+	}
+	_, _ = d.conn.Exec(
+		`DELETE FROM events WHERE delivered_at IS NOT NULL AND id NOT IN (
+		   SELECT id FROM events WHERE delivered_at IS NOT NULL ORDER BY id DESC LIMIT ?
+		 )`,
+		keep,
+	)
+}
+
 func scanEvents(rows interface {
 	Next() bool
 	Scan(...any) error

--- a/internal/relay/notifications.go
+++ b/internal/relay/notifications.go
@@ -64,8 +64,18 @@ func NewNotifier(database *db.DB, registry *SessionRegistry, events *EventBus) *
 func (n *Notifier) Start(done <-chan struct{}) {
 	n.done = done
 	go n.runEvaluator(done)
+	go n.runSweeper(done)
 	go n.runDigestScheduler(done)
 }
+
+// Outbox sweeper tuning.
+const (
+	sweepInterval    = 1500 * time.Millisecond // delivery latency ceiling per tick
+	sweepBatch       = 100                     // undelivered events processed per tick
+	maxEventAttempts = 5                       // dead-letter past this many failed tries
+	sweepPruneEvery  = 40                      // prune the replay log every Nth tick (~1min)
+	eventLogKeep     = 5000                    // delivered rows retained for replay
+)
 
 // --- Evaluator ---
 
@@ -87,40 +97,100 @@ func (n *Notifier) runEvaluator(done <-chan struct{}) {
 	}
 }
 
-// handleEvent matches a single event against enabled rules. Only semantic
-// events (those carrying a Semantic payload) are considered; visual events are
-// ignored.
+// handleEvent persists a semantic event to the durable outbox (TSU-52). Delivery
+// is no longer synchronous here — the sweeper (runSweeper) drains the outbox and
+// fires rules, so a relay restart or a transient action failure can't silently
+// drop a notification. Only semantic events (those carrying a Semantic payload)
+// are persisted; visual events are ignored.
 func (n *Notifier) handleEvent(evt MCPEvent) {
 	if evt.Semantic == nil {
 		return
 	}
-	// Persist to the durable outbox / replay log (TSU-52 slice-A). Best-effort:
-	// a logging failure never blocks rule firing. delivery_id is left empty here
-	// (internal event → fresh UUID); external sources pass a stable key for
-	// dedup. The synchronous firing below is unchanged; the sweeper (slice-B)
-	// will later drive delivery from this table.
-	if payload, err := json.Marshal(evt.Semantic); err == nil {
-		if _, _, err := n.db.InsertEvent("", evt.Project, evt.Type, strVal(evt.Semantic["agent"]), string(payload)); err != nil {
-			log.Printf("notifier: persist event %s: %v", evt.Type, err)
-		}
-	}
-	rules, err := n.db.ListEnabledNotificationRulesForEvent(evt.Type)
+	// delivery_id is empty here (internal event → fresh UUID); external sources
+	// (a GitHub webhook) pass a stable key so a retry dedupes via INSERT OR IGNORE.
+	payload, err := json.Marshal(evt.Semantic)
 	if err != nil {
-		log.Printf("notifier: list rules for %s: %v", evt.Type, err)
+		log.Printf("notifier: marshal event %s: %v", evt.Type, err)
 		return
 	}
+	if _, _, err := n.db.InsertEvent("", evt.Project, evt.Type, strVal(evt.Semantic["agent"]), string(payload)); err != nil {
+		log.Printf("notifier: persist event %s: %v", evt.Type, err)
+	}
+}
+
+// deliverEvent fires the rules matching one outbox event, then marks it
+// delivered. It only retries (toward the DLQ) when EVERY matched rule failed —
+// that path has no successful side effect (e.g. an already-sent inbox message)
+// to duplicate on the next attempt, so retries stay safe.
+func (n *Notifier) deliverEvent(e db.Event) {
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(e.Payload), &payload); err != nil {
+		n.failEvent(e, "payload unmarshal: "+err.Error())
+		return
+	}
+	rules, err := n.db.ListEnabledNotificationRulesForEvent(e.EventType)
+	if err != nil {
+		n.failEvent(e, "list rules: "+err.Error())
+		return
+	}
+	fired, failures := 0, 0
 	for _, rule := range rules {
-		rule := rule
-		// Scope by project: a rule fires for its own project, or for any
-		// project if it has no specific project ("default" acts as global only
-		// when the event is also default).
-		if rule.Project != evt.Project && rule.Project != "default" {
+		// Scope by project: a rule fires for its own project, or "default" acts
+		// as a global fallback.
+		if rule.Project != e.Project && rule.Project != "default" {
 			continue
 		}
-		if !matchRule(rule, evt.Semantic) {
+		if !matchRule(rule, payload) {
 			continue
 		}
-		go n.fireRule(rule, evt.Type, evt.Project, evt.Semantic, false)
+		fired++
+		if _, rec := n.fireRule(rule, e.EventType, e.Project, payload, false); rec != nil && rec.Outcome != "ok" {
+			failures++
+		}
+	}
+	// Delivered when nothing matched, or at least one matched rule succeeded.
+	if fired == 0 || failures < fired {
+		_ = n.db.MarkEventDelivered(e.ID)
+		return
+	}
+	n.failEvent(e, "all matched rules failed")
+}
+
+// failEvent retries an event or dead-letters it past the attempt cap.
+func (n *Notifier) failEvent(e db.Event, reason string) {
+	if e.Attempts+1 >= maxEventAttempts {
+		log.Printf("notifier: event %s dead-lettered after %d attempts: %s", e.ID, e.Attempts+1, reason)
+		_ = n.db.MarkEventDead(e.ID, "DLQ: "+reason)
+		return
+	}
+	_ = n.db.IncrementEventAttempt(e.ID, reason)
+}
+
+// runSweeper drains the outbox: polls undelivered events, fires their rules, and
+// marks them delivered (or dead-letters after maxEventAttempts). Replaces the
+// old synchronous fire-and-forget so delivery is durable + replayable. Prunes
+// the replay log periodically to bound growth.
+func (n *Notifier) runSweeper(done <-chan struct{}) {
+	ticker := time.NewTicker(sweepInterval)
+	defer ticker.Stop()
+	ticks := 0
+	for {
+		select {
+		case <-done:
+			return
+		case <-ticker.C:
+			events, err := n.db.UndeliveredEvents(sweepBatch)
+			if err != nil {
+				log.Printf("notifier: sweep: %v", err)
+				continue
+			}
+			for _, e := range events {
+				n.deliverEvent(e)
+			}
+			if ticks++; ticks%sweepPruneEvery == 0 {
+				n.db.PruneDeliveredEvents(eventLogKeep)
+			}
+		}
 	}
 }
 

--- a/internal/relay/sweeper_test.go
+++ b/internal/relay/sweeper_test.go
@@ -1,0 +1,82 @@
+package relay
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"agent-relay/internal/db"
+	"agent-relay/internal/models"
+)
+
+// fetchEvent returns the outbox event with the given id (or fails the test).
+func fetchEvent(t *testing.T, d *db.DB, id string) db.Event {
+	t.Helper()
+	evs, err := d.RecentEvents("", 100)
+	if err != nil {
+		t.Fatalf("recent events: %v", err)
+	}
+	for _, e := range evs {
+		if e.ID == id {
+			return e
+		}
+	}
+	t.Fatalf("event %s not found", id)
+	return db.Event{}
+}
+
+// TestSweeper_DeliverAndDLQ covers TSU-52 slice-B: an event with no matching
+// rule is marked delivered immediately; an event whose only matched rule keeps
+// failing is retried and dead-lettered past maxEventAttempts.
+func TestSweeper_DeliverAndDLQ(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	database, err := db.NewTestDB(dbPath)
+	if err != nil {
+		t.Fatalf("create test db: %v", err)
+	}
+	t.Cleanup(func() { _ = database.Close() })
+	n := &Notifier{db: database}
+	const project = "p1"
+
+	// (1) No matching rule → delivered on first pass.
+	noRuleID, _, err := database.InsertEvent("", project, "event:no-rule", "", `{}`)
+	if err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	n.deliverEvent(fetchEvent(t, database, noRuleID))
+	if e := fetchEvent(t, database, noRuleID); e.DeliveredAt == nil {
+		t.Fatalf("no-rule event must be delivered immediately")
+	}
+
+	// (2) A webhook rule with an empty target always fails → retry then DLQ.
+	if _, err := database.CreateNotificationRule(&models.NotificationRule{
+		Project: project, Name: "always-fails", Enabled: true,
+		Event: "event:fail-sweep", Match: "{}", Action: "webhook", Target: "",
+	}); err != nil {
+		t.Fatalf("create rule: %v", err)
+	}
+	failID, _, err := database.InsertEvent("", project, "event:fail-sweep", "", `{}`)
+	if err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	// Drive the sweeper one pass at a time, re-fetching the (incremented) row.
+	for i := 0; i < maxEventAttempts; i++ {
+		e := fetchEvent(t, database, failID)
+		if e.DeliveredAt != nil {
+			t.Fatalf("event dead-lettered too early (after %d passes)", i)
+		}
+		n.deliverEvent(e)
+	}
+
+	final := fetchEvent(t, database, failID)
+	if final.DeliveredAt == nil {
+		t.Fatalf("event should be dead-lettered (delivered_at stamped) after %d attempts", maxEventAttempts)
+	}
+	if !strings.HasPrefix(final.LastError, "DLQ:") {
+		t.Fatalf("expected DLQ last_error, got %q", final.LastError)
+	}
+	if final.Attempts < maxEventAttempts {
+		t.Fatalf("expected attempts ≥ %d, got %d", maxEventAttempts, final.Attempts)
+	}
+}


### PR DESCRIPTION
Switches notification delivery from synchronous fire-and-forget to the durable outbox: handleEvent persists only; a sweeper polls undelivered → fires rules → marks delivered. Restart/transient-failure can't silently drop a notification; events replayable. Retry only when ALL matched rules failed (no double-ping), DLQ past maxEventAttempts. Replay log pruned. Tests: no-rule→delivered, always-fail→retry→DLQ. build+vet+tests green. Next: slice-C ECA rules table, slice-D /webhook HMAC. 🤖 Generated with [Claude Code](https://claude.com/claude-code)