### PR TITLE
fix(tools): init ?tools=full + skill/hook refresh on update (create_project not found)

### DIFF
--- a/.trovexignore
+++ b/.trovexignore
@@ -9,6 +9,9 @@ CLAUDE.md
 AGENTS.md
 LICENSE*
 .claude/*
+# Shipped skill docs: install.sh + the auto-updater download these from the repo
+# into ~/.claude/commands/ + ~/.claude/hooks/ — they MUST stay real files on disk.
+skill/**
 #
 # Blog articles stay publishable source files (they ship as web pages):
 **/blog/**

--- a/internal/cli/hooks.go
+++ b/internal/cli/hooks.go
@@ -85,6 +85,23 @@ func hooksInstall(scripts embed.FS, hooksDir, settingsPath string) {
 	fmt.Printf("✓ wrote %d hook scripts → %s\n", wrote, hooksDir)
 
 	// 2. Merge the hook wiring into settings.json (backup first, idempotent).
+	wired, err := mergeHookSettings(hooksDir, settingsPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "wire settings: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Printf("✓ wired %d new hook event(s) into %s\n", wired, settingsPath)
+	fmt.Println("  events: PreToolUse, PostToolUse, Stop, SubagentStart, SubagentStop, SessionStart")
+	fmt.Println("  hooks POST to ${RELAY_URL:-http://localhost:8090}; need `jq` + `curl` on PATH.")
+	fmt.Println("  Restart the Claude Code session (or /clear) so it reloads settings.json.")
+}
+
+// mergeHookSettings idempotently wires the on-disk hook scripts into the Claude
+// Code settings.json (backup first). Skips an event whose script isn't on disk
+// and an event already pointing at the script. Returns the count newly wired.
+// Shared by `hooks install` and the auto-updater's refresh so a `update` repairs
+// the wiring, not just the scripts.
+func mergeHookSettings(hooksDir, settingsPath string) (int, error) {
 	settings := map[string]any{}
 	if raw, err := os.ReadFile(settingsPath); err == nil {
 		_ = os.WriteFile(settingsPath+".bak", raw, 0o644) // best-effort backup
@@ -101,7 +118,7 @@ func hooksInstall(scripts embed.FS, hooksDir, settingsPath string) {
 	for _, he := range hookEvents {
 		cmd := filepath.Join(hooksDir, he.script)
 		if _, err := os.Stat(cmd); err != nil {
-			continue // script not on disk (e.g. not in this build) → don't wire a dead command
+			continue
 		}
 		arr, _ := hooks[he.event].([]any)
 		if hookAlreadyWired(arr, cmd) {
@@ -117,17 +134,12 @@ func hooksInstall(scripts embed.FS, hooksDir, settingsPath string) {
 
 	out, err := json.MarshalIndent(settings, "", "    ")
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "encode settings: %v\n", err)
-		os.Exit(1)
+		return 0, err
 	}
 	if err := os.WriteFile(settingsPath, append(out, '\n'), 0o644); err != nil {
-		fmt.Fprintf(os.Stderr, "write %s: %v\n", settingsPath, err)
-		os.Exit(1)
+		return 0, err
 	}
-	fmt.Printf("✓ wired %d new hook event(s) into %s\n", wired, settingsPath)
-	fmt.Println("  events: PreToolUse, PostToolUse, Stop, SubagentStart, SubagentStop, SessionStart")
-	fmt.Println("  hooks POST to ${RELAY_URL:-http://localhost:8090}; need `jq` + `curl` on PATH.")
-	fmt.Println("  Restart the Claude Code session (or /clear) so it reloads settings.json.")
+	return wired, nil
 }
 
 // hookAlreadyWired reports whether an event's hook array already runs cmd.

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 type mcpConfig struct {
@@ -66,11 +67,16 @@ func runInit(args []string) {
 
 	mcpPath := filepath.Join(dir, ".mcp.json")
 
-	// Build the URL
-	url := fmt.Sprintf("http://%s:%s/mcp", host, port)
+	// Build the URL. tools=full exposes every tool on tools/list so list-driven
+	// clients (Claude Code) can call create_project et al. directly — the default
+	// (discovery) only lists discover_tools + call_tool, which surfaces as
+	// "tool 'create_project' not found" for direct callers. Power users wanting the
+	// ~10k-token-lighter init can switch the URL to ?tools=discovery.
+	params := []string{"tools=full"}
 	if project != "" {
-		url += "?project=" + project
+		params = append([]string{"project=" + project}, params...)
 	}
+	url := fmt.Sprintf("http://%s:%s/mcp?%s", host, port, strings.Join(params, "&"))
 
 	// Check if file already exists
 	if _, err := os.Stat(mcpPath); err == nil {

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -393,7 +393,17 @@ func refreshSkillAndHooks(version string) {
 			hookOK++
 		}
 	}
-	fmt.Printf("skill %d/2, hooks %d/%d\n", skillOK, hookOK, len(hooks))
+
+	// Re-wire settings.json so an update REPAIRS the hook wiring, not just the
+	// scripts — a downloaded script that isn't referenced in settings.json never
+	// fires (the partial-state bug that left last_seen/tokens dead). Idempotent;
+	// skipped on Windows (bash hooks, .ps1 is a follow-up).
+	wired := 0
+	if runtime.GOOS != "windows" {
+		settingsPath := filepath.Join(home, ".claude", "settings.json")
+		wired, _ = mergeHookSettings(hooksDir, settingsPath)
+	}
+	fmt.Printf("skill %d/2, hooks %d/%d (wired %d new)\n", skillOK, hookOK, len(hooks), wired)
 }
 
 // verifyChecksum compares the SHA-256 of file against the entry for name in a

--- a/internal/relay/handlers_ingest.go
+++ b/internal/relay/handlers_ingest.go
@@ -131,6 +131,13 @@ func (r *Relay) handleIngestSessionStart(w http.ResponseWriter, req *http.Reques
 		})
 	}
 
+	// Always tell the session what to do when a tool looks missing — the #1
+	// confusion under discovery mode ("tool 'create_project' not found").
+	toolsHint := "agent-relay tools: if a tool isn't found (e.g. \"tool 'create_project' not found\"), " +
+		"this relay uses progressive disclosure — invoke any tool by name via call_tool(tool, args) " +
+		"(use discover_tools(category) first to get its schema), or add ?tools=full to the relay MCP URL " +
+		"in .mcp.json and run /mcp to list every tool directly."
+
 	resp := map[string]any{"bound": found}
 	if found {
 		resp["agent"] = name
@@ -138,9 +145,11 @@ func (r *Relay) handleIngestSessionStart(w http.ResponseWriter, req *http.Reques
 		resp["additionalContext"] = fmt.Sprintf(
 			"You are the agent-relay agent %q in project %q (session re-bound after %s). "+
 				"Your identity persists across /clear via this worktree. "+
-				"Call get_inbox to see messages addressed to you, and set ?agent=%s on the relay MCP URL.",
-			name, project, sourceOrStartup(body.Source), name,
+				"Call get_inbox to see messages addressed to you, and set ?agent=%s on the relay MCP URL. %s",
+			name, project, sourceOrStartup(body.Source), name, toolsHint,
 		)
+	} else {
+		resp["additionalContext"] = toolsHint
 	}
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(resp)

--- a/skill/relay.md
+++ b/skill/relay.md
@@ -119,19 +119,14 @@ Rules:
 
 ## Activity Tracking
 
-The relay tracks real-time agent activity via Claude Code hooks. Copy hook scripts from `skill/hooks/` to `~/.claude/hooks/` and add to `~/.claude/settings.json`:
+The dashboard's live signals (last_seen, activity stream, per-turn tokens/cost, identity re-bind on `/clear`) are fed by Claude Code hooks. Install them with one command — it writes the scripts to `~/.claude/hooks/` AND wires `~/.claude/settings.json` (idempotent, backs up first):
 
-```json
-{
-  "hooks": {
-    "PreToolUse": [{ "hooks": [{ "type": "command", "command": "~/.claude/hooks/ingest-pre-tool.sh", "timeout": 5 }] }],
-    "PostToolUse": [{ "hooks": [{ "type": "command", "command": "~/.claude/hooks/ingest-post-tool.sh", "timeout": 5 }] }],
-    "Stop": [{ "hooks": [{ "type": "command", "command": "~/.claude/hooks/ingest-stop.sh", "timeout": 5 }] }],
-    "SubagentStart": [{ "hooks": [{ "type": "command", "command": "~/.claude/hooks/ingest-subagent-start.sh", "timeout": 5 }] }],
-    "SubagentStop": [{ "hooks": [{ "type": "command", "command": "~/.claude/hooks/ingest-subagent-stop.sh", "timeout": 5 }] }]
-  }
-}
+```bash
+agent-relay hooks install   # then restart the session (or /clear) so it reloads settings.json
+agent-relay hooks status    # per-event diagnostic: is each script on disk AND wired?
 ```
+
+Requires `jq` + `curl`; hooks POST to `${RELAY_URL:-http://localhost:8090}` (set `RELAY_URL`/`RELAY_API_KEY` if the relay runs elsewhere or auth is on). `install.sh` runs this for you and the auto-updater re-runs the wiring on each update. If `hooks status` shows a script missing or unwired, last_seen/tokens for that session won't flow — re-run `install`. (Mac/Linux today; Windows uses `install.ps1` until native PowerShell hooks land.)
 
 Activity types: typing (Write/Edit), reading (Read/Glob/Grep), terminal (Bash), browsing (WebSearch), thinking (Agent/Skill), waiting (10s idle), idle (30s).
 
@@ -141,7 +136,7 @@ Link session to agent: pass `session_id` from `whoami` in `register_agent`.
 
 ## Token Efficiency
 
-- **Worker agents should connect with `?tools=discovery`** (`http://localhost:8090/mcp?tools=discovery`): only 2 tools are exposed (~460 tokens of schemas instead of ~11,000). Call `discover_tools(category)` to fetch one category's schemas, then `call_tool(tool: "send_message", args: {...})` to invoke. Categories: session, messaging, conversations, tasks, boards, memory, profiles, agents, teams, projects.
+- **Tools exposure modes (`?tools=` on the MCP URL).** `?tools=full` lists every tool (~11k tokens) so a list-driven client (Claude Code) can call them directly by name — this is what `agent-relay init` writes. `?tools=discovery` (the relay's bare default) lists only `discover_tools` + `call_tool` (~460 tokens). **If a tool seems missing** (e.g. `tool 'create_project' not found`), you are in discovery mode: call `discover_tools(category)` then `call_tool(tool: "create_project", args: {...})` — every tool stays callable that way — **or** add `?tools=full` to the relay URL in `.mcp.json` and run `/mcp` to reload. Categories: session, messaging, conversations, tasks, boards, memory, profiles, agents, teams, projects. (Token-conscious worker loops can opt into `?tools=discovery` + `call_tool`.)
 - **`get_inbox`, `list_tasks`, `list_agents`, `list_memories` return compact markdown tables by default** (~half the tokens of JSON). Pass `format: "json"` when you need the structured shape.
 - Default connection (no `?tools=`) keeps full schemas for compatibility.
 


### PR DESCRIPTION
Real users hit 'tool create_project not found' — relay defaults to discovery mode (only discover_tools/call_tool listed), and init wrote a URL with no ?tools=. Fix: init writes ?tools=full (all tools directly callable); skill/relay.md documents the modes + recovery + uses 'hooks install'; SessionStart context always carries a tool-not-found hint; auto-updater re-wires settings.json (not just downloads scripts); skill/** stays on disk. build+vet+tests green. 🤖 Generated with [Claude Code](https://claude.com/claude-code)