### PR TITLE
fix(stale): Linear dispatch transition bumps last_activity_at

### DIFF
--- a/internal/db/linear.go
+++ b/internal/db/linear.go
@@ -107,6 +107,14 @@ func (d *DB) UpsertLinearMirror(s LinearMirrorSeed) (taskID string, created bool
 		if err != nil {
 			return "", false, fmt.Errorf("update linear mirror: %w", err)
 		}
+		// A Linear-driven status CHANGE is activity — the dispatch (Todo→In
+		// Progress) is the OPPOSITE of stale, but the mirror update alone left
+		// last_activity_at at created_at, so a freshly dispatched task read as
+		// instantly stale. Bump it on any status transition, mirroring the
+		// agent-side reset-on-activity (transitionTask).
+		if existing.Status != s.Status {
+			_, _ = d.conn.Exec("UPDATE tasks SET last_activity_at = ? WHERE id = ?", now, existing.ID)
+		}
 		return existing.ID, false, nil
 	}
 

--- a/internal/db/linear_activity_test.go
+++ b/internal/db/linear_activity_test.go
@@ -1,0 +1,50 @@
+package db
+
+import "testing"
+
+// TestUpsertLinearMirror_BumpsActivityOnTransition guards the dispatch-flip
+// calibration bug: when a C-level moves a Linear issue Todo→In Progress (the
+// dispatch), the mirror must bump last_activity_at — a freshly dispatched task
+// is the OPPOSITE of stale. A content-only re-sync (same status) must NOT bump.
+func TestUpsertLinearMirror_BumpsActivityOnTransition(t *testing.T) {
+	d := testDB(t)
+	const project = "p1"
+	const old = "2020-01-01T00:00:00.000000Z"
+
+	// Mirror a pending (Todo) issue.
+	taskID, created, err := d.UpsertLinearMirror(LinearMirrorSeed{
+		Project: project, LinearIssueID: "iss-1", Title: "badge", Status: "pending",
+	})
+	if err != nil || !created {
+		t.Fatalf("insert: created=%v err=%v", created, err)
+	}
+	// Backdate last_activity_at to simulate a task dispatched hours after creation.
+	if _, err := d.conn.Exec("UPDATE tasks SET last_activity_at=? WHERE id=?", old, taskID); err != nil {
+		t.Fatalf("backdate: %v", err)
+	}
+
+	// Dispatch: Todo → In Progress (status changes) → must bump.
+	if _, _, err := d.UpsertLinearMirror(LinearMirrorSeed{
+		Project: project, LinearIssueID: "iss-1", Title: "badge", Status: "in-progress",
+	}); err != nil {
+		t.Fatalf("dispatch upsert: %v", err)
+	}
+	got, _ := d.GetTask(taskID, project)
+	if got.LastActivityAt == nil || *got.LastActivityAt == old {
+		t.Fatalf("dispatch transition must bump last_activity_at off %s, got %v", old, got.LastActivityAt)
+	}
+
+	// Backdate again, then a content-only re-sync (SAME status) must NOT bump.
+	if _, err := d.conn.Exec("UPDATE tasks SET last_activity_at=? WHERE id=?", old, taskID); err != nil {
+		t.Fatalf("backdate 2: %v", err)
+	}
+	if _, _, err := d.UpsertLinearMirror(LinearMirrorSeed{
+		Project: project, LinearIssueID: "iss-1", Title: "badge (edited title)", Status: "in-progress",
+	}); err != nil {
+		t.Fatalf("resync upsert: %v", err)
+	}
+	got, _ = d.GetTask(taskID, project)
+	if got.LastActivityAt == nil || *got.LastActivityAt != old {
+		t.Fatalf("content-only re-sync must NOT bump last_activity_at (want %s, got %v)", old, got.LastActivityAt)
+	}
+}


### PR DESCRIPTION
C-level dispatch (Todo→In Progress) updated status via the mirror but left last_activity_at at created_at → freshly dispatched task read as instantly stale (TSU-48 escalated at 17min vs 3h/6h threshold). Fix: UpsertLinearMirror bumps last_activity_at on a status transition (not on content-only re-sync), mirroring agent-side reset-on-activity. Regression test included. build+vet+tests green. 🤖 Generated with [Claude Code](https://claude.com/claude-code)