### PR TITLE
fix(cli): init upgrades existing .mcp.json URL to ?tools=full

### DIFF
--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -12,6 +12,21 @@ type mcpConfig struct {
 	MCPServers map[string]mcpServerEntry `json:"mcpServers"`
 }
 
+// ensureToolsFull appends ?tools=full (or &tools=full) to a relay MCP URL that
+// has no tools= mode, so list-driven clients see every tool. An explicit
+// tools=discovery is respected (returns unchanged). Returns the URL + whether it
+// changed.
+func ensureToolsFull(rawURL string) (string, bool) {
+	if strings.Contains(rawURL, "tools=") {
+		return rawURL, false
+	}
+	sep := "?"
+	if strings.Contains(rawURL, "?") {
+		sep = "&"
+	}
+	return rawURL + sep + "tools=full", true
+}
+
 type mcpServerEntry struct {
 	Type string `json:"type"`
 	URL  string `json:"url"`
@@ -85,9 +100,22 @@ func runInit(args []string) {
 		if err == nil {
 			var cfg mcpConfig
 			if json.Unmarshal(existing, &cfg) == nil {
-				if _, exists := cfg.MCPServers["agent-relay"]; exists {
+				if entry, exists := cfg.MCPServers["agent-relay"]; exists {
+					// Already configured — upgrade the URL to ?tools=full if it's
+					// missing, so an existing project gets the fix (list-driven
+					// clients couldn't see create_project under the discovery
+					// default) without a manual edit. Idempotent otherwise.
+					if upgraded, changed := ensureToolsFull(entry.URL); changed {
+						entry.URL = upgraded
+						cfg.MCPServers["agent-relay"] = entry
+						writeConfig(mcpPath, cfg)
+						fmt.Printf("upgraded agent-relay URL in %s (added tools=full)\n", mcpPath)
+						fmt.Printf("  url: %s\n", upgraded)
+						fmt.Println("  → run /mcp in Claude Code to reload")
+						return
+					}
 					fmt.Printf("agent-relay already configured in %s\n", mcpPath)
-					fmt.Printf("  url: %s\n", cfg.MCPServers["agent-relay"].URL)
+					fmt.Printf("  url: %s\n", entry.URL)
 					return
 				}
 				// Add agent-relay to existing config

--- a/internal/cli/init_test.go
+++ b/internal/cli/init_test.go
@@ -1,0 +1,22 @@
+package cli
+
+import "testing"
+
+func TestEnsureToolsFull(t *testing.T) {
+	cases := []struct {
+		in      string
+		want    string
+		changed bool
+	}{
+		{"http://localhost:8090/mcp", "http://localhost:8090/mcp?tools=full", true},
+		{"http://localhost:8090/mcp?project=demo", "http://localhost:8090/mcp?project=demo&tools=full", true},
+		{"http://localhost:8090/mcp?tools=full", "http://localhost:8090/mcp?tools=full", false},
+		{"http://localhost:8090/mcp?tools=discovery", "http://localhost:8090/mcp?tools=discovery", false},
+	}
+	for _, c := range cases {
+		got, changed := ensureToolsFull(c.in)
+		if got != c.want || changed != c.changed {
+			t.Fatalf("ensureToolsFull(%q) = (%q, %v), want (%q, %v)", c.in, got, changed, c.want, c.changed)
+		}
+	}
+}


### PR DESCRIPTION
init skipped when agent-relay was already configured → existing projects never got ?tools=full → create_project invisible. Now init upgrades the existing URL (idempotent, respects tools=discovery). Test added. build+vet+tests green. 🤖 Generated with [Claude Code](https://claude.com/claude-code)