### PR TITLE
feat(team): fleet console default view + constellation behind Show mode

### DIFF
--- a/internal/web/static/v2/index.html
+++ b/internal/web/static/v2/index.html
@@ -224,10 +224,19 @@
         </article>
       </section>
 
-      <!-- ============ TEAM · MESSAGE CINEMA ============ -->
+      <!-- ============ TEAM · FLEET CONSOLE (+ SHOW MODE) ============ -->
       <section class="page page-team" data-page="team" hidden>
+        <div class="team-modebar">
+          <div class="seg" id="teamModeSeg" role="tablist" aria-label="Fleet view mode">
+            <button class="seg-btn" data-mode="console" role="tab" aria-selected="true">Console</button>
+            <button class="seg-btn" data-mode="show" role="tab" aria-selected="false">Show mode</button>
+          </div>
+        </div>
         <div class="cinema">
-          <div class="stage" id="stage" aria-label="Agent constellation">
+          <!-- Console: dense, legible fleet grid (default) -->
+          <div class="fleet" id="fleetGrid" aria-label="Fleet console"></div>
+          <!-- Show mode: the agent constellation (cinema) -->
+          <div class="stage" id="stage" aria-label="Agent constellation" hidden>
             <svg class="stage-wires" id="stageWires" aria-hidden="true" preserveAspectRatio="none">
               <defs>
                 <filter id="cometGlow" x="-60%" y="-60%" width="220%" height="220%">
@@ -242,9 +251,11 @@
             <div class="stage-captions" id="stageCaptions" aria-hidden="true"></div>
             <div class="stage-empty" id="stageEmpty" hidden></div>
           </div>
-          <aside class="transcript" id="transcript" aria-label="Live transcript">
+          <!-- Persistent, searchable message feed (shared by both modes) -->
+          <aside class="transcript" id="transcript" aria-label="Live messages">
             <div class="card-head">
-              <span class="card-label">transcript</span>
+              <span class="card-label">messages</span>
+              <input type="search" class="msg-search" id="msgSearch" placeholder="filtrer…" aria-label="Filter messages" />
               <span class="card-meta" id="transcriptMeta">live</span>
             </div>
             <div class="transcript-body" id="transcriptBody"></div>

