### PR TITLE
feat(obs): TSU-53 slice-C — budget-exceeded alert (relay acts on the budget)

### DIFF
--- a/internal/db/quotas.go
+++ b/internal/db/quotas.go
@@ -131,7 +131,9 @@ func (d *DB) GetQuotaUsage(project, agentName string) (*models.QuotaUsage, error
 func (d *DB) countTokenUsage24h(project, agent string) int64 {
 	cutoff := time.Now().UTC().Add(-24 * time.Hour).Format(memoryTimeFmt)
 	var count int64
-	_ = d.ro().QueryRow(`SELECT COALESCE(SUM(bytes), 0) FROM token_usage WHERE project = ? AND agent = ? AND created_at > ?`,
+	// Use the real per-turn token count when present, else the bytes/4 estimate
+	// (tokenSum) — a per-day TOKEN quota must measure tokens, not raw payload bytes.
+	_ = d.ro().QueryRow(`SELECT COALESCE(`+tokenSum+`, 0) FROM token_usage WHERE project = ? AND agent = ? AND created_at > ?`,
 		project, agent, cutoff).Scan(&count)
 	return count
 }

--- a/internal/relay/agent_budget_test.go
+++ b/internal/relay/agent_budget_test.go
@@ -1,0 +1,62 @@
+package relay
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"agent-relay/internal/db"
+)
+
+// TestCheckBudgets covers TSU-53 slice-C: an agent over its per-day token quota
+// fires a budget-exceeded event (once/hour, deduped), and the quota measures
+// real tokens (tokenSum), not raw bytes.
+func TestCheckBudgets(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	database, err := db.NewTestDB(dbPath)
+	if err != nil {
+		t.Fatalf("db: %v", err)
+	}
+	t.Cleanup(func() { _ = database.Close() })
+	events := NewEventBus()
+	h := NewHandlers(database, NewSessionRegistry(nil), nil, events)
+
+	const project, agent = "p1", "greedy"
+	if err := database.SetAgentQuota(project, agent, 1000, 0, 0, 0); err != nil { // 1000 tokens/day
+		t.Fatalf("quota: %v", err)
+	}
+	now := time.Now().UTC().Format("2006-01-02T15:04:05.000000Z")
+	if err := database.InsertTokenUsageBatch([]db.TokenRecord{
+		{Project: project, Agent: agent, Input: 1500, Output: 600, CreatedAt: now}, // 2100 > 1000
+	}); err != nil {
+		t.Fatalf("tokens: %v", err)
+	}
+
+	// Quota measures real tokens now (tokenSum), so it's over.
+	allowed, used, limit := database.CheckQuota(project, agent, "tokens")
+	if allowed || used != 2100 || limit != 1000 {
+		t.Fatalf("CheckQuota = (allowed=%v used=%d limit=%d), want (false, 2100, 1000)", allowed, used, limit)
+	}
+
+	sub := events.Subscribe()
+	defer events.Unsubscribe(sub)
+
+	h.checkBudgets([]db.TokenRecord{{Project: project, Agent: agent}})
+	select {
+	case e := <-sub:
+		if e.Type != "event:budget-exceeded" || e.Semantic["agent"] != agent {
+			t.Fatalf("unexpected event: %+v", e)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected budget-exceeded event, none fired")
+	}
+
+	// Dedup: a second check within the hour fires nothing.
+	h.checkBudgets([]db.TokenRecord{{Project: project, Agent: agent}})
+	select {
+	case e := <-sub:
+		t.Fatalf("duplicate budget event within the hour: %+v", e)
+	case <-time.After(300 * time.Millisecond):
+		// good — deduped
+	}
+}

--- a/internal/relay/handlers.go
+++ b/internal/relay/handlers.go
@@ -27,6 +27,11 @@ type Handlers struct {
 	connMu    sync.RWMutex
 	connector connector.TaskConnector
 
+	// budgetAlerted dedupes the per-agent budget-exceeded alert to once an hour
+	// (TSU-53 slice-C), so a runaway agent pings once, not every flush.
+	budgetMu      sync.Mutex
+	budgetAlerted map[string]time.Time
+
 	// requireRegistered gates mutating tools behind a registered acting agent
 	// (RELAY_REQUIRE_REGISTERED). Set from config in relay.New before dispatch.
 	requireRegistered bool
@@ -54,9 +59,49 @@ func (h *Handlers) getConnector() connector.TaskConnector {
 }
 
 func NewHandlers(database *db.DB, registry *SessionRegistry, ingester *ingest.Ingester, events *EventBus) *Handlers {
-	h := &Handlers{db: database, registry: registry, ingester: ingester, events: events, tokenCh: make(chan db.TokenRecord, 256)}
+	h := &Handlers{db: database, registry: registry, ingester: ingester, events: events, tokenCh: make(chan db.TokenRecord, 256), budgetAlerted: map[string]time.Time{}}
 	go h.flushTokenUsage()
 	return h
+}
+
+// checkBudgets fires a budget-exceeded event for any agent in the just-flushed
+// batch that crossed its per-day token quota (TSU-53 slice-C: the relay ACTS on
+// the budget — alert, on top of the hard quota block). Deduped to once/hour per
+// agent. The event flows through the bus → rules → a ping (default rule targets
+// the human/owner). Best-effort: never blocks token recording.
+func (h *Handlers) checkBudgets(batch []db.TokenRecord) {
+	seen := map[string]bool{}
+	for _, r := range batch {
+		if r.Agent == "" {
+			continue
+		}
+		key := r.Project + "/" + r.Agent
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+
+		allowed, used, limit := h.db.CheckQuota(r.Project, r.Agent, "tokens")
+		if allowed || limit <= 0 {
+			continue
+		}
+		h.budgetMu.Lock()
+		recent := time.Since(h.budgetAlerted[key]) < time.Hour
+		if !recent {
+			h.budgetAlerted[key] = time.Now()
+		}
+		h.budgetMu.Unlock()
+		if recent {
+			continue
+		}
+		log.Printf("notifier: budget-exceeded %s used %d/%d tokens (24h)", key, used, limit)
+		h.events.EmitSemantic("event:budget-exceeded", r.Project, r.Agent, map[string]any{
+			"agent": r.Agent,
+			"used":  used,
+			"limit": limit,
+			"line":  fmt.Sprintf("Budget exceeded: %s used %d/%d tokens (24h)", r.Agent, used, limit),
+		})
+	}
 }
 
 // flushTokenUsage batches token usage records and inserts them every 5s or 50 records.
@@ -74,7 +119,9 @@ func (h *Handlers) flushTokenUsage() {
 		buf = buf[:0]
 		if err := h.db.InsertTokenUsageBatch(batch); err != nil {
 			log.Printf("token usage flush error: %v", err)
+			return
 		}
+		h.checkBudgets(batch)
 	}
 
 	for {

--- a/internal/relay/notifications.go
+++ b/internal/relay/notifications.go
@@ -792,6 +792,15 @@ func (n *Notifier) seedDefaults() {
 			Target:  "human",
 			Opts:    `{"interval_hours":8,"priority":"P3"}`,
 		},
+		{
+			Name:    "Budget exceeded → human (P0)",
+			Enabled: true,
+			Event:   "event:budget-exceeded",
+			Match:   `{}`,
+			Action:  "message",
+			Target:  "human",
+			Opts:    `{"priority":"P0","template":"💸 {line}"}`,
+		},
 	}
 	for i := range defaults {
 		r := defaults[i]


### PR DESCRIPTION
Per-agent token quota already hard-blocks; slice-C adds the alert: an agent over max_tokens_per_day fires event:budget-exceeded (deduped 1h/agent) → rules → ping. Default rule seeded (→ human P0). Also fixes countTokenUsage24h to measure real tokens (tokenSum), not raw bytes. Test included. build+vet+tests green. 🤖 Generated with [Claude Code](https://claude.com/claude-code)