### PR TITLE
fix(tokens): register_agent must pass cwd — closes token attribution (TSU-64)

### DIFF
--- a/internal/relay/handlers.go
+++ b/internal/relay/handlers.go
@@ -611,6 +611,7 @@ func buildOnboardingPrompt(name, description, cwd string, interactive bool) stri
 	b.WriteString("  name: \"cto\",\n  project: \"" + name + "\",\n")
 	b.WriteString("  role: \"Technical leader and architect. Owns the backlog, coordinates teams.\",\n")
 	b.WriteString("  is_executive: true,\n  profile_slug: \"cto\",\n")
+	b.WriteString("  cwd: \"<this repo's absolute path, $PWD>\",  // REQUIRED for token tracking: binds your session so the Stop hook's real-token usage attributes to you\n")
 	b.WriteString("  session_id: \"<session_id from whoami>\"\n})\n```\n\n")
 
 	b.WriteString("### 5d. Team memberships\n\n")
@@ -643,7 +644,7 @@ func buildOnboardingPrompt(name, description, cwd string, interactive bool) stri
 	b.WriteString("Use this exact template for each worker (replace `<SLUG>`, `<ROLE>`, `<NAME>`):\n\n")
 	b.WriteString("```bash\nclaude -w --dangerously-skip-permissions \\\n")
 	b.WriteString("  \"You are the <ROLE> of " + name + ". Boot sequence:\n")
-	b.WriteString("  1. register_agent({ name: '<SLUG>', project: '" + name + "', profile_slug: '<SLUG>', reports_to: 'cto' })\n")
+	b.WriteString("  1. register_agent({ name: '<SLUG>', project: '" + name + "', profile_slug: '<SLUG>', reports_to: 'cto', cwd: '$PWD' })  // cwd REQUIRED — binds your session so real per-turn tokens attribute to you\n")
 	b.WriteString("  2. get_session_context() — read everything: profile, vault docs, memories, tasks\n")
 	b.WriteString("  3. Research the technologies and patterns mentioned in your context using web search. Get up to speed.\n")
 	b.WriteString("  4. set_memory() to persist your research findings in the relay (scope: 'agent', key: 'onboarding-research')\n")

--- a/skill/relay.md
+++ b/skill/relay.md
@@ -31,11 +31,11 @@ API scripts: add `-H "Authorization: Bearer <RELAY_API_KEY>"`. A `401 {"error":"
 ## Identity
 
 1. Infer agent name + project from context, or ask user.
-2. `register_agent(name, project, role, reports_to, session_id)` — pass `session_id` from `whoami` for activity tracking.
+2. `register_agent(name, project, role, reports_to, session_id, cwd)` — pass `session_id` from `whoami`, and **`cwd` = your working dir (`$PWD`)**. `cwd` is REQUIRED for token/activity tracking: the SessionStart hook re-binds your (rotated) session to the agent that owns that `cwd`, so the Stop hook's real per-turn token usage attributes to you. Without `cwd`, the bind fails and your token usage is dropped (cost/health stay on a bytes estimate).
 3. Pass `as` and `project` on **every** tool call.
 
 ```
-register_agent(name: "backend", project: "my-app", role: "Go developer", reports_to: "tech-lead")
+register_agent(name: "backend", project: "my-app", role: "Go developer", reports_to: "tech-lead", cwd: "/abs/path/to/worktree")
 send_message(as: "backend", project: "my-app", to: "frontend", subject: "...", content: "...")
 ```
 


### PR DESCRIPTION
Traced: real tokens never land because /ingest/tokens drops unbound sessions, and binding (SessionStart→RebindSessionByCwd) needs an agent owning that cwd — but the skill + spawn template registered WITHOUT cwd. Proven: with cwd set, the session binds + a real-token row lands. Fix: register_agent guidance + spawn template now pass cwd ($PWD). Closes TSU-64 once agents re-register + /clear. build+vet green. 🤖 Generated with [Claude Code](https://claude.com/claude-code)