### PR TITLE
feat(memory): TSU-51 slice-B — inject accepted decisions at session start

### DIFF
--- a/internal/relay/handlers.go
+++ b/internal/relay/handlers.go
@@ -695,10 +695,29 @@ func (h *Handlers) buildSessionContext(project, agentName string, profileSlug *s
 	if err != nil || memories == nil {
 		memories = []models.Memory{}
 	}
+	// Decisions get a dedicated section below, so drop layer="decision" from the
+	// generic memory view — never let the memory budget crowd out settled calls.
+	kept := memories[:0]
+	for _, m := range memories {
+		if m.Layer != "decision" {
+			kept = append(kept, m)
+		}
+	}
+	memories = kept
 	projectedMems := projectMemories(memories, sessionMemoryBudget)
 	result["relevant_memories"] = projectedMems
 	if len(projectedMems) < len(memories) {
 		result["memories_omitted"] = len(memories) - len(projectedMems)
+	}
+
+	// Accepted decisions — the settled-calls set (TSU-51), ALWAYS surfaced so a
+	// new agent reads them before re-litigating. Bounded; full text via
+	// recall_decisions / get_memory(key).
+	if decs, derr := h.db.ListDecisions(project); derr == nil && len(decs) > 0 {
+		result["decisions"] = projectDecisions(decs, sessionDecisionMax)
+		if len(decs) > sessionDecisionMax {
+			result["decisions_omitted"] = len(decs) - sessionDecisionMax
+		}
 	}
 
 	// Vault/doc context is served externally (the doc-context host), not injected here.

--- a/internal/relay/project.go
+++ b/internal/relay/project.go
@@ -1,8 +1,10 @@
 package relay
 
 import (
+	"encoding/json"
 	"unicode/utf8"
 
+	"agent-relay/internal/db"
 	"agent-relay/internal/models"
 )
 
@@ -341,6 +343,42 @@ func memorySummaryBytes(s MemorySummary) int {
 // Constraints-layer memories bypass the budget (mirrors the P0-bypass rule):
 // a CTO constraint must always survive into the boot payload. The caller
 // (ListBootMemories) already orders constraints first, then updated_at DESC.
+// sessionDecisionMax bounds how many accepted decisions are injected at session
+// start. Decisions are one-liners, so the count keeps the section bounded
+// without a byte budget; the overflow count is surfaced and the rest are
+// reachable via recall_decisions.
+const sessionDecisionMax = 40
+
+// DecisionSummary is the compact session-context form of an accepted decision.
+type DecisionSummary struct {
+	Key       string `json:"key"`
+	Area      string `json:"area,omitempty"`
+	Decision  string `json:"decision"`
+	Rationale string `json:"rationale,omitempty"`
+}
+
+// projectDecisions decodes accepted decision memories into the compact boot form,
+// capped at max.
+func projectDecisions(decs []models.Memory, max int) []DecisionSummary {
+	if max > 0 && len(decs) > max {
+		decs = decs[:max]
+	}
+	out := make([]DecisionSummary, 0, len(decs))
+	for _, m := range decs {
+		s := DecisionSummary{Key: m.Key}
+		var dv db.DecisionValue
+		if json.Unmarshal([]byte(m.Value), &dv) == nil && dv.Decision != "" {
+			s.Decision = dv.Decision
+			s.Area = dv.Area
+			s.Rationale = dv.Rationale
+		} else {
+			s.Decision = m.Value
+		}
+		out = append(out, s)
+	}
+	return out
+}
+
 func projectMemories(mems []models.Memory, maxBytes int) []MemorySummary {
 	if len(mems) == 0 {
 		return []MemorySummary{}

--- a/internal/relay/session_decisions_test.go
+++ b/internal/relay/session_decisions_test.go
@@ -1,0 +1,46 @@
+package relay
+
+import (
+	"path/filepath"
+	"testing"
+
+	"agent-relay/internal/db"
+)
+
+// TestSessionContext_InjectsDecisions covers TSU-51 slice-B: the accepted
+// decision set is surfaced in the session-start context as its own `decisions`
+// section, and decisions are NOT double-listed in relevant_memories.
+func TestSessionContext_InjectsDecisions(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	database, err := db.NewTestDB(dbPath)
+	if err != nil {
+		t.Fatalf("create test db: %v", err)
+	}
+	t.Cleanup(func() { _ = database.Close() })
+	h := NewHandlers(database, NewSessionRegistry(nil), nil, NewEventBus())
+	const project = "p1"
+
+	if _, err := database.RememberDecision(project, "wraith-dev", "ingest/hooks",
+		"POST hook events to the relay; no file-drop watcher", "watcher deadlocked", nil, ""); err != nil {
+		t.Fatalf("remember: %v", err)
+	}
+
+	ctx := h.buildSessionContext(project, "wraith-dev", nil)
+
+	decs, ok := ctx["decisions"].([]DecisionSummary)
+	if !ok || len(decs) != 1 {
+		t.Fatalf("session context must carry 1 decision, got %v (%T)", ctx["decisions"], ctx["decisions"])
+	}
+	if decs[0].Key != "DEC-ingest-hooks-1" || decs[0].Decision == "" {
+		t.Fatalf("decision summary wrong: %+v", decs[0])
+	}
+
+	// The decision must NOT also appear in relevant_memories (no double-listing).
+	if mems, ok := ctx["relevant_memories"].([]MemorySummary); ok {
+		for _, m := range mems {
+			if m.Key == "DEC-ingest-hooks-1" {
+				t.Fatalf("decision leaked into relevant_memories — should be decisions-only")
+			}
+		}
+	}
+}


### PR DESCRIPTION
Completes the decision-log: `get_session_context` surfaces the project's accepted decisions as a dedicated `decisions` section (bounded, overflow surfaced) so new agents read settled calls without asking. Decisions dropped from relevant_memories (own section, budget can't crowd them out). Test included. build+vet+tests green. TSU-51 done (A+B). 🤖 Generated with [Claude Code](https://claude.com/claude-code)