### PR TITLE
feat(tasks): last_activity_at — stale clock resets on activity (calibration)

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -449,6 +449,10 @@ func migrate(conn *sql.DB) error {
 		"blocked_periods": "TEXT NOT NULL DEFAULT '[]'", // json array of {start,end} (blocked_at[])
 		"in_review_at":    "TEXT",
 		"done_at":         "TEXT",
+		// last_activity_at bumps on any agent activity (transition / comment /
+		// progress note) so the stale-scanner measures idle-since-activity, not
+		// idle-since-dispatch — a heads-down lead on a multi-hour build isn't stale.
+		"last_activity_at": "TEXT",
 	})
 	// Migrate legacy reply_to_task -> parent_task_id
 	_, _ = conn.Exec(`UPDATE tasks SET parent_task_id = reply_to_task WHERE reply_to_task IS NOT NULL AND parent_task_id IS NULL`)
@@ -879,6 +883,12 @@ func migrate(conn *sql.DB) error {
 	)`)
 	_, _ = conn.Exec(`CREATE INDEX IF NOT EXISTS idx_events_undelivered ON events(delivered_at) WHERE delivered_at IS NULL`)
 	_, _ = conn.Exec(`CREATE INDEX IF NOT EXISTS idx_events_created ON events(id DESC)`)
+
+	// Backfill last_activity_at for rows that predate the column: seed it from the
+	// best existing timestamp so the stale-scanner has a baseline (idempotent —
+	// only fills NULLs).
+	_, _ = conn.Exec(`UPDATE tasks SET last_activity_at = COALESCE(started_at, accepted_at, dispatched_at)
+	                  WHERE last_activity_at IS NULL`)
 
 	// Lowercase all agent names for case-insensitive matching
 	migrateLowercaseAgentNames(conn)

--- a/internal/db/linear.go
+++ b/internal/db/linear.go
@@ -115,11 +115,11 @@ func (d *DB) UpsertLinearMirror(s LinearMirrorSeed) (taskID string, created bool
 		`INSERT INTO tasks
 		   (id, profile_slug, dispatched_by, title, description, priority, status, project, dispatched_at,
 		    source, linear_issue_id, linear_key, external_url, points, labels, linear_state, assignee,
-		    cycle_id, cycle_name, cycle_start, cycle_end, parent_task_id, linear_project_id, blocked_periods)
-		 VALUES (?, '', 'linear', ?, ?, ?, ?, ?, ?, 'linear', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, '[]')`,
+		    cycle_id, cycle_name, cycle_start, cycle_end, parent_task_id, linear_project_id, last_activity_at, blocked_periods)
+		 VALUES (?, '', 'linear', ?, ?, ?, ?, ?, ?, 'linear', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, '[]')`,
 		id, s.Title, s.Description, s.Priority, s.Status, s.Project, now,
 		s.LinearIssueID, s.LinearKey, s.ExternalURL, s.Points, s.Labels, s.LinearState, s.Assignee,
