### PR TITLE
fix(activity): live state stream — join by agent name, not stale session_id

### DIFF
--- a/internal/ingest/detector.go
+++ b/internal/ingest/detector.go
@@ -16,6 +16,8 @@ const (
 
 type SessionState struct {
 	SessionID string    `json:"session_id"`
+	Agent     string    `json:"agent,omitempty"`   // owning agent, resolved from session→cwd binding
+	Project   string    `json:"project,omitempty"` // owning agent's project
 	Activity  Activity  `json:"activity"`
 	Tool      string    `json:"tool"`
 	File      string    `json:"file"`
@@ -30,6 +32,8 @@ type sessionEntry struct {
 	file         string
 	activity     Activity
 	state        string
+	agent        string // resolved owning agent (cached; empty until resolved)
+	project      string
 	idleSent     bool
 	waitSent     bool
 	displayUntil time.Time // activity stays visible until this time
@@ -37,18 +41,24 @@ type sessionEntry struct {
 	pendingAct   Activity
 }
 
+// AgentResolver maps a live Claude session_id to the agent that owns it (via the
+// session→cwd binding in the DB). Returns ok=false for unbound sessions.
+type AgentResolver func(sessionID string) (project, name string, ok bool)
+
 type Detector struct {
 	mu          sync.RWMutex
 	sessions    map[string]*sessionEntry
 	out         chan<- AgentEvent
+	resolve     AgentResolver
 	subMu       sync.RWMutex
 	subscribers map[chan []SessionState]struct{}
 }
 
-func newDetector(out chan<- AgentEvent) *Detector {
+func newDetector(out chan<- AgentEvent, resolve AgentResolver) *Detector {
 	return &Detector{
 		sessions:    make(map[string]*sessionEntry),
 		out:         out,
+		resolve:     resolve,
 		subscribers: make(map[chan []SessionState]struct{}),
 	}
 }
@@ -92,6 +102,8 @@ func (d *Detector) getSessionsLocked() []SessionState {
 	for sid, s := range d.sessions {
 		result = append(result, SessionState{
 			SessionID: sid,
+			Agent:     s.agent,
+			Project:   s.project,
 			Activity:  s.activity,
 			Tool:      s.tool,
 			File:      s.file,
@@ -110,6 +122,15 @@ func (d *Detector) RecordEvent(evt AgentEvent) {
 	if !ok {
 		s = &sessionEntry{}
 		d.sessions[evt.SessionID] = s
+	}
+
+	// Resolve the owning agent once per session (and retry while unresolved —
+	// the SessionStart rebind may land after the first activity event). Bounded
+	// to ~1 indexed read per session, never per event once bound.
+	if s.agent == "" && d.resolve != nil {
+		if proj, name, ok := d.resolve(evt.SessionID); ok {
+			s.project, s.agent = proj, name
+		}
 	}
 
 	s.lastEvent = evt.Timestamp
@@ -153,19 +174,7 @@ func (d *Detector) RecordEvent(evt AgentEvent) {
 func (d *Detector) GetSessions() []SessionState {
 	d.mu.RLock()
 	defer d.mu.RUnlock()
-
-	result := make([]SessionState, 0, len(d.sessions))
-	for sid, s := range d.sessions {
-		result = append(result, SessionState{
-			SessionID: sid,
-			Activity:  s.activity,
-			Tool:      s.tool,
-			File:      s.file,
-			LastEvent: s.lastEvent,
-			State:     s.state,
-		})
-	}
-	return result
+	return d.getSessionsLocked()
 }
 
 func (d *Detector) run(ctx context.Context) {

--- a/internal/ingest/detector_test.go
+++ b/internal/ingest/detector_test.go
@@ -13,7 +13,7 @@ import (
 func TestDetector_TickEmitsNonBlocking(t *testing.T) {
 	// Unbuffered + no reader: a blocking send here would hang tick forever.
 	out := make(chan AgentEvent)
-	d := newDetector(out)
+	d := newDetector(out, nil)
 
 	// Session old enough to trigger an idle event on the next tick.
 	d.RecordEvent(AgentEvent{
@@ -37,11 +37,48 @@ func TestDetector_TickEmitsNonBlocking(t *testing.T) {
 	}
 }
 
+// TestDetector_ResolvesAgent confirms RecordEvent tags a session with its owning
+// agent via the resolver, that the resolver is consulted only until it resolves
+// (cached thereafter), and that retries happen while a session stays unresolved.
+func TestDetector_ResolvesAgent(t *testing.T) {
+	out := make(chan AgentEvent, 4)
+	calls := 0
+	resolved := false
+	d := newDetector(out, func(sid string) (string, string, bool) {
+		calls++
+		if !resolved {
+			return "", "", false // unbound on first event
+		}
+		return "proj", "wraith-dev", true
+	})
+
+	// First event: resolver returns not-found → session stays untagged.
+	d.RecordEvent(AgentEvent{SessionID: "s1", Type: EventToolStart, Tool: "Edit", Timestamp: time.Now()})
+	if got := d.GetSessions(); len(got) != 1 || got[0].Agent != "" {
+		t.Fatalf("expected untagged session, got %+v", got)
+	}
+
+	// Now the rebind lands; the next event resolves and caches the agent.
+	resolved = true
+	d.RecordEvent(AgentEvent{SessionID: "s1", Type: EventToolStart, Tool: "Bash", Timestamp: time.Now()})
+	got := d.GetSessions()
+	if len(got) != 1 || got[0].Agent != "wraith-dev" || got[0].Project != "proj" {
+		t.Fatalf("expected session tagged wraith-dev/proj, got %+v", got)
+	}
+
+	// A third event must NOT call the resolver again (already cached).
+	before := calls
+	d.RecordEvent(AgentEvent{SessionID: "s1", Type: EventToolEnd, Timestamp: time.Now()})
+	if calls != before {
+		t.Fatalf("resolver called again after resolution (%d → %d); should be cached", before, calls)
+	}
+}
+
 // TestDetector_TickDeliversWhenDrained confirms the idle event still reaches a
 // reader when one is present (buffered sink).
 func TestDetector_TickDeliversWhenDrained(t *testing.T) {
 	out := make(chan AgentEvent, 4)
-	d := newDetector(out)
+	d := newDetector(out, nil)
 	d.RecordEvent(AgentEvent{
 		SessionID: "s1",
 		Type:      EventToolEnd,

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -7,6 +7,10 @@ import (
 type Config struct {
 	EventBufferSize int
 	SessionProvider SessionProvider
+	// AgentResolver maps a live session_id → owning agent. Lets the detector tag
+	// activity with the stable agent identity (not the rotating session_id), so
+	// the UI joins activity to agents by name. Optional; nil → activity untagged.
+	AgentResolver AgentResolver
 }
 
 func (c *Config) defaults() {
@@ -35,7 +39,7 @@ func New(cfg Config) (*Ingester, error) {
 	// file-drop watcher is gone. Nothing consumes Events in production; the
 	// detector's tick sends to it non-blockingly and drops when unread.
 	events := make(chan AgentEvent, cfg.EventBufferSize)
-	detector := newDetector(events)
+	detector := newDetector(events, cfg.AgentResolver)
 
 	go detector.run(ctx)
 

--- a/internal/relay/api.go
+++ b/internal/relay/api.go
@@ -463,6 +463,7 @@ func (r *Relay) apiGetAgents(w http.ResponseWriter, req *http.Request) {
 		})
 	}
 
+	actByAgent := r.activityByAgent()
 	actMap := r.activityBySessionID()
 	now := time.Now().UTC()
 	result := make([]apiAgent, 0, len(agents))
@@ -488,16 +489,29 @@ func (r *Relay) apiGetAgents(w http.ResponseWriter, req *http.Request) {
 			online = now.Sub(t) < 5*time.Minute
 		}
 		aa.Online = online
-		if a.SessionID != nil {
-			if s, ok := actMap[*a.SessionID]; ok {
-				aa.Activity = string(s.Activity)
-				aa.ActivityTool = s.Tool
-			}
-		}
+		applyActivity(&aa, project, a.Name, a.SessionID, actByAgent, actMap)
 		result = append(result, aa)
 	}
 
 	writeJSON(w, result)
+}
+
+// applyActivity attaches live activity to an agent row. It joins by agent name
+// first (robust to session_id rotation and a stale agents.session_id column),
+// then falls back to the session_id-keyed map for a just-registered session the
+// detector hasn't resolved to an owner yet.
+func applyActivity(aa *apiAgent, project, name string, sessionID *string, byAgent, bySession map[string]ingest.SessionState) {
+	if s, ok := byAgent[project+"\x00"+name]; ok {
+		aa.Activity = string(s.Activity)
+		aa.ActivityTool = s.Tool
+		return
+	}
+	if sessionID != nil {
+		if s, ok := bySession[*sessionID]; ok {
+			aa.Activity = string(s.Activity)
+			aa.ActivityTool = s.Tool
+		}
+	}
 }
 
 func (r *Relay) activityBySessionID() map[string]ingest.SessionState {
@@ -505,6 +519,24 @@ func (r *Relay) activityBySessionID() map[string]ingest.SessionState {
 	if r.Ingester != nil {
 		for _, s := range r.Ingester.GetSessions() {
 			m[s.SessionID] = s
+		}
+	}
+	return m
+}
+
+// activityByAgent maps "project\x00agent" → live session state, for the sessions
+// the detector resolved to an owning agent. Joining on the agent name is robust
+// to session_id rotation (/clear) and to a stale agents.session_id column — the
+// session_id-keyed join silently missed for every agent but the just-registered
+// one. Keyed by project+name to avoid collisions across projects.
+func (r *Relay) activityByAgent() map[string]ingest.SessionState {
+	m := make(map[string]ingest.SessionState)
+	if r.Ingester != nil {
+		for _, s := range r.Ingester.GetSessions() {
+			if s.Agent == "" {
+				continue
+			}
+			m[s.Project+"\x00"+s.Agent] = s
 		}
 	}
 	return m
@@ -530,6 +562,7 @@ func (r *Relay) apiGetAllAgents(w http.ResponseWriter) {
 		})
 	}
 
+	actByAgent := r.activityByAgent()
 	actMap := r.activityBySessionID()
 	now := time.Now().UTC()
 	result := make([]apiAgent, 0, len(agents))
@@ -554,12 +587,7 @@ func (r *Relay) apiGetAllAgents(w http.ResponseWriter) {
 			AvatarURL:    a.AvatarURL,
 			Teams:        teamsByAgent[a.Project+":"+a.Name],
 		}
-		if a.SessionID != nil {
-			if s, ok := actMap[*a.SessionID]; ok {
-				aa.Activity = string(s.Activity)
-				aa.ActivityTool = s.Tool
-			}
-		}
+		applyActivity(&aa, a.Project, a.Name, a.SessionID, actByAgent, actMap)
 		result = append(result, aa)
 	}
 
@@ -971,10 +999,18 @@ type sseAgent struct {
 }
 
 func (r *Relay) buildSSEPayload(sessions []ingest.SessionState) ssePayload {
-	// Build session lookup
+	// Lookup live activity by owning agent (project+name). The detector resolves
+	// each session to its agent, so joining on the stable identity survives
+	// session_id rotation (/clear) and a stale agents.session_id column — the old
+	// session_id join missed for every agent but a just-registered one. Keep a
+	// session_id map as a fallback for sessions not yet resolved to an owner.
+	sessByAgent := make(map[string]ingest.SessionState)
 	sessMap := make(map[string]ingest.SessionState)
 	for _, s := range sessions {
 		sessMap[s.SessionID] = s
+		if s.Agent != "" {
+			sessByAgent[s.Project+"\x00"+s.Agent] = s
+		}
 	}
 
 	agents, _ := r.DB.ListAllAgents()
@@ -990,27 +1026,29 @@ func (r *Relay) buildSSEPayload(sessions []ingest.SessionState) ssePayload {
 			SessionID: a.SessionID,
 		}
 
-		// Enrich with SSE activity if session linked
-		if a.SessionID != nil {
-			if s, ok := sessMap[*a.SessionID]; ok {
-				sa.Activity = string(s.Activity)
-				if s.Activity != ingest.ActivityIdle && s.Activity != ingest.ActivityWaiting && s.Activity != ingest.ActivityThinking {
-					sa.ActivityTool = s.Tool
-				}
+		// Enrich with live activity — agent-name join first, session_id fallback.
+		s, ok := sessByAgent[a.Project+"\x00"+a.Name]
+		if !ok && a.SessionID != nil {
+			s, ok = sessMap[*a.SessionID]
+		}
+		if ok {
+			sa.Activity = string(s.Activity)
+			if s.Activity != ingest.ActivityIdle && s.Activity != ingest.ActivityWaiting && s.Activity != ingest.ActivityThinking {
+				sa.ActivityTool = s.Tool
+			}
 
-				// Derive status from activity
-				switch {
-				case a.Status == "sleeping":
-					// sleeping stays sleeping
-				case a.Status == "deleted":
-					// deleted stays deleted
-				case s.Activity != ingest.ActivityIdle && s.State != "idle" && s.State != "exited":
-					sa.Status = "busy"
-				case now.Sub(s.LastEvent) < 5*time.Minute:
-					sa.Status = "active"
-				default:
-					sa.Status = "inactive"
-				}
+			// Derive status from activity
+			switch {
+			case a.Status == "sleeping":
+				// sleeping stays sleeping
+			case a.Status == "deleted":
+				// deleted stays deleted
+			case s.Activity != ingest.ActivityIdle && s.State != "idle" && s.State != "exited":
+				sa.Status = "busy"
+			case now.Sub(s.LastEvent) < 5*time.Minute:
+				sa.Status = "active"
+			default:
+				sa.Status = "inactive"
 			}
 		}
 

--- a/internal/relay/handlers_ingest_test.go
+++ b/internal/relay/handlers_ingest_test.go
@@ -5,7 +5,77 @@ import (
 	"testing"
 
 	"agent-relay/internal/db"
+	"agent-relay/internal/ingest"
 )
+
+// withIngester attaches a real ingester whose AgentResolver is wired to the test
+// DB — mirroring the production wiring in main.go — so activity events resolve to
+// their owning agent.
+func withIngester(t *testing.T, r *Relay) {
+	t.Helper()
+	ing, err := ingest.New(ingest.Config{
+		AgentResolver: func(sid string) (string, string, bool) {
+			p, n, f, _ := r.DB.GetAgentBySessionID(sid)
+			return p, n, f
+		},
+	})
+	if err != nil {
+		t.Fatalf("ingest.New: %v", err)
+	}
+	t.Cleanup(ing.Stop)
+	r.Ingester = ing
+}
+
+// findAgent returns the agent row with the given name from a /api/agents array.
+func findAgent(arr []any, name string) map[string]any {
+	for _, e := range arr {
+		if m, ok := e.(map[string]any); ok && m["name"] == name {
+			return m
+		}
+	}
+	return nil
+}
+
+// TestActivityJoinsByAgentNameSurvivesSessionRotation is the regression guard for
+// the dead state-stream bug: /api/agents joined live activity on the agent's
+// stored session_id, which goes stale on /clear — so the board showed every agent
+// as idle. The join now keys on the resolved agent name, which survives rotation.
+func TestActivityJoinsByAgentNameSurvivesSessionRotation(t *testing.T) {
+	r := testRelay(t)
+	withIngester(t, r)
+
+	sid := "sess-A"
+	if _, _, err := r.DB.RegisterAgent("proj", "wraith-dev", "dev", "", nil, nil, false, &sid, "[]", 0, db.RegisterOptions{}); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+
+	// An activity event for the live session → detector resolves sess-A→wraith-dev.
+	if w := doAPI(r, "POST", "/ingest/activity", `{"session_id":"sess-A","type":"tool_start","tool":"Edit"}`); w.Code != http.StatusNoContent {
+		t.Fatalf("ingest activity: %d %s", w.Code, w.Body.String())
+	}
+
+	w := doAPI(r, "GET", "/agents?project=proj", "")
+	a := findAgent(decodeJSONArray(t, w), "wraith-dev")
+	if a == nil {
+		t.Fatal("wraith-dev not in /api/agents")
+	}
+	if a["activity"] != "typing" || a["activity_tool"] != "Edit" {
+		t.Fatalf("expected activity=typing tool=Edit, got activity=%v tool=%v", a["activity"], a["activity_tool"])
+	}
+
+	// Simulate /clear: the agent's stored session_id rotates to a new value the
+	// detector has never seen. The name-keyed join must still surface the activity
+	// (the old session_id join would now miss → idle).
+	newSid := "sess-B"
+	if _, _, err := r.DB.RegisterAgent("proj", "wraith-dev", "dev", "", nil, nil, false, &newSid, "[]", 0, db.RegisterOptions{}); err != nil {
+		t.Fatalf("re-register: %v", err)
+	}
+	w = doAPI(r, "GET", "/agents?project=proj", "")
+	a = findAgent(decodeJSONArray(t, w), "wraith-dev")
+	if a == nil || a["activity"] != "typing" {
+		t.Fatalf("activity lost after session rotation — name-join regression: got %v", a["activity"])
+	}
+}
 
 func TestIngestSessionStartRebindsByCwd(t *testing.T) {
 	r := testRelay(t)

--- a/internal/web/static/v2/api.js
+++ b/internal/web/static/v2/api.js
@@ -237,3 +237,27 @@ export function connectStream(project, onEvent, onState) {
   open();
   return () => { closed = true; if (timer) clearTimeout(timer); if (es) es.close(); };
 }
+
+// SSE for the live activity board. The relay pushes a full snapshot
+// {sessions, agents} on every state change (and once on connect). onSnapshot
+// receives the parsed payload; reconnects with exponential backoff like
+// connectStream. Returns a close fn.
+export function connectActivity(onSnapshot) {
+  let es = null, closed = false, delay = 1000, timer = null;
+  function open() {
+    if (closed) return;
+    es = new EventSource('/api/activity/stream');
+    es.onopen = () => { delay = 1000; };
+    es.onmessage = (e) => {
+      try { onSnapshot(JSON.parse(e.data)); } catch (_) { /* ignore */ }
+    };
+    es.onerror = () => {
+      es.close();
+      if (closed) return;
+      timer = setTimeout(open, delay);
+      delay = Math.min(delay * 2, 15000);
+    };
+  }
+  open();
+  return () => { closed = true; if (timer) clearTimeout(timer); if (es) es.close(); };
+}

--- a/internal/web/static/v2/team.js
+++ b/internal/web/static/v2/team.js
@@ -6,7 +6,7 @@
 // hour). The glow here is the ONE permitted indulgence — everything else stays
 // flat. prefers-reduced-motion → comets become instant arrival pings.
 import {
-  colorFor, initialFor, fmtAgo, prefersReducedMotion, isoSince,
+  colorFor, initialFor, fmtAgo, prefersReducedMotion, isoSince, connectActivity,
 } from './api.js';
 
 const NS = 'http://www.w3.org/2000/svg';
@@ -45,6 +45,8 @@ export function initTeam(root, ctx) {
   let token = 0;
   let ro = null;
   let heatSweep = null;
+  let closeActivity = null;        // live-activity SSE close fn
+  const liveState = new Map();     // name → 'active' | 'online' | 'idle' (live)
 
   const reduce = () => prefersReducedMotion();
 
@@ -99,13 +101,18 @@ export function initTeam(root, ctx) {
   // reports_to, whose targets are often inactive execs). Each team becomes a
   // tinted zone + section label, its members arranged on a ring inside it, so the
   // teams read at a glance. Agents with no team land in an "unassigned" cluster.
-  const TEAM_COLOR = { engineering: '#22c55e', growth: '#6e6bf2', leads: '#38bdf8', unassigned: '#64748b' };
+  const TEAM_COLOR = { engineering: '#22c55e', growth: '#6e6bf2', comex: '#fbbf24', distribution: '#f472b6', leads: '#38bdf8', unassigned: '#64748b' };
   // an agent's primary team: first non-"leads" team (leads is a cross-cutting hat).
   function primaryTeam(a) {
     const ts = a.teams || [];
     const t = ts.find((x) => x.slug !== 'leads') || ts[0];
     return t ? t.slug : 'unassigned';
   }
+  // Team cards laid out as a balanced masonry: each card's HEIGHT is proportional
+  // to its member count (label band + member rows), and cards drop into the
+  // shortest column. A 2-member team is a short card, a 7-member team a tall one —
+  // so the board fills evenly instead of leaving a half-empty oversized box when
+  // the team count doesn't divide the grid. All maths in normalized 0..1 space.
   function computeLayout() {
     pos.clear();
     hubsMeta = [];
@@ -124,38 +131,58 @@ export function initTeam(root, ctx) {
         (x.slug === 'unassigned' ? 1 : 0) - (y.slug === 'unassigned' ? 1 : 0)
         || y.members.length - x.members.length);
 
-    // Bounded grid of team cards — never overlapping, scales to N teams. Members
-    // pack in a mini-grid inside each card (all maths in normalized 0..1 space).
     const N = list.length;
     const cols = Math.min(3, N);
-    const rows = Math.ceil(N / cols);
-    const PADX = 0.02, PADY = 0.025, GAP = 0.014;
-    const cw = (1 - PADX * 2 - GAP * (cols - 1)) / cols;
-    const ch = (1 - PADY * 2 - GAP * (rows - 1)) / rows;
+    const PADX = 0.02, PADY = 0.025, GAPX = 0.014, GAPY = 0.02;
+    const LABEL_BAND = 0.9;                 // header height, in member-row units
+    const cw = (1 - PADX * 2 - GAPX * (cols - 1)) / cols;
 
-    list.forEach((g, gi) => {
-      const c = gi % cols, r = Math.floor(gi / cols);
-      const x0 = PADX + c * (cw + GAP);
-      const y0 = PADY + r * (ch + GAP);
-      const m = g.members;
-      const n = m.length;
-      const mcols = n <= 1 ? 1 : n <= 2 ? 2 : 3;
+    // Per-team card geometry. Small teams use 2 member-columns (wider node spacing
+    // → long labels don't collide); 5+ members use 3.
+    const cards = list.map((g) => {
+      const n = g.members.length;
+      const mcols = n <= 1 ? 1 : n <= 4 ? 2 : 3;
       const mrows = Math.ceil(n / mcols);
-      const gx = cw / (mcols + 1);
-      const top = y0 + ch * 0.22;            // reserve the top of the card for the label
-      const usable = ch * 0.70;
-      const gy = usable / (mrows + 1);
-      m.forEach((name, i) => {
-        const cc = i % mcols, rr = Math.floor(i / mcols);
-        pos.set(name, { nx: x0 + gx * (cc + 1), ny: top + gy * (rr + 1) });
-      });
-      hubsMeta.push({
-        slug: g.slug, x0, y0, cw, ch,
-        color: TEAM_COLOR[g.slug] || colorFor(g.slug),
-        label: g.slug === 'unassigned' ? 'UNASSIGNED' : g.slug.toUpperCase(),
-        count: n,
-      });
+      return { ...g, n, mcols, mrows, units: LABEL_BAND + mrows };
     });
+
+    // Masonry: drop each card into the currently-shortest column.
+    const colUnits = new Array(cols).fill(0);
+    const colCards = Array.from({ length: cols }, () => []);
+    for (const c of cards) {
+      let ci = 0;
+      for (let i = 1; i < cols; i++) if (colUnits[i] < colUnits[ci]) ci = i;
+      colCards[ci].push(c);
+      colUnits[ci] += c.units;
+    }
+
+    // Scale one unit-row so the tallest column (incl. inter-card gaps) fits the band.
+    const maxCards = Math.max(...colCards.map((cc) => cc.length), 1);
+    const maxUnits = Math.max(...colUnits, 1);
+    const uh = (1 - PADY * 2 - GAPY * (maxCards - 1)) / maxUnits;
+
+    for (let ci = 0; ci < cols; ci++) {
+      const x0 = PADX + ci * (cw + GAPX);
+      let y = PADY;
+      for (const c of colCards[ci]) {
+        const ch = c.units * uh;
+        const top = y + LABEL_BAND * uh;     // member band starts below the label
+        const memH = ch - LABEL_BAND * uh;
+        const gx = cw / (c.mcols + 1);
+        const gy = memH / (c.mrows + 1);
+        c.members.forEach((name, i) => {
+          const cc = i % c.mcols, rr = Math.floor(i / c.mcols);
+          pos.set(name, { nx: x0 + gx * (cc + 1), ny: top + gy * (rr + 1) });
+        });
+        hubsMeta.push({
+          slug: c.slug, x0, y0: y, cw, ch,
+          color: TEAM_COLOR[c.slug] || colorFor(c.slug),
+          label: c.slug === 'unassigned' ? 'UNASSIGNED' : c.slug.toUpperCase(),
+          count: c.n,
+        });
+        y += ch + GAPY;
+      }
+    }
   }
   // Leaders / executives first, then by heat-ish role, then name.
   function rank(a, b) {
@@ -244,7 +271,7 @@ export function initTeam(root, ctx) {
     ctx.openSheet(el);
   }
   function nodeHTML(a) {
-    const state = a.online ? (a.activity && a.activity !== 'idle' ? 'active' : 'online') : 'idle';
+    const state = liveState.get(a.name) || baseState(a);
     const role = a.profile_slug || shortRole(a.role);
     // one dot per team the agent belongs to → shows multi-team membership at a glance.
     const teams = (a.teams || []);
@@ -300,6 +327,39 @@ export function initTeam(root, ctx) {
       const n = counts.get(name) || 0;
       el.style.setProperty('--heat', (n / max).toFixed(3));
       el.dataset.heat = n;
+    }
+  }
+
+  /* --------------------- live activity (state dots) --------------- */
+  // The node's resting state from the load-time agent record (last_seen + last
+  // known activity). The live SSE snapshot overrides this when a session is hot.
+  function baseState(a) {
+    return a && a.online ? (a.activity && a.activity !== 'idle' ? 'active' : 'online') : 'idle';
+  }
+  // Map a detector session state → the node's visual state. active/thinking = at
+  // work (blue, fast breathe); waiting = present between turns (green); idle or
+  // exited = idle (dim).
+  function nodeStateFor(s) {
+    if (s.state === 'idle' || s.state === 'exited' || s.activity === 'idle') return 'idle';
+    if (s.state === 'waiting' || s.activity === 'waiting') return 'online';
+    return 'active';
+  }
+  // Apply a live snapshot ({sessions, agents}) from /api/activity/stream. Joins
+  // on the resolved agent name (stable across /clear, unlike session_id) and
+  // updates each node's data-state live. Agents absent from the snapshot fall
+  // back to their load-time resting state.
+  function applyActivitySnapshot(snap) {
+    const sessions = (snap && Array.isArray(snap.sessions)) ? snap.sessions : [];
+    const proj = ctx.selection;
+    liveState.clear();
+    for (const s of sessions) {
+      if (!s.agent || !nameSet.has(s.agent)) continue;
+      if (proj !== 'all' && s.project && s.project !== proj) continue;
+      liveState.set(s.agent, nodeStateFor(s));
+    }
+    const byName = new Map(agents.map((a) => [a.name, a]));
+    for (const [name, el] of nodeEl) {
+      el.dataset.state = liveState.get(name) || baseState(byName.get(name));
     }
   }
 
@@ -519,6 +579,11 @@ export function initTeam(root, ctx) {
     ro.observe(stage);
   }
   heatSweep = setInterval(() => { if (!root.hidden) { refreshHeat(); renderTranscript(); } }, 60000);
+  // Live state dots: one long-lived SSE subscription; snapshots are filtered to
+  // the current selection inside the handler, so project switches need no
+  // reconnect. (Re-assign guards against a double-init re-subscribing.)
+  if (closeActivity) closeActivity();
+  closeActivity = connectActivity(applyActivitySnapshot);
 
   return {
     activate() {

--- a/main.go
+++ b/main.go
@@ -77,6 +77,10 @@ func startStdioMCP() {
 		SessionProvider: func() map[string]bool {
 			return database.GetKnownSessionIDs()
 		},
+		AgentResolver: func(sessionID string) (string, string, bool) {
+			project, name, found, _ := database.GetAgentBySessionID(sessionID)
+			return project, name, found
+		},
 	})
 	if err != nil {
 		log.Fatalf("failed to init ingester: %v", err)
@@ -117,6 +121,10 @@ func startServer() {
 	ingester, err := ingest.New(ingest.Config{
 		SessionProvider: func() map[string]bool {
 			return database.GetKnownSessionIDs()
+		},
+		AgentResolver: func(sessionID string) (string, string, bool) {
+			project, name, found, _ := database.GetAgentBySessionID(sessionID)
+			return project, name, found
 		},
 	})
 	if err != nil {


### PR DESCRIPTION
## Why
The fleet board's status dots were dead — every agent showed idle/online even while working (owner-reported: *"le stream d'état ne marche pas du tout"*). Diagnosed live on the relay: the backend SSE works, but **session→agent resolution is broken aux deux bouts**.

## Root cause
**Backend.** The activity→agent join keyed on the agent's stored `session_id`, which `/clear` rotates (and which is often null/stale — observed: `cto` & `donna-dev` shared one session_id; only the just-registered agent ever showed activity). So `actMap[*a.SessionID]` missed for ~everyone and the detector's rich activity never reached the UI.

**Frontend.** `team.js` read `/api/agents` once at load and only animated on `message` events — it never subscribed to the activity stream, so the dots were frozen even when the data was right.

## Fix
- **Detector resolves session→agent once** (cached, retried while unbound) via an `AgentResolver` (= `GetAgentBySessionID`, the same call the token path already uses) and tags `SessionState` with the stable **agent name + project**.
- **All three join sites** (`apiGetAgents`, `apiGetAllAgents`, SSE `buildSSEPayload`) now join on `project+name` — robust to session rotation and a stale `agents.session_id` column. Session-id fallback retained for a just-registered session.
- **team.js subscribes to `/api/activity/stream`** and updates each node's `data-state` live (joined by resolved name), falling back to load-time state for agents with no live session.
- **Layout:** `computeLayout` replaced its fixed rows×cols grid (half-empty oversized box when team count didn't divide the grid) with a **content-sized masonry** — card height ∝ member count, dropped into the shortest column; small teams use 2 member-columns so long labels don't collide; comex/distribution tints added.

## Tests
- `internal/ingest`: detector resolver — resolve-once, cache, retry-while-unbound.
- `internal/relay`: end-to-end — activity joins by name **and survives session_id rotation** (the exact bug).
- Full suite green with `-tags fts5`; `gofmt` clean under the go.mod toolchain (1.25.5).

## Deploy note
UI is `go:embed`-ed → ships in the binary. Cut **v1.4.5** after merge → `agent-relay update` prod → model+activity live fleet-wide. No DB/schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)