### PR TITLE
feat(memory): TSU-51 slice-A — remember verb (ADR-style decision log)

### DIFF
--- a/internal/db/decisions.go
+++ b/internal/db/decisions.go
@@ -1,0 +1,108 @@
+package db
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"agent-relay/internal/models"
+)
+
+// DecisionValue is the structured payload stored in a decision memory's value
+// (layer="decision"). The ADR record: the settled rule + why, its lifecycle
+// status, the area it governs, and the prior decision it replaces.
+type DecisionValue struct {
+	Decision   string `json:"decision"`
+	Rationale  string `json:"rationale,omitempty"`
+	Status     string `json:"status"` // accepted | superseded | needs_review
+	Area       string `json:"area,omitempty"`
+	Supersedes string `json:"supersedes,omitempty"`
+}
+
+// decisionKeyArea sanitizes an area into the key segment (DEC-<area>-NNN): keys
+// can't carry slashes/spaces, but the original area is preserved in the value.
+func decisionKeyArea(area string) string {
+	a := strings.ToLower(strings.TrimSpace(area))
+	a = strings.NewReplacer("/", "-", " ", "-", "_", "-").Replace(a)
+	if a == "" {
+		a = "general"
+	}
+	return a
+}
+
+// nextDecisionSeq returns the next monotonic number for an area's DEC keys.
+// Counts all (incl. archived) so numbers are never reused.
+func (d *DB) nextDecisionSeq(project, keyArea string) int {
+	var n int
+	_ = d.ro().QueryRow(
+		`SELECT COUNT(*) FROM memories WHERE layer='decision' AND project=? AND key LIKE ?`,
+		project, "DEC-"+keyArea+"-%",
+	).Scan(&n)
+	return n + 1
+}
+
+// RememberDecision records an ADR-style decision as a memory (layer="decision",
+// scope="project" so the whole team reads it). key = DEC-<area>-NNN. Enforces
+// dedup-or-supersede: an active decision in the same area with the same text is
+// rejected unless `supersedes` is given; on supersede the named prior decision
+// is archived so only the live set stays "accepted". Returns the new decision.
+func (d *DB) RememberDecision(project, agent, area, decision, rationale string, tags []string, supersedes string) (*models.Memory, error) {
+	decision = strings.TrimSpace(decision)
+	if decision == "" {
+		return nil, fmt.Errorf("decision text is required")
+	}
+	keyArea := decisionKeyArea(area)
+
+	// Dedup-or-supersede: reject a near-identical active decision in this area
+	// unless the caller explicitly supersedes one.
+	if supersedes == "" {
+		active, _ := d.GetMemoriesByLayer(project, "", "decision")
+		for _, m := range active {
+			var dv DecisionValue
+			if json.Unmarshal([]byte(m.Value), &dv) != nil {
+				continue
+			}
+			if decisionKeyArea(dv.Area) == keyArea && normalizeDecisionText(dv.Decision) == normalizeDecisionText(decision) {
+				return nil, fmt.Errorf("near-duplicate of %s (%q) — pass supersedes=%q to replace it", m.Key, dv.Decision, m.Key)
+			}
+		}
+	} else if err := d.archiveDecision(project, supersedes, agent); err != nil {
+		return nil, err
+	}
+
+	key := fmt.Sprintf("DEC-%s-%d", keyArea, d.nextDecisionSeq(project, keyArea))
+	val := DecisionValue{Decision: decision, Rationale: strings.TrimSpace(rationale), Status: "accepted", Area: strings.TrimSpace(area), Supersedes: supersedes}
+	vj, _ := json.Marshal(val)
+
+	// Tag with the area for search/filtering (plus any caller tags).
+	allTags := append([]string{"decision", keyArea}, tags...)
+	return d.SetMemory(project, agent, key, string(vj), TagsToJSON(allTags), "project", "stated", "decision", true)
+}
+
+// archiveDecision marks a prior decision superseded (archived → leaves the
+// accepted set). Errors if the key isn't an active decision.
+func (d *DB) archiveDecision(project, key, agent string) error {
+	now := time.Now().UTC().Format(memoryTimeFmt)
+	res, err := d.conn.Exec(
+		`UPDATE memories SET archived_at=?, archived_by=? WHERE project=? AND key=? AND layer='decision' AND archived_at IS NULL`,
+		now, "superseded:"+agent, project, key,
+	)
+	if err != nil {
+		return fmt.Errorf("archive superseded decision: %w", err)
+	}
+	if n, _ := res.RowsAffected(); n == 0 {
+		return fmt.Errorf("supersedes %q: no active decision with that id", key)
+	}
+	return nil
+}
+
+// ListDecisions returns the accepted (active, non-superseded) decisions for a
+// project — the bounded set injected at session start.
+func (d *DB) ListDecisions(project string) ([]models.Memory, error) {
+	return d.GetMemoriesByLayer(project, "", "decision")
+}
+
+func normalizeDecisionText(s string) string {
+	return strings.Join(strings.Fields(strings.ToLower(s)), " ")
+}

