### PR TITLE
feat(obs): TSU-53 slice-B — per-agent health badge (last_seen x token-delta)

### DIFF
--- a/internal/db/health.go
+++ b/internal/db/health.go
@@ -1,0 +1,109 @@
+package db
+
+import "time"
+
+// Agent-health thresholds (TSU-53 slice-B).
+const (
+	healthDeadAfter    = 30 * time.Minute // no last_seen within → dead
+	healthRecentWindow = 10 * time.Minute // "spending now" window for working vs idle
+)
+
+// AgentHealth is a per-agent liveness + activity snapshot derived from last_seen
+// crossed with recent token spend — the data behind the board's health badge.
+type AgentHealth struct {
+	Agent        string `json:"agent"`
+	Status       string `json:"status"` // working | idle | dead
+	LastSeen     string `json:"last_seen"`
+	IdleSeconds  int64  `json:"idle_seconds"`
+	TokensRecent int64  `json:"tokens_recent"` // last healthRecentWindow
+	Tokens24h    int64  `json:"tokens_24h"`
+}
+
+// classifyHealth derives the badge from idle time × recent spend:
+//   - dead:    no activity within healthDeadAfter (the agent's process is gone)
+//   - working: seen recently AND spending tokens in the recent window
+//   - idle:    seen recently but quiet (waiting / blocked / between turns)
+//
+// (A "looping" state — fresh + spending + no progress — needs the repeated-tool
+// signal and lands in a follow-up; this is the liveness core.)
+func classifyHealth(idle time.Duration, tokensRecent int64) string {
+	switch {
+	case idle > healthDeadAfter:
+		return "dead"
+	case tokensRecent > 0:
+		return "working"
+	default:
+		return "idle"
+	}
+}
+
+// parseAgentTime parses a stored timestamp, tolerating both the microsecond
+// memory format and RFC3339 (different writers use each).
+func parseAgentTime(s string) (time.Time, bool) {
+	for _, layout := range []string{memoryTimeFmt, time.RFC3339Nano, time.RFC3339} {
+		if t, err := time.Parse(layout, s); err == nil {
+			return t, true
+		}
+	}
+	return time.Time{}, false
+}
+
+// GetAgentHealth returns the health snapshot for every agent in a project, newest
+// activity first. Tokens use the real per-turn counts when present, else the
+// bytes/4 estimate (an honest floor until the transcript hook feeds exact counts).
+func (d *DB) GetAgentHealth(project string) ([]AgentHealth, error) {
+	agents, err := d.ListAgents(project)
+	if err != nil {
+		return nil, err
+	}
+	now := time.Now().UTC()
+	recentSince := now.Add(-healthRecentWindow).Format(memoryTimeFmt)
+	daySince := now.Add(-24 * time.Hour).Format(memoryTimeFmt)
+
+	recent := d.tokensByAgentSince(project, recentSince)
+	day := d.tokensByAgentSince(project, daySince)
+
+	out := make([]AgentHealth, 0, len(agents))
+	for _, a := range agents {
+		h := AgentHealth{
+			Agent:        a.Name,
+			LastSeen:     a.LastSeen,
+			TokensRecent: recent[a.Name],
+			Tokens24h:    day[a.Name],
+		}
+		idle := time.Duration(0)
+		if t, ok := parseAgentTime(a.LastSeen); ok {
+			idle = now.Sub(t)
+			if idle < 0 {
+				idle = 0
+			}
+		} else {
+			idle = healthDeadAfter + time.Minute // unparseable → treat as dead
+		}
+		h.IdleSeconds = int64(idle.Seconds())
+		h.Status = classifyHealth(idle, h.TokensRecent)
+		out = append(out, h)
+	}
+	return out, nil
+}
+
+// tokensByAgentSince sums each agent's tokens since a time (real counts when
+// present, else bytes/4). Returns agent → tokens.
+func (d *DB) tokensByAgentSince(project, since string) map[string]int64 {
+	res := map[string]int64{}
+	rows, err := d.ro().Query(`SELECT agent, `+tokenSum+` FROM token_usage
+		WHERE project = ? AND created_at >= ? GROUP BY agent`, project, since)
+	if err != nil {
+		return res
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		var agent string
+		var toks int64
+		if err := rows.Scan(&agent, &toks); err != nil {
+			continue
+		}
+		res[agent] = toks
+	}
+	return res
+}

