### PR TITLE
fix(activity): online-while-working + resolve non-deleted + runtime thresholds (re-land of #116)

### DIFF
--- a/internal/db/agents.go
+++ b/internal/db/agents.go
@@ -251,8 +251,13 @@ func (d *DB) GetAgentBySessionID(sessionID string) (project, name string, found 
 	if sessionID == "" {
 		return "", "", false, nil
 	}
+	// status != 'deleted' (not '= active'): an agent working hard locally only
+	// bumps last_seen on relay tool calls, so the 30-min sweep can mark it
+	// 'inactive' mid-work. Resolving only 'active' rows then dropped its live
+	// activity → the board showed it offline while it was clearly busy. Resolve
+	// any non-deleted agent; liveness is decided by the live session, not status.
 	row := d.ro().QueryRow(
-		"SELECT project, name FROM agents WHERE session_id = ? AND status = 'active' LIMIT 1",
+		"SELECT project, name FROM agents WHERE session_id = ? AND status != 'deleted' LIMIT 1",
 		sessionID,
 	)
 	switch e := row.Scan(&project, &name); {
@@ -290,7 +295,7 @@ func (d *DB) RebindSessionByCwd(cwd, sessionID string) (project, name string, fo
 		return "", "", false, nil
 	}
 	row := d.ro().QueryRow(
-		"SELECT project, name FROM agents WHERE cwd = ? AND status = 'active' LIMIT 1",
+		"SELECT project, name FROM agents WHERE cwd = ? AND status != 'deleted' LIMIT 1",
 		cwd,
 	)
 	switch e := row.Scan(&project, &name); {

--- a/internal/ingest/detector.go
+++ b/internal/ingest/detector.go
@@ -7,12 +7,28 @@ import (
 )
 
 const (
-	waitingThreshold = 10 * time.Second
-	idleThreshold    = 30 * time.Second
-	exitThreshold    = 5 * time.Minute
-	tickInterval     = 2 * time.Second
-	minDisplayTime   = 1500 * time.Millisecond // activity visible for at least 1.5s
+	tickInterval   = 2 * time.Second
+	minDisplayTime = 1500 * time.Millisecond // activity visible for at least 1.5s
 )
+
+// Thresholds are the activity-lifecycle timeouts. They are read live (per tick)
+// from a provider so an operator can tune them at runtime with no restart.
+type Thresholds struct {
+	Waiting time.Duration // tool_end → "waiting" (turn looks finished)
+	Idle    time.Duration // no events → "idle"
+	Exit    time.Duration // no events → session dropped from the board
+}
+
+// DefaultThresholds: idle bumped 30s → 120s (30s flipped agents to idle during
+// normal think/read pauses). Tunable at runtime via the thresholds provider.
+var DefaultThresholds = Thresholds{
+	Waiting: 10 * time.Second,
+	Idle:    120 * time.Second,
+	Exit:    5 * time.Minute,
+}
+
+// ThresholdProvider returns the current thresholds; nil fields fall back to defaults.
+type ThresholdProvider func() Thresholds
 
 type SessionState struct {
 	SessionID string    `json:"session_id"`
@@ -50,17 +66,38 @@ type Detector struct {
 	sessions    map[string]*sessionEntry
 	out         chan<- AgentEvent
 	resolve     AgentResolver
+	thresholds  ThresholdProvider
 	subMu       sync.RWMutex
 	subscribers map[chan []SessionState]struct{}
 }
 
-func newDetector(out chan<- AgentEvent, resolve AgentResolver) *Detector {
+func newDetector(out chan<- AgentEvent, resolve AgentResolver, thresholds ThresholdProvider) *Detector {
 	return &Detector{
 		sessions:    make(map[string]*sessionEntry),
 		out:         out,
 		resolve:     resolve,
+		thresholds:  thresholds,
 		subscribers: make(map[chan []SessionState]struct{}),
 	}
+}
+
+// currentThresholds reads the live thresholds, filling any zero field from the
+// defaults so a partial/absent config can never produce a 0-duration timeout.
+func (d *Detector) currentThresholds() Thresholds {
+	t := DefaultThresholds
+	if d.thresholds != nil {
+		c := d.thresholds()
+		if c.Waiting > 0 {
+			t.Waiting = c.Waiting
+		}
+		if c.Idle > 0 {
+			t.Idle = c.Idle
+		}
+		if c.Exit > 0 {
+			t.Exit = c.Exit
+		}
+	}
+	return t
 }
 
 // Subscribe returns a channel that receives session state snapshots on every change.
@@ -198,6 +235,7 @@ func (d *Detector) tick(now time.Time) {
 	// every RecordEvent/GetSessions. broadcast() stays under the lock because it
 	// reads d.sessions via getSessionsLocked.
 	var pending []AgentEvent
+	th := d.currentThresholds()
 	d.mu.Lock()
 	for sid, s := range d.sessions {
 		elapsed := now.Sub(s.lastEvent)
@@ -210,7 +248,7 @@ func (d *Detector) tick(now time.Time) {
 			s.pendingType = ""
 		}
 
-		if elapsed > exitThreshold {
+		if elapsed > th.Exit {
 			if s.state != "exited" {
 				s.state = "exited"
 				s.activity = ActivityIdle
@@ -225,7 +263,7 @@ func (d *Detector) tick(now time.Time) {
 			continue
 		}
 
-		if elapsed > idleThreshold && !s.idleSent {
+		if elapsed > th.Idle && !s.idleSent {
 			s.idleSent = true
 			s.state = "idle"
 			s.activity = ActivityIdle
@@ -238,7 +276,7 @@ func (d *Detector) tick(now time.Time) {
 			continue
 		}
 
-		if elapsed > waitingThreshold && s.lastType == EventToolEnd && !s.waitSent {
+		if elapsed > th.Waiting && s.lastType == EventToolEnd && !s.waitSent {
 			s.waitSent = true
 			s.state = "waiting"
 			s.activity = ActivityWaiting

--- a/internal/ingest/detector_test.go
+++ b/internal/ingest/detector_test.go
@@ -13,13 +13,13 @@ import (
 func TestDetector_TickEmitsNonBlocking(t *testing.T) {
 	// Unbuffered + no reader: a blocking send here would hang tick forever.
 	out := make(chan AgentEvent)
-	d := newDetector(out, nil)
+	d := newDetector(out, nil, nil)
 
 	// Session old enough to trigger an idle event on the next tick.
 	d.RecordEvent(AgentEvent{
 		SessionID: "s1",
 		Type:      EventToolEnd,
-		Timestamp: time.Now().Add(-idleThreshold - time.Second),
+		Timestamp: time.Now().Add(-DefaultThresholds.Idle - time.Second),
 	})
 
 	done := make(chan struct{})
@@ -50,7 +50,7 @@ func TestDetector_ResolvesAgent(t *testing.T) {
 			return "", "", false // unbound on first event
 		}
 		return "proj", "wraith-dev", true
-	})
+	}, nil)
 
 	// First event: resolver returns not-found → session stays untagged.
 	d.RecordEvent(AgentEvent{SessionID: "s1", Type: EventToolStart, Tool: "Edit", Timestamp: time.Now()})
@@ -78,11 +78,11 @@ func TestDetector_ResolvesAgent(t *testing.T) {
 // reader when one is present (buffered sink).
 func TestDetector_TickDeliversWhenDrained(t *testing.T) {
 	out := make(chan AgentEvent, 4)
-	d := newDetector(out, nil)
+	d := newDetector(out, nil, nil)
 	d.RecordEvent(AgentEvent{
 		SessionID: "s1",
 		Type:      EventToolEnd,
-		Timestamp: time.Now().Add(-idleThreshold - time.Second),
+		Timestamp: time.Now().Add(-DefaultThresholds.Idle - time.Second),
 	})
 	d.tick(time.Now())
 	select {

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -11,6 +11,9 @@ type Config struct {
 	// activity with the stable agent identity (not the rotating session_id), so
 	// the UI joins activity to agents by name. Optional; nil → activity untagged.
 	AgentResolver AgentResolver
+	// Thresholds returns the live activity-lifecycle timeouts (read per tick) so
+	// they can be tuned at runtime. Optional; nil → DefaultThresholds.
+	Thresholds ThresholdProvider
 }
 
 func (c *Config) defaults() {
@@ -39,7 +42,7 @@ func New(cfg Config) (*Ingester, error) {
 	// file-drop watcher is gone. Nothing consumes Events in production; the
 	// detector's tick sends to it non-blockingly and drops when unread.
 	events := make(chan AgentEvent, cfg.EventBufferSize)
-	detector := newDetector(events, cfg.AgentResolver)
+	detector := newDetector(events, cfg.AgentResolver, cfg.Thresholds)
 
 	go detector.run(ctx)
 

--- a/internal/relay/api.go
+++ b/internal/relay/api.go
@@ -92,6 +92,10 @@ func (r *Relay) ServeAPI(w http.ResponseWriter, req *http.Request) {
 		r.apiGetActivity(w)
 	case path == "/activity/stream" && req.Method == http.MethodGet:
 		r.apiStreamActivity(w, req)
+	case path == "/activity-config" && req.Method == http.MethodGet:
+		r.apiGetActivityConfig(w)
+	case path == "/activity-config" && req.Method == http.MethodPost:
+		r.apiSetActivityConfig(w, req)
 	case path == "/events/stream" && req.Method == http.MethodGet:
 		r.apiStreamEvents(w, req)
 	case path == "/events/recent" && req.Method == http.MethodGet:
@@ -490,6 +494,12 @@ func (r *Relay) apiGetAgents(w http.ResponseWriter, req *http.Request) {
 		}
 		aa.Online = online
 		applyActivity(&aa, project, a.Name, a.SessionID, actByAgent, actMap)
+		// A live detector session means the agent is working now — online even if
+		// last_seen is stale (last_seen only bumps on relay tool calls, not on the
+		// activity hooks an agent fires while heads-down in local work).
+		if aa.Activity != "" {
+			aa.Online = true
+		}
 		result = append(result, aa)
 	}
 
@@ -588,6 +598,9 @@ func (r *Relay) apiGetAllAgents(w http.ResponseWriter) {
 			Teams:        teamsByAgent[a.Project+":"+a.Name],
 		}
 		applyActivity(&aa, a.Project, a.Name, a.SessionID, actByAgent, actMap)
+		if aa.Activity != "" {
+			aa.Online = true
+		}
 		result = append(result, aa)
 	}
 
@@ -943,6 +956,46 @@ func (r *Relay) apiResolveMemoryConflict(w http.ResponseWriter, req *http.Reques
 		return
 	}
 	writeJSON(w, map[string]any{"resolved": true, "memory": mem})
+}
+
+// apiGetActivityConfig returns the live activity-lifecycle thresholds (seconds).
+// Empty = using the built-in default for that field.
+func (r *Relay) apiGetActivityConfig(w http.ResponseWriter) {
+	writeJSON(w, map[string]any{
+		"idle_seconds":    r.DB.GetSetting("activity_idle_seconds"),
+		"waiting_seconds": r.DB.GetSetting("activity_waiting_seconds"),
+		"exit_seconds":    r.DB.GetSetting("activity_exit_seconds"),
+		"defaults":        map[string]int{"idle": 120, "waiting": 10, "exit": 300},
+	})
+}
+
+// apiSetActivityConfig tunes the activity thresholds at runtime — the detector
+// reads them live each tick, so changes apply with no restart. Only the provided
+// fields change; a value <= 0 clears the override (reverts to default).
+func (r *Relay) apiSetActivityConfig(w http.ResponseWriter, req *http.Request) {
+	var body struct {
+		IdleSeconds    *int `json:"idle_seconds"`
+		WaitingSeconds *int `json:"waiting_seconds"`
+		ExitSeconds    *int `json:"exit_seconds"`
+	}
+	if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
+		http.Error(w, `{"error":"invalid json"}`, http.StatusBadRequest)
+		return
+	}
+	set := func(key string, v *int) {
+		if v == nil {
+			return
+		}
+		if *v <= 0 {
+			r.DB.SetSetting(key, "")
+		} else {
+			r.DB.SetSetting(key, strconv.Itoa(*v))
+		}
+	}
+	set("activity_idle_seconds", body.IdleSeconds)
+	set("activity_waiting_seconds", body.WaitingSeconds)
+	set("activity_exit_seconds", body.ExitSeconds)
+	r.apiGetActivityConfig(w)
 }
 
 func (r *Relay) apiGetActivity(w http.ResponseWriter) {

--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -23,6 +24,16 @@ import (
 )
 
 var Version = "dev"
+
+// settingSeconds parses a settings value as a positive number of seconds, or
+// returns 0 (→ the detector falls back to its default for that threshold).
+func settingSeconds(v string) time.Duration {
+	n, err := strconv.Atoi(strings.TrimSpace(v))
+	if err != nil || n <= 0 {
+		return 0
+	}
+	return time.Duration(n) * time.Second
+}
 
 func main() {
 	if len(os.Args) > 1 {
@@ -81,6 +92,13 @@ func startStdioMCP() {
 			project, name, found, _ := database.GetAgentBySessionID(sessionID)
 			return project, name, found
 		},
+		Thresholds: func() ingest.Thresholds {
+			return ingest.Thresholds{
+				Waiting: settingSeconds(database.GetSetting("activity_waiting_seconds")),
+				Idle:    settingSeconds(database.GetSetting("activity_idle_seconds")),
+				Exit:    settingSeconds(database.GetSetting("activity_exit_seconds")),
+			}
+		},
 	})
 	if err != nil {
 		log.Fatalf("failed to init ingester: %v", err)
@@ -125,6 +143,13 @@ func startServer() {
 		AgentResolver: func(sessionID string) (string, string, bool) {
 			project, name, found, _ := database.GetAgentBySessionID(sessionID)
 			return project, name, found
+		},
+		Thresholds: func() ingest.Thresholds {
+			return ingest.Thresholds{
+				Waiting: settingSeconds(database.GetSetting("activity_waiting_seconds")),
+				Idle:    settingSeconds(database.GetSetting("activity_idle_seconds")),
+				Exit:    settingSeconds(database.GetSetting("activity_exit_seconds")),
+			}
 		},
 	})
 	if err != nil {


### PR DESCRIPTION
Re-land of #116 — that PR's squash merge landed **empty** (a git-juggling mistake on my side; the changes never reached main). Same diff, recovered from the original commit.

## Fixes (verified on prod-DB copy)
1. **Online while working** — an agent with a live detector session is online regardless of stale `last_seen` (apiGetAgents + apiGetAllAgents).
2. **Resolve any non-deleted agent** — `GetAgentBySessionID`/`RebindSessionByCwd` no longer filter `status='active'`, so a swept-`inactive` but busy agent still resolves + shows its activity.
3. **Idle 30s→120s + runtime-tunable** — waiting/idle/exit read live per tick via a `ThresholdProvider`; tune with no restart via `POST /api/activity-config` (`GET` to read).

`go build/vet/test` green (`-tags fts5`); gofmt clean (1.25.5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)