--- a/internal/db/decisions_test.go
+++ b/internal/db/decisions_test.go
@@ -1,0 +1,74 @@
+package db
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestRememberDecision covers TSU-51 slice-A: ADR-style decisions stored as
+// project memories, monotonic DEC keys, dedup-or-supersede, and recall of the
+// accepted (non-superseded) set.
+func TestRememberDecision(t *testing.T) {
+	d := testDB(t)
+	const project = "p1"
+
+	m1, err := d.RememberDecision(project, "wraith-dev", "ingest/hooks",
+		"POST hook events to the relay; no file-drop watcher", "watcher deadlocked the detector", []string{"arch"}, "")
+	if err != nil {
+		t.Fatalf("remember: %v", err)
+	}
+	if m1.Key != "DEC-ingest-hooks-1" {
+		t.Fatalf("key = %q, want DEC-ingest-hooks-1", m1.Key)
+	}
+
+	// A second decision in the same area gets the next sequence number.
+	m2, err := d.RememberDecision(project, "wraith-dev", "ingest/hooks",
+		"tokens come from the Stop hook reading the transcript", "", nil, "")
+	if err != nil {
+		t.Fatalf("remember 2: %v", err)
+	}
+	if m2.Key != "DEC-ingest-hooks-2" {
+		t.Fatalf("key = %q, want DEC-ingest-hooks-2", m2.Key)
+	}
+
+	// Dedup: re-asserting the same decision text in the area without supersedes is rejected.
+	if _, err := d.RememberDecision(project, "wraith-dev", "ingest/hooks",
+		"POST hook events to the relay; no file-drop watcher", "", nil, ""); err == nil {
+		t.Fatal("expected near-duplicate to be rejected without supersedes")
+	}
+
+	// Recall: 2 accepted decisions.
+	accepted, err := d.ListDecisions(project)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(accepted) != 2 {
+		t.Fatalf("want 2 accepted, got %d", len(accepted))
+	}
+
+	// Supersede m1 with a revised decision → m1 archived, accepted set still has 2
+	// (m2 + the new one), m1 gone.
+	m3, err := d.RememberDecision(project, "wraith-dev", "ingest/hooks",
+		"POST hook events to the relay over HTTP/2", "perf", nil, m1.Key)
+	if err != nil {
+		t.Fatalf("supersede: %v", err)
+	}
+	var dv DecisionValue
+	if err := json.Unmarshal([]byte(m3.Value), &dv); err != nil || dv.Supersedes != m1.Key {
+		t.Fatalf("new decision must record supersedes=%s, got %+v (err %v)", m1.Key, dv, err)
+	}
+	accepted, _ = d.ListDecisions(project)
+	if len(accepted) != 2 {
+		t.Fatalf("after supersede want 2 accepted, got %d", len(accepted))
+	}
+	for _, m := range accepted {
+		if m.Key == m1.Key {
+			t.Fatalf("superseded decision %s must not be in the accepted set", m1.Key)
+		}
+	}
+
+	// Superseding a non-existent decision errors.
+	if _, err := d.RememberDecision(project, "wraith-dev", "x", "y", "", nil, "DEC-nope-9"); err == nil {
+		t.Fatal("expected error superseding a non-existent decision")
+	}
+}

--- a/internal/relay/handlers_memory.go
+++ b/internal/relay/handlers_memory.go
@@ -76,6 +76,40 @@ func (h *Handlers) HandleGetMemory(ctx context.Context, req mcp.CallToolRequest)
 	return h.resultJSONTracked(project, agent, "get_memory", result)
 }
 
