### PR TITLE
feat(team): surface all 7 activities + offline/sleeping + disk-served UI (no-restart deploys)

### DIFF
--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -5,6 +5,7 @@ import (
 	"io/fs"
 	"log"
 	"net/http"
+	"os"
 	"sync"
 	"time"
 
@@ -129,12 +130,26 @@ func (r *Relay) ListenAndServe(addr string) error {
 	// REST API
 	mux.HandleFunc("/api/", r.ServeAPI)
 
-	// Embedded static files
-	staticFS, err := fs.Sub(web.StaticFiles, "static")
-	if err != nil {
-		log.Fatalf("failed to create sub FS: %v", err)
+	// Static UI. A RELAY_UI_DIR override serves the UI from disk so UI changes
+	// deploy with a file copy — no rebuild, no relay restart (and thus no MCP-pipe
+	// drop). Falls back to the embedded build when unset/invalid.
+	var uiHandler http.Handler
+	if dir := os.Getenv("RELAY_UI_DIR"); dir != "" {
+		if st, serr := os.Stat(dir); serr == nil && st.IsDir() {
+			log.Printf("serving UI from disk override RELAY_UI_DIR=%s", dir)
+			uiHandler = http.FileServer(http.Dir(dir))
+		} else {
+			log.Printf("RELAY_UI_DIR=%s is not a directory — falling back to embedded UI", dir)
+		}
 	}
-	mux.Handle("/", http.FileServerFS(staticFS))
+	if uiHandler == nil {
+		staticFS, err := fs.Sub(web.StaticFiles, "static")
+		if err != nil {
+			log.Fatalf("failed to create sub FS: %v", err)
+		}
+		uiHandler = http.FileServerFS(staticFS)
+	}
+	mux.Handle("/", uiHandler)
 
 	handler := r.buildMiddlewareChain(mux)
 	r.httpServer = &http.Server{Addr: addr, Handler: handler}

--- a/internal/web/static/v2/team.js
+++ b/internal/web/static/v2/team.js
@@ -280,13 +280,13 @@ export function initTeam(root, ctx) {
     ctx.openSheet(el);
   }
   function nodeHTML(a) {
-    const state = stateFor(a.name, a);
+    const state = disp(a).act;
     const role = a.profile_slug || shortRole(a.role);
     // one dot per team the agent belongs to → shows multi-team membership at a glance.
     const teams = (a.teams || []);
     const dots = teams.map((t) =>
       `<span class="an-team" style="background:${TEAM_COLOR[t.slug] || colorFor(t.slug)}" title="${esc(t.name || t.slug)}"></span>`).join('');
-    return `<div class="agent-node" data-name="${esc(a.name)}" data-state="${state}" style="--c:${colorFor(a.name)}" tabindex="0" aria-label="${esc(a.name)}${role ? ' · ' + esc(role) : ''}${teams.length ? ' · teams: ' + esc(teams.map((t) => t.slug).join(', ')) : ''}">
+    return `<div class="agent-node" data-name="${esc(a.name)}" data-act="${state}" style="--c:${colorFor(a.name)}" tabindex="0" aria-label="${esc(a.name)}${role ? ' · ' + esc(role) : ''}${teams.length ? ' · teams: ' + esc(teams.map((t) => t.slug).join(', ')) : ''}">
       <span class="an-orbit" aria-hidden="true"></span>
       <span class="an-heat" aria-hidden="true"></span>
       <span class="an-avatar">${a.avatar_url ? `<img class="an-img" src="${esc(a.avatar_url)}" alt="" loading="lazy" onerror="this.remove()">` : esc(initialFor(a.name))}<span class="an-status" aria-hidden="true"></span></span>
@@ -340,34 +340,52 @@ export function initTeam(root, ctx) {
   }
 
   /* --------------------- live activity (state dots) --------------- */
-  // The node's resting state from the load-time agent record (last_seen + last
-  // known activity). The live SSE snapshot overrides this when a session is hot.
-  function baseState(a) {
-    return a && a.online ? (a.activity && a.activity !== 'idle' ? 'active' : 'online') : 'idle';
+  // Activity vocabulary — 1:1 with what the relay tracks (internal/ingest/mapper.go):
+  // the 7 live activities + the two lifecycle states (sleeping, offline). Each gets
+  // an inline-SVG icon (no emoji, per house rules); color is driven by CSS [data-act].
+  const ACT = {
+    terminal: { label: 'terminal', icon: 'M4 17l6-5-6-5M13 19h7' },
+    typing:   { label: 'editing',  icon: 'M12 20h9M16.5 3.5a2.1 2.1 0 0 1 3 3L7 19l-4 1 1-4z' },
+    reading:  { label: 'reading',  icon: 'M11 18a7 7 0 1 1 0-14 7 7 0 0 1 0 14zM21 21l-4.35-4.35' },
+    browsing: { label: 'web',      icon: 'M12 3a9 9 0 1 0 0 18 9 9 0 0 0 0-18M3 12h18M12 3c2.6 2.7 2.6 15.3 0 18M12 3c-2.6 2.7-2.6 15.3 0 18' },
+    thinking: { label: 'thinking', icon: 'M12 2l2.1 6.2L20.5 10l-6.4 1.8L12 18l-2.1-6.2L3.5 10l6.4-1.8z' },
+    waiting:  { label: 'waiting',  icon: 'M9 5v14M15 5v14' },
+    idle:     { label: 'idle',     icon: 'M5 12h14' },
+    sleeping: { label: 'sleeping', icon: 'M20.5 13a8 8 0 1 1-9.5-9.5 6.2 6.2 0 0 0 9.5 9.5z' },
+    offline:  { label: 'offline',  icon: 'M12 3a9 9 0 1 0 0 18 9 9 0 0 0 0-18M5.6 5.6l12.8 12.8' },
+  };
+  function actIcon(key) {
+    const d = (ACT[key] || ACT.idle).icon;
+    return `<svg class="fl-ic" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="${d}"/></svg>`;
   }
-  // Map a detector session state → the node's visual state. active/thinking = at
-  // work (blue, fast breathe); waiting = present between turns (green); idle or
-  // exited = idle (dim).
-  function nodeStateFor(s) {
-    if (s.state === 'idle' || s.state === 'exited' || s.activity === 'idle') return 'idle';
-    if (s.state === 'waiting' || s.activity === 'waiting') return 'online';
-    return 'active';
+  const WORKING = new Set(['terminal', 'typing', 'reading', 'browsing', 'thinking']);
+  // Resolve an agent → {act, label}. Priority: live session (hot) → DB lifecycle
+  // (sleeping / inactive→offline) → last-known resolved activity → idle. The tool
+  // name (Bash, Grep…) is shown when present, else the activity word.
+  function disp(a) {
+    const live = a && liveInfo.get(a.name);
+    if (live && live.state !== 'idle' && live.state !== 'exited') {
+      const act = live.state === 'waiting' ? 'waiting' : (ACT[live.act] ? live.act : 'thinking');
+      return { act, label: live.tool || ACT[act].label };
+    }
+    if (a && a.status === 'sleeping') return { act: 'sleeping', label: 'sleeping' };
+    if (!a || a.status === 'inactive' || !a.online) return { act: 'offline', label: 'offline' };
+    if (a.activity && a.activity !== 'idle' && ACT[a.activity]) {
+      return { act: a.activity, label: a.activity_tool || ACT[a.activity].label };
+    }
+    return { act: 'idle', label: 'idle' };
   }
-  // Short human label for what an agent is doing right now: the live tool when
-  // working, else the activity word, else the coarse state.
-  function liveLabel(s) {
-    if (s.tool) return s.tool;
-    if (s.activity && s.activity !== 'idle') return s.activity;
-    return s.state || 'idle';
+  // Repaint a console row's activity (icon + label + data-act for color).
+  function paintRow(row, a) {
+    const d = disp(a);
+    row.dataset.act = d.act;
+    const lab = row.querySelector('.fl-act');
+    if (lab) lab.innerHTML = actIcon(d.act) + `<span class="fl-actlabel">${esc(d.label)}</span>`;
   }
-  const stateFor = (name, a) => (liveInfo.get(name) || {}).state || baseState(a);
-  const restLabel = (a) => (a && a.online ? (a.activity && a.activity !== 'idle' ? a.activity : 'online') : 'offline');
-  const labelFor = (name, a) => (liveInfo.get(name) || {}).label || restLabel(a);
 
-  // Apply a live snapshot ({sessions, agents}) from /api/activity/stream. Joins
-  // on the resolved agent name (stable across /clear, unlike session_id) and
-  // updates the live state + tool label for both views. Agents absent from the
-  // snapshot fall back to their load-time resting state.
+  // Apply a live snapshot ({sessions}) from /api/activity/stream. Joins on the
+  // resolved agent name (stable across /clear, unlike session_id) and repaints
+  // both views. Agents absent from the snapshot fall back to DB lifecycle/idle.
   function applyActivitySnapshot(snap) {
     const sessions = (snap && Array.isArray(snap.sessions)) ? snap.sessions : [];
     const proj = ctx.selection;
@@ -375,18 +393,11 @@ export function initTeam(root, ctx) {
     for (const s of sessions) {
       if (!s.agent || !nameSet.has(s.agent)) continue;
       if (proj !== 'all' && s.project && s.project !== proj) continue;
-      liveInfo.set(s.agent, { state: nodeStateFor(s), label: liveLabel(s) });
+      liveInfo.set(s.agent, { act: s.activity, tool: s.tool, state: s.state });
     }
     const byName = new Map(agents.map((a) => [a.name, a]));
-    for (const [name, el] of nodeEl) {
-      el.dataset.state = stateFor(name, byName.get(name));
-    }
-    for (const [name, row] of fleetRowEl) {
-      const a = byName.get(name);
-      row.dataset.state = stateFor(name, a);
-      const lab = row.querySelector('.fl-act');
-      if (lab) lab.textContent = labelFor(name, a);
-    }
+    for (const [name, el] of nodeEl) el.dataset.act = disp(byName.get(name)).act;
+    for (const [name, row] of fleetRowEl) paintRow(row, byName.get(name));
   }
 
   /* --------------------- fleet console (default view) ------------- */
@@ -417,11 +428,12 @@ export function initTeam(root, ctx) {
       const label = g.slug === 'unassigned' ? 'UNASSIGNED' : g.slug.toUpperCase();
       const rows = g.members.map((a) => {
         const role = a.profile_slug || shortRole(a.role);
-        return `<button class="fl-row" type="button" data-name="${esc(a.name)}" data-state="${stateFor(a.name, a)}" style="--c:${colorFor(a.name)}" aria-label="${esc(a.name)}${role ? ' · ' + esc(role) : ''}">
+        const d = disp(a);
+        return `<button class="fl-row" type="button" data-name="${esc(a.name)}" data-act="${d.act}" style="--c:${colorFor(a.name)}" aria-label="${esc(a.name)}${role ? ' · ' + esc(role) : ''} · ${esc(d.label)}">
           <span class="fl-dot" aria-hidden="true"></span>
           <span class="fl-name">${esc(a.name)}</span>
           ${role ? `<span class="fl-role">${esc(role)}</span>` : ''}
-          <span class="fl-act">${esc(labelFor(a.name, a))}</span>
+          <span class="fl-act">${actIcon(d.act)}<span class="fl-actlabel">${esc(d.label)}</span></span>
         </button>`;
       }).join('');
       return `<section class="fl-group" style="--zc:${color}">

--- a/internal/web/static/v2/v2.css
+++ b/internal/web/static/v2/v2.css
@@ -16,6 +16,7 @@
   --amber: #fbbf24;
   --blue: #60a5fa;
   --violet: #a78bfa;
+  --cyan: #22d3ee;
   --slate: #3a4252;
   --radius: 10px;
   --radius-sm: 7px;
@@ -797,9 +798,14 @@ button { font-family: inherit; }
   position: absolute; right: -1px; bottom: -1px; width: 11px; height: 11px; border-radius: 50%;
   background: var(--text-dim); border: 2px solid var(--bg-card);
 }
-.agent-node[data-state="online"] .an-status { background: var(--accent); }
-.agent-node[data-state="active"] .an-status { background: var(--blue); animation: breathe 2s ease-in-out infinite; }
-.agent-node[data-state="idle"] .an-status { background: var(--text-dim); animation: breathe 3.6s ease-in-out infinite; }
+.agent-node .an-status { background: var(--ac, var(--text-dim)); }
+.agent-node[data-act="idle"] .an-status { animation: breathe 3.6s ease-in-out infinite; }
+.agent-node[data-act="terminal"] .an-status, .agent-node[data-act="typing"] .an-status,
+.agent-node[data-act="reading"] .an-status, .agent-node[data-act="browsing"] .an-status,
+.agent-node[data-act="thinking"] .an-status { animation: breathe 2s ease-in-out infinite; }
+.agent-node[data-act="offline"] .an-status, .agent-node[data-act="sleeping"] .an-status {
+  background: transparent; box-shadow: inset 0 0 0 1.5px var(--ac, var(--text-dim));
+}
 @keyframes breathe { 0%,100% { opacity: 1; } 50% { opacity: .35; } }
 .an-label { display: flex; flex-direction: column; align-items: center; gap: 1px; max-width: 92px; opacity: .6; transition: opacity .15s ease; }
 .an-name { font-size: 11px; color: var(--text); font-weight: 600; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 92px; }
@@ -811,9 +817,9 @@ button { font-family: inherit; }
 .an-teams { display: inline-flex; gap: 3px; justify-content: center; margin-top: 2px; }
 .an-team { width: 6px; height: 6px; border-radius: 50%; box-shadow: 0 0 0 1px rgba(0,0,0,.35); }
 .agent-node { z-index: 1; }
-.agent-node:hover, .agent-node:focus-visible, .agent-node[data-state="active"] { z-index: 6; }
-.agent-node:hover .an-label, .agent-node:focus-visible .an-label, .agent-node[data-state="active"] .an-label { opacity: 1; }
-.agent-node:hover .an-role, .agent-node:focus-visible .an-role, .agent-node[data-state="active"] .an-role { max-height: 14px; opacity: 1; }
+.agent-node:hover, .agent-node:focus-visible, .agent-node[data-act]:not([data-act="idle"]):not([data-act="offline"]) { z-index: 6; }
+.agent-node:hover .an-label, .agent-node:focus-visible .an-label, .agent-node[data-act]:not([data-act="idle"]):not([data-act="offline"]) .an-label { opacity: 1; }
+.agent-node:hover .an-role, .agent-node:focus-visible .an-role, .agent-node[data-act]:not([data-act="idle"]):not([data-act="offline"]) .an-role { max-height: 14px; opacity: 1; }
 .agent-node.ping .an-avatar { animation: nodePing .6s ease-out; }
 @keyframes nodePing {
   0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--c) 60%, transparent), 0 2px 10px rgba(0,0,0,.4); }
@@ -887,15 +893,31 @@ button { font-family: inherit; }
 .fl-row { display: grid; grid-template-columns: 12px auto minmax(0, 1fr) auto; align-items: center; gap: 9px; width: 100%; text-align: left; background: transparent; border: 0; border-radius: 7px; padding: 7px 8px; cursor: pointer; font-family: inherit; transition: background .12s; }
 .fl-row:hover { background: var(--bg-elev); }
 .fl-row:focus-visible { outline: none; box-shadow: 0 0 0 2px var(--accent-dim); }
-.fl-dot { width: 8px; height: 8px; border-radius: 50%; background: var(--text-dim); }
+.fl-dot { width: 8px; height: 8px; border-radius: 50%; background: var(--ac, var(--text-dim)); }
 .fl-name { font-size: 12.5px; font-weight: 500; color: var(--text); white-space: nowrap; }
 .fl-role { font-size: 10px; color: var(--text-dim); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-.fl-act { font-size: 10.5px; font-family: var(--mono); color: var(--text-dim); white-space: nowrap; justify-self: end; }
-.fl-row[data-state="active"] .fl-dot { background: var(--blue); box-shadow: 0 0 6px rgba(96,165,250,.5); animation: breathe 2s ease-in-out infinite; }
-.fl-row[data-state="active"] .fl-act { color: var(--blue); }
-.fl-row[data-state="online"] .fl-dot { background: var(--accent); }
-.fl-row[data-state="online"] .fl-act { color: var(--text-muted); }
-.fl-row[data-state="idle"] .fl-dot { background: var(--text-dim); }
+.fl-act { display: inline-flex; align-items: center; gap: 5px; justify-self: end; font-family: var(--mono); font-size: 10.5px; white-space: nowrap; color: var(--ac, var(--text-dim)); }
+.fl-ic { flex: none; }
+
+/* ---- activity color tokens — shared by console rows + constellation nodes ---- */
+[data-act="terminal"] { --ac: var(--amber); }
+[data-act="typing"]   { --ac: var(--blue); }
+[data-act="reading"]  { --ac: var(--cyan); }
+[data-act="browsing"] { --ac: var(--violet); }
+[data-act="thinking"] { --ac: var(--accent); }
+[data-act="waiting"]  { --ac: var(--slate); }
+[data-act="idle"]     { --ac: var(--text-dim); }
+[data-act="sleeping"] { --ac: var(--violet); }
+[data-act="offline"]  { --ac: var(--text-dim); }
+/* working states pulse; offline/sleeping are hollow; offline name dims */
+.fl-row[data-act="terminal"] .fl-dot, .fl-row[data-act="typing"] .fl-dot, .fl-row[data-act="reading"] .fl-dot,
+.fl-row[data-act="browsing"] .fl-dot, .fl-row[data-act="thinking"] .fl-dot {
+  box-shadow: 0 0 6px color-mix(in srgb, var(--ac) 55%, transparent); animation: breathe 2s ease-in-out infinite;
+}
+.fl-row[data-act="offline"] .fl-dot, .fl-row[data-act="sleeping"] .fl-dot {
+  background: transparent; box-shadow: inset 0 0 0 1.5px var(--ac);
+}
+.fl-row[data-act="offline"] .fl-name { color: var(--text-muted); }
 
 .msg-search { font-family: inherit; font-size: 11px; color: var(--text); background: var(--bg-elev); border: 1px solid var(--border); border-radius: 6px; padding: 3px 8px; width: 96px; transition: border-color .15s, width .15s; }
 .msg-search:focus { outline: none; border-color: var(--accent-dim); width: 140px; }


### PR DESCRIPTION
## Why
Owner: *"je me suis fait chier à tout faire pour bash/search etc, ça devrait s'afficher."* The relay maps **7 activities** (`internal/ingest/mapper.go`) but the board collapsed everything to a 3-state dot — the mapping work was invisible. Also, during the v1.4.6 deco the whole fleet read "offline" identically because offline/sleeping/idle weren't distinct.

## What
**UI — real per-agent activity** (console + constellation), driven by a shared `[data-act]` color token:
| activity | tools | color |
|---|---|---|
| terminal | Bash | amber |
| typing | Write/Edit/str_replace | blue |
| reading | Read/Grep/Glob/LSP | cyan |
| browsing | WebSearch/WebFetch | violet |
| thinking | ToolSearch/Agent/Skill/plan/Task* | green |
| waiting | stop / AskUserQuestion | slate |
| idle / sleeping / offline | — | dim / hollow violet / hollow |

- Live **tool name** (Bash, Grep…) shown as the label when present, else the activity word. Inline-SVG icon per activity (no emoji, house rule).
- **Lifecycle now visible**: `sleeping` (hollow violet) and `offline` (hollow + dimmed name) are distinct from a live `idle` — previously all the same grey dot.
- One resolver `disp(a)`: live session (hot) → DB lifecycle (sleeping / inactive→offline) → last-known activity → idle. Working states pulse.

**Backend — `RELAY_UI_DIR` disk override**: serves the UI from a disk dir (falls back to embedded). Future UI changes deploy with a **file copy — no rebuild, no relay restart, no MCP-pipe drop**. Kills the restart→MCP-deco footgun for all future UI iteration.

## Verified
- `go build/vet/test` green (`-tags fts5`); `node --check` clean.
- Disk-override serves the new UI **end-to-end** on a prod-DB copy with live activity (team.js + css confirmed served from disk; startup log shows the override).
- Visual QA: owner tests on deploy.

## Deploy
One restart to ship this binary (enables the override). After that, set `RELAY_UI_DIR` on prod and **all subsequent UI changes are restart-free**. Owner holds release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)