--- a/internal/web/static/v2/team.js
+++ b/internal/web/static/v2/team.js
@@ -46,7 +46,14 @@ export function initTeam(root, ctx) {
   let ro = null;
   let heatSweep = null;
   let closeActivity = null;        // live-activity SSE close fn
-  const liveState = new Map();     // name → 'active' | 'online' | 'idle' (live)
+  const liveInfo = new Map();      // name → {state, label} from the live activity stream
+  // Fleet console (default view) + constellation kept behind a "Show mode" toggle.
+  const fleetEl = root.querySelector('#fleetGrid');
+  const modeSeg = root.querySelector('#teamModeSeg');
+  const msgSearch = root.querySelector('#msgSearch');
+  const fleetRowEl = new Map();    // name → console row element
+  let mode = (() => { try { return localStorage.getItem('team-mode') || 'console'; } catch (_) { return 'console'; } })();
+  let msgFilter = '';
 
   const reduce = () => prefersReducedMotion();
 
@@ -64,8 +71,10 @@ export function initTeam(root, ctx) {
     loadedFor = project;
     computeLayout();
     renderNodes();
+    renderConsole();
     measure();
     placeNodes();
+    applyMode();
 
     // Seed recent flow (transcript + heat) — no animation for history.
     heat.clear();
@@ -271,7 +280,7 @@ export function initTeam(root, ctx) {
     ctx.openSheet(el);
   }
   function nodeHTML(a) {
-    const state = liveState.get(a.name) || baseState(a);
+    const state = stateFor(a.name, a);
     const role = a.profile_slug || shortRole(a.role);
     // one dot per team the agent belongs to → shows multi-team membership at a glance.
     const teams = (a.teams || []);
@@ -344,23 +353,110 @@ export function initTeam(root, ctx) {
     if (s.state === 'waiting' || s.activity === 'waiting') return 'online';
     return 'active';
   }
+  // Short human label for what an agent is doing right now: the live tool when
+  // working, else the activity word, else the coarse state.
+  function liveLabel(s) {
+    if (s.tool) return s.tool;
+    if (s.activity && s.activity !== 'idle') return s.activity;
+    return s.state || 'idle';
+  }
+  const stateFor = (name, a) => (liveInfo.get(name) || {}).state || baseState(a);
+  const restLabel = (a) => (a && a.online ? (a.activity && a.activity !== 'idle' ? a.activity : 'online') : 'offline');
+  const labelFor = (name, a) => (liveInfo.get(name) || {}).label || restLabel(a);
+
   // Apply a live snapshot ({sessions, agents}) from /api/activity/stream. Joins
   // on the resolved agent name (stable across /clear, unlike session_id) and
-  // updates each node's data-state live. Agents absent from the snapshot fall
-  // back to their load-time resting state.
+  // updates the live state + tool label for both views. Agents absent from the
+  // snapshot fall back to their load-time resting state.
   function applyActivitySnapshot(snap) {
     const sessions = (snap && Array.isArray(snap.sessions)) ? snap.sessions : [];
     const proj = ctx.selection;
-    liveState.clear();
+    liveInfo.clear();
     for (const s of sessions) {
       if (!s.agent || !nameSet.has(s.agent)) continue;
       if (proj !== 'all' && s.project && s.project !== proj) continue;
-      liveState.set(s.agent, nodeStateFor(s));
+      liveInfo.set(s.agent, { state: nodeStateFor(s), label: liveLabel(s) });
     }
     const byName = new Map(agents.map((a) => [a.name, a]));
     for (const [name, el] of nodeEl) {
-      el.dataset.state = liveState.get(name) || baseState(byName.get(name));
+      el.dataset.state = stateFor(name, byName.get(name));
     }
+    for (const [name, row] of fleetRowEl) {
+      const a = byName.get(name);
+      row.dataset.state = stateFor(name, a);
+      const lab = row.querySelector('.fl-act');
+      if (lab) lab.textContent = labelFor(name, a);
+    }
+  }
+
+  /* --------------------- fleet console (default view) ------------- */
+  // Agents grouped by team, unassigned last then larger teams first.
+  function teamGroups() {
+    const groups = new Map();
+    for (const a of agents) {
+      const s = primaryTeam(a);
+      if (!groups.has(s)) groups.set(s, []);
+      groups.get(s).push(a);
+    }
+    return [...groups.entries()]
+      .map(([slug, members]) => ({ slug, members: members.slice().sort(rank) }))
+      .sort((x, y) =>
+        (x.slug === 'unassigned' ? 1 : 0) - (y.slug === 'unassigned' ? 1 : 0)
+        || y.members.length - x.members.length);
+  }
+  // Dense, legible grid: every name + role + current activity always visible.
+  function renderConsole() {
+    fleetRowEl.clear();
+    if (!fleetEl) return;
+    if (!agents.length) {
+      fleetEl.innerHTML = '<div class="empty"><span class="se-title">no agents here yet</span><span class="se-sub">this project has no registered agents</span></div>';
+      return;
+    }
+    fleetEl.innerHTML = teamGroups().map((g) => {
+      const color = TEAM_COLOR[g.slug] || colorFor(g.slug);
+      const label = g.slug === 'unassigned' ? 'UNASSIGNED' : g.slug.toUpperCase();
+      const rows = g.members.map((a) => {
+        const role = a.profile_slug || shortRole(a.role);
+        return `<button class="fl-row" type="button" data-name="${esc(a.name)}" data-state="${stateFor(a.name, a)}" style="--c:${colorFor(a.name)}" aria-label="${esc(a.name)}${role ? ' · ' + esc(role) : ''}">
+          <span class="fl-dot" aria-hidden="true"></span>
+          <span class="fl-name">${esc(a.name)}</span>
+          ${role ? `<span class="fl-role">${esc(role)}</span>` : ''}
+          <span class="fl-act">${esc(labelFor(a.name, a))}</span>
+        </button>`;
+      }).join('');
+      return `<section class="fl-group" style="--zc:${color}">
+        <header class="fl-ghead"><span class="fl-gname">${esc(label)}</span><span class="fl-gcount">${g.members.length}</span></header>
+        <div class="fl-rows">${rows}</div>
+      </section>`;
+    }).join('');
+    fleetEl.querySelectorAll('.fl-row').forEach((el) => {
+      fleetRowEl.set(el.dataset.name, el);
+      el.addEventListener('click', () => openAgentSheet(el.dataset.name));
+    });
+  }
+
+  // Toggle Console ↔ Show mode (constellation). Persisted across sessions.
+  function applyMode() {
+    const showCinema = mode === 'show';
+    if (stage) stage.hidden = !showCinema;
+    if (fleetEl) fleetEl.hidden = showCinema;
+    if (modeSeg) {
+      modeSeg.querySelectorAll('.seg-btn').forEach((b) => {
+        const on = b.dataset.mode === mode;
+        b.classList.toggle('active', on);
+        b.setAttribute('aria-selected', on ? 'true' : 'false');
+      });
+    }
+    try { localStorage.setItem('team-mode', mode); } catch (_) { /* private mode */ }
+    if (showCinema) requestAnimationFrame(() => { measure(); placeNodes(); refreshHeat(); });
+  }
+
+  // Filter the message feed by a free-text query (from / to / subject / body).
+  function applyMsgFilter() {
+    const q = msgFilter.toLowerCase();
+    transcriptBody.querySelectorAll('.tr-row').forEach((row) => {
+      row.style.display = (!q || row.textContent.toLowerCase().includes(q)) ? '' : 'none';
+    });
   }
 
   /* --------------------------- pulses ----------------------------- */
@@ -518,6 +614,7 @@ export function initTeam(root, ctx) {
         </div>
       </div>`;
     }).join('');
+    if (msgFilter) applyMsgFilter();
   }
 
   // Click / keyboard toggles a row open to reveal the full message.
@@ -574,6 +671,19 @@ export function initTeam(root, ctx) {
   // which reloads when loadedFor no longer matches the selection.
   ctx.onSelection(() => { loadedFor = null; });
 
+  if (modeSeg) {
+    modeSeg.addEventListener('click', (e) => {
+      const btn = e.target.closest('.seg-btn');
+      if (!btn) return;
+      mode = btn.dataset.mode === 'show' ? 'show' : 'console';
+      renderConsole();
+      applyMode();
+    });
+  }
+  if (msgSearch) {
+    msgSearch.addEventListener('input', () => { msgFilter = msgSearch.value.trim(); applyMsgFilter(); });
+  }
+
   if (window.ResizeObserver) {
     ro = new ResizeObserver(() => { if (!root.hidden && agents.length) { measure(); placeNodes(); } });
     ro.observe(stage);
@@ -588,8 +698,9 @@ export function initTeam(root, ctx) {
   return {
     activate() {
       if (loadedFor !== ctx.selection) { load(); return; }
-      // already loaded — the stage now has a real size, so re-measure & place.
-      requestAnimationFrame(() => { measure(); placeNodes(); refreshHeat(); });
+      // already loaded — re-apply the mode (re-measures the stage in show mode,
+      // which only now has a real size).
+      applyMode();
     },
   };
 }

--- a/internal/web/static/v2/v2.css
+++ b/internal/web/static/v2/v2.css
@@ -866,10 +866,46 @@ button { font-family: inherit; }
 .tr-body { font-size: 12px; line-height: 1.55; color: var(--text); white-space: pre-wrap; word-break: break-word;
   max-height: 320px; overflow-y: auto; scrollbar-width: thin; font-family: ui-monospace, "SF Mono", Menlo, monospace; }
 
+/* ---------- fleet console (default team view) ---------- */
+.team-modebar { display: flex; justify-content: flex-end; margin-bottom: 12px; }
+.seg { display: inline-flex; gap: 2px; padding: 2px; background: var(--bg-card); border: 1px solid var(--border); border-radius: 9px; }
+.seg-btn { font-family: inherit; font-size: 11.5px; letter-spacing: .3px; color: var(--text-dim); background: transparent; border: 0; border-radius: 7px; padding: 5px 13px; cursor: pointer; transition: color .15s, background .15s; }
+.seg-btn:hover { color: var(--text-muted); }
+.seg-btn.active { color: var(--text); background: var(--bg-elev); box-shadow: inset 0 0 0 1px var(--border); }
+.seg-btn:focus-visible { outline: none; box-shadow: 0 0 0 2px var(--accent-dim); }
+
+.fleet {
+  min-height: 560px; height: calc(100dvh - 264px); overflow-y: auto;
+  scrollbar-width: thin; scrollbar-color: var(--border) transparent;
+  display: grid; grid-template-columns: repeat(auto-fill, minmax(248px, 1fr)); gap: 12px; align-content: start;
+}
+.fl-group { background: var(--bg-card); border: 1px solid var(--border); border-radius: var(--radius); padding: 12px 10px 9px; height: max-content; }
+.fl-ghead { display: flex; align-items: baseline; gap: 8px; margin: 0 0 8px; padding-left: 9px; border-left: 2px solid var(--zc); }
+.fl-gname { font-size: 10.5px; font-weight: 700; letter-spacing: 1.2px; color: var(--text); }
+.fl-gcount { font-size: 10px; color: var(--text-dim); font-variant-numeric: tabular-nums; }
+.fl-rows { display: flex; flex-direction: column; gap: 1px; }
+.fl-row { display: grid; grid-template-columns: 12px auto minmax(0, 1fr) auto; align-items: center; gap: 9px; width: 100%; text-align: left; background: transparent; border: 0; border-radius: 7px; padding: 7px 8px; cursor: pointer; font-family: inherit; transition: background .12s; }
+.fl-row:hover { background: var(--bg-elev); }
+.fl-row:focus-visible { outline: none; box-shadow: 0 0 0 2px var(--accent-dim); }
+.fl-dot { width: 8px; height: 8px; border-radius: 50%; background: var(--text-dim); }
+.fl-name { font-size: 12.5px; font-weight: 500; color: var(--text); white-space: nowrap; }
+.fl-role { font-size: 10px; color: var(--text-dim); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.fl-act { font-size: 10.5px; font-family: var(--mono); color: var(--text-dim); white-space: nowrap; justify-self: end; }
+.fl-row[data-state="active"] .fl-dot { background: var(--blue); box-shadow: 0 0 6px rgba(96,165,250,.5); animation: breathe 2s ease-in-out infinite; }
+.fl-row[data-state="active"] .fl-act { color: var(--blue); }
+.fl-row[data-state="online"] .fl-dot { background: var(--accent); }
+.fl-row[data-state="online"] .fl-act { color: var(--text-muted); }
+.fl-row[data-state="idle"] .fl-dot { background: var(--text-dim); }
+
+.msg-search { font-family: inherit; font-size: 11px; color: var(--text); background: var(--bg-elev); border: 1px solid var(--border); border-radius: 6px; padding: 3px 8px; width: 96px; transition: border-color .15s, width .15s; }
+.msg-search:focus { outline: none; border-color: var(--accent-dim); width: 140px; }
+.msg-search::placeholder { color: var(--text-dim); }
+
 /* ---------- phase 3 responsive ---------- */
 @media (max-width: 1080px) {
   .cinema { grid-template-columns: 1fr; }
   .stage { height: 460px; min-height: 420px; }
+  .fleet { height: auto; min-height: 0; }
   .transcript { max-height: 360px; }
   .proj-card.is-mirror { grid-column: span 1; }
   .home-hero { align-items: flex-start; }


### PR DESCRIPTION
## Why
Owner feedback on the team board: *"on voit pas les noms des leaf quand y'en a bcp, t'as des messages qu'on voit pas, c'est fouilli et pas clair."* The constellation ("message cinema") optimizes for spectacle over legibility — wrong tradeoff for an ops tool.

## What
- **Default = fleet CONSOLE**: agents grouped by team in a responsive, content-sized card grid (`auto-fill minmax(248px,1fr)` — no half-empty boxes). Every **name + role + live activity (tool)** is **always visible**. Status dot driven by the live activity stream (active=blue pulse / online=green / idle=dim).
- **Constellation preserved behind a "Show mode" toggle** (segmented control, persisted in localStorage) — *"quitte à mettre un SHOW MODE lol"*.
- **Message feed** is now the persistent primary surface in both modes (already expandable to full body) + a **free-text filter** (from/to/subject/body) so nothing is missed.
- Shared state: the live snapshot carries a **tool label** and updates both console rows and constellation nodes; `baseState`/`stateFor`/`labelFor` unify resting vs live state.

No backend change — builds on the name-keyed activity join from #113.

## Design (per ui-ux-2026)
Grounded **structural / function-forward** lane: dark tokens (existing `:root`), hairline team cards, mono for activity/data, tabular counts. Real hierarchy (team header weight, dim roles, mono activity). A11y: `.fl-row` is a real `<button>`, visible focus rings (≥3:1), keyboard-navigable, `prefers-reduced-motion` respected (existing rule covers the new `breathe`). Responsive grid via auto-fill (component-driven), collapses to single column <1080px.

## Verification
- `node --check` on team.js / api.js clean; `go build -tags fts5` green (UI embeds).
- Backend join re-verified at runtime on a **copy of the prod DB**: posting activity for real session_ids lit 5 agents by name (cto=typing, donna-dev=typing, fullstack-trovex=reading, launch-lead=waiting, wraith-dev=terminal) — confirms the #113 join end to end.
- Visual QA: owner will test on the deployed build.

## Deploy
UI is `go:embed`-ed → serving the new UI needs a prod relay **restart** (not just `agent-relay update`). Bundle with v1.4.6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)