### PR TITLE
chore(install): delegate hook setup to 'agent-relay hooks install'

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -584,6 +584,17 @@ EOF
 install_hooks() {
   step 3 "Installing activity tracking hooks"
 
+  # Preferred path: the binary owns hook setup — embedded scripts + a pure-Go,
+  # idempotent settings.json merge (no python3 dependency, no partial state).
+  # Single source of truth: the same `agent-relay hooks install` users re-run
+  # later (and `hooks status` to diagnose). Fall back to the manual path below
+  # only if the freshly-installed binary can't run.
+  local _bin="${BIN_DIR}/${BINARY_NAME}"
+  if [[ -x "$_bin" ]] && "$_bin" hooks install; then
+    return
+  fi
+  warn "Binary 'hooks install' unavailable — falling back to manual hook setup"
+
   local hooks_dir="$HOME/.claude/hooks"
   local settings_file="$HOME/.claude/settings.json"
   mkdir -p "$hooks_dir"


### PR DESCRIPTION
install.sh delegates hook setup to the binary's `hooks install` (embedded scripts + pure-Go idempotent settings.json merge) — single source of truth, no python3 dep, no partial-wiring state. Manual download+python3 path kept as fallback if the fresh binary can't run. 🤖 Generated with [Claude Code](https://claude.com/claude-code)