### PR TITLE
fix(serve): single-writer lock — two relays on one DB is now impossible

### DIFF
--- a/main.go
+++ b/main.go
@@ -97,6 +97,17 @@ func startServer() {
 	cfg := config.Load()
 	cfg.Version = Version
 
+	// Single-writer guard: refuse to start if another relay already serves this
+	// DB. Two relays on one SQLite file corrupt it (this is what wiped agents +
+	// teams when a stray launchd relay came up on the same database).
+	if dbPath, perr := db.DBPath(); perr == nil {
+		if release, lerr := acquireServeLock(dbPath + ".lock"); lerr != nil {
+			log.Fatalf("another agent-relay is already serving %s — refusing to start a second writer (it corrupts the DB). Stop the other instance first.", dbPath)
+		} else {
+			defer release()
+		}
+	}
+
 	database, err := db.New()
 	if err != nil {
 		log.Fatalf("failed to init database: %v", err)

--- a/serve_lock_unix.go
+++ b/serve_lock_unix.go
@@ -1,0 +1,29 @@
+//go:build !windows
+
+package main
+
+import (
+	"os"
+	"syscall"
+)
+
+// acquireServeLock takes an exclusive, non-blocking advisory lock on a lockfile
+// next to the DB so two relay processes can NEVER serve the same database at
+// once — the failure that wiped agents+teams when a second (launchd) relay came
+// up on the same SQLite file. Returns a release func, or an error if another
+// live relay already holds it (caller should refuse to start). The lock is held
+// for the process lifetime and released by the OS if the process dies.
+func acquireServeLock(path string) (func(), error) {
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o644)
+	if err != nil {
+		return nil, err
+	}
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		_ = f.Close()
+		return nil, err // EWOULDBLOCK → another relay holds it
+	}
+	return func() {
+		_ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+		_ = f.Close()
+	}, nil
+}

--- a/serve_lock_windows.go
+++ b/serve_lock_windows.go
@@ -1,0 +1,9 @@
+//go:build windows
+
+package main
+
+// acquireServeLock is a no-op on Windows (flock is unix-only). Windows isn't a
+// relay host in this deployment; revisit with LockFileEx if that changes.
+func acquireServeLock(_ string) (func(), error) {
+	return func() {}, nil
+}


### PR DESCRIPTION
Root cause of the agents+teams wipe: a stray launchd relay came up on the same SQLite DB as the running relay → two writers → corruption. Fix: `serve` takes an exclusive flock on `<db>.lock`; a 2nd relay on the same DB refuses to start with a clear message. Windows no-op stub. Verified live (2nd serve exits 'already serving — refusing'). build+vet+win-cross green. 🤖 Generated with [Claude Code](https://claude.com/claude-code)