### PR TITLE
fix(obs): cost falls back to bytes/4 estimate for legacy token rows

### DIFF
--- a/internal/db/cost.go
+++ b/internal/db/cost.go
@@ -63,7 +63,7 @@ func (d *DB) GetCostByAgent(project, since string) ([]AgentCost, error) {
 	}
 	rows, err := d.ro().Query(`
 		SELECT agent, COALESCE(model, ''),
-		       SUM(input_tokens), SUM(output_tokens), SUM(cache_read_tokens), SUM(cache_creation_tokens)
+		       SUM(input_tokens), SUM(output_tokens), SUM(cache_read_tokens), SUM(cache_creation_tokens), SUM(bytes)
 		FROM token_usage
 		WHERE project = ? AND created_at >= ?
 		GROUP BY agent, model`,
@@ -77,8 +77,8 @@ func (d *DB) GetCostByAgent(project, since string) ([]AgentCost, error) {
 	agg := map[string]*AgentCost{}
 	for rows.Next() {
 		var agent, model string
-		var in, out, cr, cc int64
-		if err := rows.Scan(&agent, &model, &in, &out, &cr, &cc); err != nil {
+		var in, out, cr, cc, bytes int64
+		if err := rows.Scan(&agent, &model, &in, &out, &cr, &cc, &bytes); err != nil {
 			return nil, fmt.Errorf("scan cost: %w", err)
 		}
 		a := agg[agent]
@@ -86,8 +86,18 @@ func (d *DB) GetCostByAgent(project, since string) ([]AgentCost, error) {
 			a = &AgentCost{Agent: agent}
 			agg[agent] = a
 		}
-		a.Tokens += in + out + cr + cc
-		a.USD += costUSD(rateForModel(model, fallback), in, out, cr, cc)
+		rate := rateForModel(model, fallback)
+		if in+out+cr+cc > 0 {
+			a.Tokens += in + out + cr + cc
+			a.USD += costUSD(rate, in, out, cr, cc)
+		} else if bytes > 0 {
+			// Legacy bytes-only row (no real per-turn counts yet): estimate
+			// tokens at bytes/4 and price at the input rate — a rough, honest
+			// floor until the Stop hook feeds real input/output counts.
+			est := bytes / 4
+			a.Tokens += est
+			a.USD += costUSD(rate, est, 0, 0, 0)
+		}
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err

--- a/internal/db/cost_test.go
+++ b/internal/db/cost_test.go
@@ -60,3 +60,29 @@ func TestGetCostByAgent(t *testing.T) {
 		t.Fatalf("carol (model-less, default=haiku) cost = %.4f, want 1.00", carol)
 	}
 }
+
+// TestGetCostByAgent_BytesFallback covers the legacy path: a bytes-only row (no
+// real token counts) is estimated at bytes/4 tokens priced at the input rate.
+func TestGetCostByAgent_BytesFallback(t *testing.T) {
+	d := testDB(t)
+	const project = "p2"
+	const since = "2020-01-01T00:00:00.000000Z"
+	d.SetSetting("cost_default_model", "opus")
+
+	// 4M bytes → 1M estimated tokens at opus input ($5/MTok) = $5.00.
+	if err := d.InsertTokenUsageBatch([]TokenRecord{
+		{Project: project, Agent: "dave", Tool: "send_message", Bytes: 4_000_000, CreatedAt: "2026-06-26T00:00:00.000000Z"},
+	}); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	costs, err := d.GetCostByAgent(project, since)
+	if err != nil || len(costs) != 1 {
+		t.Fatalf("cost: len=%d err=%v", len(costs), err)
+	}
+	if costs[0].Tokens != 1_000_000 {
+		t.Fatalf("est tokens = %d, want 1_000_000 (bytes/4)", costs[0].Tokens)
+	}
+	if math.Abs(costs[0].USD-5.0) > 1e-6 {
+		t.Fatalf("bytes-fallback cost = %.4f, want 5.00", costs[0].USD)
+	}
+}


### PR DESCRIPTION
Live finding: all 23k prod token_usage rows are legacy bytes-only (real per-turn ingestion produces 0 rows) → cost was $0 for everyone. Estimate bytes/4 @ input rate for rows without real counts (honest floor, consistent with existing token reporting); real rows still price precisely. Test added. build+vet+tests green. 🤖 Generated with [Claude Code](https://claude.com/claude-code)