--- a/internal/db/health_test.go
+++ b/internal/db/health_test.go
@@ -1,0 +1,66 @@
+package db
+
+import (
+	"testing"
+	"time"
+)
+
+func TestClassifyHealth(t *testing.T) {
+	cases := []struct {
+		name         string
+		idle         time.Duration
+		tokensRecent int64
+		want         string
+	}{
+		{"fresh + spending = working", 1 * time.Minute, 5000, "working"},
+		{"fresh + quiet = idle", 2 * time.Minute, 0, "idle"},
+		{"stale = dead (even if it spent earlier)", 45 * time.Minute, 9999, "dead"},
+		{"just past the dead line", healthDeadAfter + time.Second, 0, "dead"},
+		{"right at the recent edge, spending", healthRecentWindow, 1, "working"},
+	}
+	for _, c := range cases {
+		if got := classifyHealth(c.idle, c.tokensRecent); got != c.want {
+			t.Fatalf("%s: classifyHealth(%v, %d) = %q, want %q", c.name, c.idle, c.tokensRecent, got, c.want)
+		}
+	}
+}
+
+// TestGetAgentHealth_Integration: a freshly-touched agent that spent tokens reads
+// "working"; the snapshot carries recent + 24h token totals.
+func TestGetAgentHealth_Integration(t *testing.T) {
+	d := testDB(t)
+	const project = "p1"
+
+	now := time.Now().UTC().Format(memoryTimeFmt)
+	if _, err := d.conn.Exec(
+		`INSERT INTO agents (id, name, role, registered_at, last_seen, project, status) VALUES (?, ?, 'eng', ?, ?, ?, 'active')`,
+		"agent-worker-1", "worker", now, now, project,
+	); err != nil {
+		t.Fatalf("insert agent: %v", err)
+	}
+	if err := d.InsertTokenUsageBatch([]TokenRecord{
+		{Project: project, Agent: "worker", Input: 1000, Output: 500, CreatedAt: now},
+	}); err != nil {
+		t.Fatalf("tokens: %v", err)
+	}
+
+	hs, err := d.GetAgentHealth(project)
+	if err != nil {
+		t.Fatalf("health: %v", err)
+	}
+	var w *AgentHealth
+	for i := range hs {
+		if hs[i].Agent == "worker" {
+			w = &hs[i]
+		}
+	}
+	if w == nil {
+		t.Fatal("worker missing from health")
+	}
+	if w.Status != "working" {
+		t.Fatalf("status = %q, want working (fresh + spending)", w.Status)
+	}
+	if w.TokensRecent != 1500 {
+		t.Fatalf("tokens_recent = %d, want 1500", w.TokensRecent)
+	}
+}

--- a/internal/relay/api.go
+++ b/internal/relay/api.go
@@ -55,6 +55,8 @@ func (r *Relay) ServeAPI(w http.ResponseWriter, req *http.Request) {
 		r.apiGetOrgTree(w, req)
 	case path == "/agents/all" && req.Method == http.MethodGet:
 		r.apiGetAllAgents(w)
+	case path == "/agents/health" && req.Method == http.MethodGet:
+		r.apiGetAgentHealth(w, req)
 	case path == "/conversations/all" && req.Method == http.MethodGet:
 		r.apiGetAllConversations(w)
 	case path == "/conversations" && req.Method == http.MethodGet:

--- a/internal/relay/api_messages.go
+++ b/internal/relay/api_messages.go
@@ -5,7 +5,27 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+
+	"agent-relay/internal/db"
 )
+
+// apiGetAgentHealth returns the per-agent health snapshot (TSU-53 slice-B).
+// Path: GET /api/agents/health
+func (r *Relay) apiGetAgentHealth(w http.ResponseWriter, req *http.Request) {
+	project := req.URL.Query().Get("project")
+	if project == "" {
+		project = "default"
+	}
+	data, err := r.DB.GetAgentHealth(project)
+	if err != nil {
+		http.Error(w, `{"error":"failed to get agent health"}`, http.StatusInternalServerError)
+		return
+	}
+	if data == nil {
+		data = []db.AgentHealth{}
+	}
+	writeJSON(w, data)
+}
 
 // apiPostMessage is the plain-REST send endpoint (owner directive: dokan scripts
 // notify the relay over REST, never the /mcp JSON-RPC call_tool dispatcher). It


### PR DESCRIPTION
`GET /api/agents/health` → per-agent status: dead / working / idle, from last_seen crossed with recent token spend (real counts or bytes/4 floor). Pure classifier unit-tested + integration test. 'looping' state is a follow-up. build+vet+tests green. 🤖 Generated with [Claude Code](https://claude.com/claude-code)