### PR TITLE
feat(obs): TSU-53 slice-A — per-agent $ cost rollup (per-tier, cache-aware)

### DIFF
--- a/internal/db/cost.go
+++ b/internal/db/cost.go
@@ -1,0 +1,102 @@
+package db
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// modelRate is a model tier's price per MILLION tokens (input / output), from
+// claude.com pricing (2026): Opus $5/$25, Sonnet $3/$15, Haiku $1/$5.
+type modelRate struct {
+	inPerMTok, outPerMTok float64
+}
+
+var modelRates = map[string]modelRate{
+	"opus":   {5, 25},
+	"sonnet": {3, 15},
+	"haiku":  {1, 5},
+}
+
+// rateForModel resolves a model string to its tier by substring (e.g.
+// "claude-opus-4-8" → opus). Falls back to the configured default tier, then opus.
+func rateForModel(model, fallback string) modelRate {
+	m := strings.ToLower(model)
+	for tier, r := range modelRates {
+		if strings.Contains(m, tier) {
+			return r
+		}
+	}
+	if r, ok := modelRates[strings.ToLower(fallback)]; ok {
+		return r
+	}
+	return modelRates["opus"]
+}
+
+// costUSD computes a turn's dollar cost at a tier. Cache reads bill at 0.1×
+// input and 5-min cache writes at 1.25× input (the conservative default) — NOT
+// flat input price, or long-running cached agents are massively over-reported.
+// Output bills at the output rate. Rates are per million tokens.
+func costUSD(r modelRate, input, output, cacheRead, cacheCreation int64) float64 {
+	const m = 1_000_000.0
+	return (float64(input)*r.inPerMTok +
+		float64(cacheRead)*r.inPerMTok*0.1 +
+		float64(cacheCreation)*r.inPerMTok*1.25 +
+		float64(output)*r.outPerMTok) / m
+}
+
+// AgentCost is the per-agent token + dollar rollup over a window.
+type AgentCost struct {
+	Agent  string  `json:"agent"`
+	Tokens int64   `json:"tokens"`
+	USD    float64 `json:"usd"`
+}
+
+// GetCostByAgent rolls up real-token usage into $ per agent since a time, pricing
+// each (agent, model) group at its tier (rows with no model use the configured
+// default tier, setting "cost_default_model", else opus). Legacy bytes-only rows
+// (pre-real-counts) contribute 0 $ — cost reflects measured tokens. Sorted by $ desc.
+func (d *DB) GetCostByAgent(project, since string) ([]AgentCost, error) {
+	fallback := strings.TrimSpace(d.GetSetting("cost_default_model"))
+	if fallback == "" {
+		fallback = "opus"
+	}
+	rows, err := d.ro().Query(`
+		SELECT agent, COALESCE(model, ''),
+		       SUM(input_tokens), SUM(output_tokens), SUM(cache_read_tokens), SUM(cache_creation_tokens)
+		FROM token_usage
+		WHERE project = ? AND created_at >= ?
+		GROUP BY agent, model`,
+		project, since,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("cost by agent: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	agg := map[string]*AgentCost{}
+	for rows.Next() {
+		var agent, model string
+		var in, out, cr, cc int64
+		if err := rows.Scan(&agent, &model, &in, &out, &cr, &cc); err != nil {
+			return nil, fmt.Errorf("scan cost: %w", err)
+		}
+		a := agg[agent]
+		if a == nil {
+			a = &AgentCost{Agent: agent}
+			agg[agent] = a
+		}
+		a.Tokens += in + out + cr + cc
+		a.USD += costUSD(rateForModel(model, fallback), in, out, cr, cc)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	out := make([]AgentCost, 0, len(agg))
+	for _, a := range agg {
+		out = append(out, *a)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].USD > out[j].USD })
+	return out, nil
+}

--- a/internal/db/cost_test.go
+++ b/internal/db/cost_test.go
@@ -1,0 +1,62 @@
+package db
+
+import (
+	"math"
+	"testing"
+)
+
+// TestGetCostByAgent covers TSU-53 slice-A: per-agent $ rollup priced per model
+// tier, with cache-read billed at 0.1× input (not flat), and a default-tier
+// fallback when the row has no model.
+func TestGetCostByAgent(t *testing.T) {
+	d := testDB(t)
+	const project = "p1"
+	const ts = "2026-06-26T00:00:00.000000Z"
+	const since = "2020-01-01T00:00:00.000000Z"
+
+	err := d.InsertTokenUsageBatch([]TokenRecord{
+		// opus: 1M input ($5) + 1M output ($25) + 1M cache_read (0.1×5 = $0.50) = $30.50
+		{Project: project, Agent: "alice", Model: "claude-opus-4-8", Input: 1_000_000, Output: 1_000_000, CacheRead: 1_000_000, CreatedAt: ts},
+		// sonnet: 1M input ($3)
+		{Project: project, Agent: "bob", Model: "claude-sonnet-4-6", Input: 1_000_000, CreatedAt: ts},
+	})
+	if err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	costs, err := d.GetCostByAgent(project, since)
+	if err != nil {
+		t.Fatalf("cost: %v", err)
+	}
+	if len(costs) != 2 {
+		t.Fatalf("want 2 agents, got %d", len(costs))
+	}
+	// Sorted by $ desc → alice first.
+	if costs[0].Agent != "alice" {
+		t.Fatalf("want alice first (higher $), got %q", costs[0].Agent)
+	}
+	if math.Abs(costs[0].USD-30.50) > 1e-6 {
+		t.Fatalf("alice cost = %.4f, want 30.50", costs[0].USD)
+	}
+	if math.Abs(costs[1].USD-3.0) > 1e-6 {
+		t.Fatalf("bob cost = %.4f, want 3.00", costs[1].USD)
+	}
+
+	// Default-tier fallback: a model-less row prices at the configured default.
+	d.SetSetting("cost_default_model", "haiku")
+	if err := d.InsertTokenUsageBatch([]TokenRecord{
+		{Project: project, Agent: "carol", Model: "", Input: 1_000_000, CreatedAt: ts}, // haiku input $1
+	}); err != nil {
+		t.Fatalf("insert carol: %v", err)
+	}
+	costs, _ = d.GetCostByAgent(project, since)
+	var carol float64 = -1
+	for _, c := range costs {
+		if c.Agent == "carol" {
+			carol = c.USD
+		}
+	}
+	if math.Abs(carol-1.0) > 1e-6 {
+		t.Fatalf("carol (model-less, default=haiku) cost = %.4f, want 1.00", carol)
+	}
+}

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -593,6 +593,9 @@ func migrate(conn *sql.DB) error {
 		"output_tokens":         "INTEGER NOT NULL DEFAULT 0",
 		"cache_read_tokens":     "INTEGER NOT NULL DEFAULT 0",
 		"cache_creation_tokens": "INTEGER NOT NULL DEFAULT 0",
+		// model tier the turn ran on (e.g. "claude-opus-4-8") — drives per-tier $
+		// cost. Empty when the hook didn't report it → costed at the default tier.
+		"model": "TEXT NOT NULL DEFAULT ''",
 	})
 	_, _ = conn.Exec(`CREATE INDEX IF NOT EXISTS idx_token_usage_project_time ON token_usage(project, created_at)`)
 	_, _ = conn.Exec(`CREATE INDEX IF NOT EXISTS idx_token_usage_agent_time ON token_usage(project, agent, created_at)`)