-		s.CycleID, s.CycleName, s.CycleStart, s.CycleEnd, s.ParentTaskID, s.LinearProjectID,
+		s.CycleID, s.CycleName, s.CycleStart, s.CycleEnd, s.ParentTaskID, s.LinearProjectID, now,
 	)
 	if err != nil {
 		return "", false, fmt.Errorf("insert linear mirror: %w", err)

--- a/internal/db/task_activity_test.go
+++ b/internal/db/task_activity_test.go
@@ -1,0 +1,41 @@
+package db
+
+import "testing"
+
+// TestLastActivityAt_BumpsOnActivity guards the stale-calibration fix: a task's
+// last_activity_at is stamped at dispatch and reset by activity (transition,
+// progress note) so the stale-scanner measures idle-since-activity, not
+// idle-since-dispatch.
+func TestLastActivityAt_BumpsOnActivity(t *testing.T) {
+	d := testDB(t)
+	const project = "p1"
+
+	task, err := d.DispatchTask(project, "", "dispatcher", "build me", "", "P1", nil, nil)
+	if err != nil {
+		t.Fatalf("dispatch: %v", err)
+	}
+	got, _ := d.GetTask(task.ID, project)
+	if got.LastActivityAt == nil || *got.LastActivityAt == "" {
+		t.Fatalf("last_activity_at must be stamped at dispatch")
+	}
+	atDispatch := *got.LastActivityAt
+
+	// A transition is activity → bumps last_activity_at.
+	if _, err := d.ClaimTask(task.ID, "agent-x", project); err != nil {
+		t.Fatalf("claim: %v", err)
+	}
+	got, _ = d.GetTask(task.ID, project)
+	if got.LastActivityAt == nil || *got.LastActivityAt < atDispatch {
+		t.Fatalf("transition must not regress last_activity_at (was %q, now %v)", atDispatch, got.LastActivityAt)
+	}
+	afterClaim := *got.LastActivityAt
+
+	// A progress note is activity → bumps it again.
+	if err := d.AddProgressNote(task.ID, project, "agent-x", "still working, big build"); err != nil {
+		t.Fatalf("progress note: %v", err)
+	}
+	got, _ = d.GetTask(task.ID, project)
+	if got.LastActivityAt == nil || *got.LastActivityAt < afterClaim {
+		t.Fatalf("progress note must bump last_activity_at (was %q, now %v)", afterClaim, got.LastActivityAt)
+	}
+}

--- a/internal/db/task_progress.go
+++ b/internal/db/task_progress.go
@@ -21,13 +21,16 @@ func (d *DB) AddProgressNote(taskID, project, agent, note string) error {
 	if note == "" {
 		return nil
 	}
+	now := time.Now().UTC().Format(time.RFC3339)
 	_, err := d.conn.Exec(
 		`INSERT INTO task_progress_notes (task_id, project, agent, note, created_at) VALUES (?, ?, ?, ?, ?)`,
-		taskID, project, agent, note, time.Now().UTC().Format(time.RFC3339),
+		taskID, project, agent, note, now,
 	)
 	if err != nil {
 		return fmt.Errorf("add progress note: %w", err)
 	}
+	// A comment / progress note is activity — reset the stale clock.
+	_, _ = d.conn.Exec("UPDATE tasks SET last_activity_at = ? WHERE id = ? AND project = ?", now, taskID, project)
 	return nil
 }
 

--- a/internal/db/tasks.go
+++ b/internal/db/tasks.go
@@ -63,7 +63,7 @@ var validTransitions = map[string][]string{
 
 const taskColumns = "id, profile_slug, assigned_to, dispatched_by, title, description, priority, status, result, blocked_reason, project, dispatched_at, accepted_at, started_at, completed_at, parent_task_id, ack_notified_at, ack_escalated_at, board_id, archived_at, " +
 	"source, linear_issue_id, linear_key, external_url, points, labels, linear_state, assignee, cycle_id, cycle_name, cycle_start, cycle_end, " +
-	"claimed_by, claimed_at, blocked_periods, in_review_at, done_at, linear_project_id"
+	"claimed_by, claimed_at, blocked_periods, in_review_at, done_at, linear_project_id, last_activity_at"
 
 func scanTask(row interface{ Scan(...any) error }) (models.Task, error) {
 	var t models.Task
@@ -73,7 +73,7 @@ func scanTask(row interface{ Scan(...any) error }) (models.Task, error) {
 		&t.AckNotifiedAt, &t.AckEscalatedAt, &t.BoardID, &t.ArchivedAt,
 		&t.Source, &t.LinearIssueID, &t.LinearKey, &t.ExternalURL, &t.Points, &t.Labels,
 		&t.LinearState, &t.Assignee, &t.CycleID, &t.CycleName, &t.CycleStart, &t.CycleEnd,
-		&t.ClaimedBy, &t.ClaimedAt, &t.BlockedPeriods, &t.InReviewAt, &t.DoneAt, &t.LinearProjectID)
+		&t.ClaimedBy, &t.ClaimedAt, &t.BlockedPeriods, &t.InReviewAt, &t.DoneAt, &t.LinearProjectID, &t.LastActivityAt)
 	return t, err
 }
 
@@ -101,10 +101,10 @@ func (d *DB) DispatchTask(project, profileSlug, dispatchedBy, title, description
 	}
 
 	_, err := d.conn.Exec(
-		`INSERT INTO tasks (id, profile_slug, dispatched_by, title, description, priority, status, project, dispatched_at, parent_task_id, board_id, source)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'native')`,
+		`INSERT INTO tasks (id, profile_slug, dispatched_by, title, description, priority, status, project, dispatched_at, parent_task_id, board_id, source, last_activity_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'native', ?)`,
 		task.ID, task.ProfileSlug, task.DispatchedBy, task.Title, task.Description,
-		task.Priority, task.Status, task.Project, task.DispatchedAt, task.ParentTaskID, task.BoardID,
+		task.Priority, task.Status, task.Project, task.DispatchedAt, task.ParentTaskID, task.BoardID, task.DispatchedAt,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("dispatch task: %w", err)
@@ -293,6 +293,9 @@ func (d *DB) transitionTask(taskID, agentName, project, newStatus string, result
 	if n, raErr := res.RowsAffected(); raErr == nil && n == 0 {
 		return nil, fmt.Errorf("concurrent transition on task %s: status changed from %q before %q could apply", taskID, oldStatus, newStatus)
 	}
+	// A transition is activity — reset the stale clock.
+	_, _ = d.conn.Exec("UPDATE tasks SET last_activity_at = ? WHERE id = ? AND project = ?", now, taskID, project)
+	task.LastActivityAt = &now
 	return task, nil
 }
 

--- a/internal/models/task.go
+++ b/internal/models/task.go
@@ -45,6 +45,9 @@ type Task struct {
 	BlockedPeriods string  `json:"blocked_periods"` // json array of {start,end}
 	InReviewAt     *string `json:"in_review_at,omitempty"`
 	DoneAt         *string `json:"done_at,omitempty"`
+	// LastActivityAt bumps on transition/comment/progress-note — the stale-scanner
+	// measures idle from here, not from dispatch.
+	LastActivityAt *string `json:"last_activity_at,omitempty"`
 
 	Subtasks []Task `json:"subtasks,omitempty"`
 }


### PR DESCRIPTION
Stale-scanner measured idle from dispatch → heads-down leads on long builds looked stale. Add `last_activity_at`: stamped at creation, bumped on transition + comment/progress note → idle measured since activity, not dispatch. Additive nullable column, backfilled from COALESCE(started_at,accepted_at,dispatched_at). blocked already excluded by the rule gate; 3h/6h thresholds are scanner-side. Regression test included. build+vet+tests green. 🤖 Generated with [Claude Code](https://claude.com/claude-code)