+// HandleRemember records an ADR-style decision (TSU-51). Decisions are project
+// memories (layer="decision"); the accepted set is surfaced at session start so
+// agents stop re-litigating settled calls.
+func (h *Handlers) HandleRemember(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	project := resolveProject(ctx, req)
+	agent := resolveAgent(ctx, req)
+	decision := req.GetString("decision", "")
+	if decision == "" {
+		return mcp.NewToolResultError("decision is required (the settled rule, one line)"), nil
+	}
+	rationale := req.GetString("rationale", "")
+	area := req.GetString("area", "")
+	tags := req.GetStringSlice("tags", nil)
+	supersedes := req.GetString("supersedes", "")
+
+	mem, err := h.db.RememberDecision(project, agent, area, decision, rationale, tags, supersedes)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("failed to remember decision: %v", err)), nil
+	}
+	h.events.Emit(MCPEvent{Type: "memory", Action: "decision", Agent: agent, Project: project, Label: mem.Key})
+	return h.resultJSONTracked(project, agent, "remember", map[string]any{"decision": mem})
+}
+
+// HandleRecallDecisions returns the project's accepted (non-superseded) decisions.
+func (h *Handlers) HandleRecallDecisions(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	project := resolveProject(ctx, req)
+	agent := resolveAgent(ctx, req)
+	decs, err := h.db.ListDecisions(project)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("failed to recall decisions: %v", err)), nil
+	}
+	return h.resultJSONTracked(project, agent, "recall_decisions", map[string]any{"decisions": decs, "count": len(decs)})
+}
+
 func (h *Handlers) HandleSearchMemory(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	project := resolveProject(ctx, req)
 	agent := resolveAgent(ctx, req)

--- a/internal/relay/tools.go
+++ b/internal/relay/tools.go
@@ -220,6 +220,29 @@ func setMemoryTool() mcp.Tool {
 	)
 }
 
+func rememberTool() mcp.Tool {
+	return mcp.NewTool(
+		"remember",
+		mcp.WithDescription("Record a SETTLED decision (ADR-style) so the team stops re-debating it. Stored as a project decision; the accepted set is surfaced at session start. Enforces dedup-or-supersede: a near-identical decision in the same area is rejected unless you pass `supersedes`."),
+		asParam,
+		projectParam,
+		mcp.WithString("decision", mcp.Description("The settled rule, one line (e.g. 'POST hook events to the relay; no file-drop watcher')"), mcp.Required()),
+		mcp.WithString("rationale", mcp.Description("Why, one line")),
+		mcp.WithString("area", mcp.Description("Component/area it governs (e.g. 'ingest/hooks') — groups the DEC key")),
+		mcp.WithArray("tags", mcp.Description("Extra tags for search"), mcp.WithStringItems()),
+		mcp.WithString("supersedes", mcp.Description("DEC id this replaces (archives the prior decision)")),
+	)
+}
+
+func recallDecisionsTool() mcp.Tool {
+	return mcp.NewTool(
+		"recall_decisions",
+		mcp.WithDescription("List the project's accepted decisions (the live, non-superseded set). Read before re-litigating a settled call."),
+		asParam,
+		projectParam,
+	)
+}
+
 func getMemoryTool() mcp.Tool {
 	return mcp.NewTool(
 		"get_memory",

--- a/internal/relay/toolset.go
+++ b/internal/relay/toolset.go
@@ -84,6 +84,8 @@ func (h *Handlers) toolRegistry() []registeredTool {
 		{server.ServerTool{Tool: listMemoriesTool(), Handler: h.HandleListMemories}, "memory"},
 		{server.ServerTool{Tool: deleteMemoryTool(), Handler: h.HandleDeleteMemory}, "memory"},
 		{server.ServerTool{Tool: resolveConflictTool(), Handler: h.HandleResolveConflict}, "memory"},
+		{server.ServerTool{Tool: rememberTool(), Handler: h.HandleRemember}, "memory"},
+		{server.ServerTool{Tool: recallDecisionsTool(), Handler: h.HandleRecallDecisions}, "memory"},
 
 		{server.ServerTool{Tool: registerProfileTool(), Handler: h.HandleRegisterProfile}, "profiles"},
 		{server.ServerTool{Tool: getProfileTool(), Handler: h.HandleGetProfile}, "profiles"},
@@ -139,6 +141,7 @@ var mutatingTools = map[string]bool{
 	"batch_complete_tasks": true, "batch_dispatch_tasks": true,
 	"create_board": true, "archive_board": true, "delete_board": true,
 	"set_memory": true, "delete_memory": true, "resolve_conflict": true,
+	"remember":         true,
 	"register_profile": true,
 	"deactivate_agent": true, "delete_agent": true, "sleep_agent": true,
 	"create_org": true, "create_team": true, "add_team_member": true,


### PR DESCRIPTION
`remember` records a settled decision as a project memory (layer=decision, no vendor). key=DEC-<area>-NNN, dedup-or-supersede (near-dup rejected unless supersedes; supersede archives prior). `recall_decisions` returns the accepted set. Reuses SetMemory supersedes-chain + GetMemoriesByLayer. Tests: keys/dedup/supersede/recall. Next slice-B: SessionStart injection. build+vet+tests green. 🤖 Generated with [Claude Code](https://claude.com/claude-code)