--- a/internal/db/token_usage.go
+++ b/internal/db/token_usage.go
@@ -18,6 +18,7 @@ type TokenRecord struct {
 	Output        int
 	CacheRead     int
 	CacheCreation int
+	Model         string
 	CreatedAt     string
 }
 
@@ -48,14 +49,14 @@ func (d *DB) InsertTokenUsageBatch(records []TokenRecord) error {
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	stmt, err := tx.Prepare("INSERT INTO token_usage (project, agent, tool, bytes, input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)")
+	stmt, err := tx.Prepare("INSERT INTO token_usage (project, agent, tool, bytes, input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens, model, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)")
 	if err != nil {
 		return err
 	}
 	defer func() { _ = stmt.Close() }()
 
 	for _, r := range records {
-		if _, err := stmt.Exec(r.Project, r.Agent, r.Tool, r.Bytes, r.Input, r.Output, r.CacheRead, r.CacheCreation, r.CreatedAt); err != nil {
+		if _, err := stmt.Exec(r.Project, r.Agent, r.Tool, r.Bytes, r.Input, r.Output, r.CacheRead, r.CacheCreation, r.Model, r.CreatedAt); err != nil {
 			return fmt.Errorf("insert token usage: %w", err)
 		}
 	}

--- a/internal/relay/api.go
+++ b/internal/relay/api.go
@@ -161,6 +161,8 @@ func (r *Relay) ServeAPI(w http.ResponseWriter, req *http.Request) {
 		r.apiGetTokenUsageByAgent(w, req)
 	case path == "/token-usage/timeseries" && req.Method == http.MethodGet:
 		r.apiGetTokenTimeSeries(w, req)
+	case path == "/cost" && req.Method == http.MethodGet:
+		r.apiGetCostByAgent(w, req)
 	// Agentic analytics (stats panel)
 	case path == "/stats" && req.Method == http.MethodGet:
 		r.apiGetAgentStats(w, req)
@@ -1775,6 +1777,24 @@ func (r *Relay) apiGetTokenUsageByProject(w http.ResponseWriter, req *http.Reque
 	}
 	if data == nil {
 		data = []db.TokenUsageSummary{}
+	}
+	writeJSON(w, data)
+}
+
+// apiGetCostByAgent returns the per-agent $ rollup (TSU-53). Path: /cost
+func (r *Relay) apiGetCostByAgent(w http.ResponseWriter, req *http.Request) {
+	project := req.URL.Query().Get("project")
+	if project == "" {
+		project = "default"
+	}
+	since := db.PeriodToSince(req.URL.Query().Get("period"))
+	data, err := r.DB.GetCostByAgent(project, since)
+	if err != nil {
+		apiError(w, http.StatusInternalServerError, "failed to get cost by agent", err)
+		return
+	}
+	if data == nil {
+		data = []db.AgentCost{}
 	}
 	writeJSON(w, data)
 }

--- a/internal/relay/handlers_ingest.go
+++ b/internal/relay/handlers_ingest.go
@@ -30,6 +30,7 @@ type ingestTokensReq struct {
 	Output        int    `json:"output"`
 	CacheRead     int    `json:"cache_read"`
 	CacheCreation int    `json:"cache_creation"`
+	Model         string `json:"model,omitempty"` // model tier the turn ran on (for $ cost)
 	TS            string `json:"ts,omitempty"`
 }
 
@@ -93,6 +94,7 @@ func (r *Relay) handleIngestTokens(w http.ResponseWriter, req *http.Request) {
 			Output:        body.Output,
 			CacheRead:     body.CacheRead,
 			CacheCreation: body.CacheCreation,
+			Model:         body.Model,
 			CreatedAt:     body.TS,
 		})
 	}


### PR DESCRIPTION
Observability foundation on existing token data. Adds model column to token_usage (additive, hook forward-compat) + GetCostByAgent: prices each (agent,model) at its tier (Opus/Sonnet/Haiku) with cache_read 0.1× input + cache-write 1.25× (not flat — else cached agents over-reported). Model-less rows → default tier (setting). `GET /api/cost`. Tests: tiered + cache + default fallback. Next: health badge, hard budget, board UI. build+vet+tests green. 🤖 Generated with [Claude Code](https://claude.com/claude-code)