### PR TITLE
fix(board): no fake 'stale 9674.6d' on tasks with no relay activity

### DIFF
--- a/internal/web/static/v2/board.js
+++ b/internal/web/static/v2/board.js
@@ -148,8 +148,13 @@ export function initBoard(root, ctx) {
   // Staleness: a card sitting in an active state past STALE_MS since it last moved.
   function staleness(t) {
     if (!isActiveStatus(t.status)) return null;
-    const since = Date.parse(t.in_review_at || t.started_at || t.claimed_at || t.accepted_at || 0);
-    if (!since) return null;
+    // Only the real activity timestamps — NOT `|| 0`, which makes Date.parse fall
+    // back to a valid date (2000-01-01) and report ~9674d "stale" on every task
+    // that has no relay activity row (e.g. Linear-mirrored tasks).
+    const ts = t.in_review_at || t.started_at || t.claimed_at || t.accepted_at;
+    if (!ts) return null;
+    const since = Date.parse(ts);
+    if (!since || Number.isNaN(since)) return null;
     const age = Date.now() - since;
     return age > STALE_MS ? age : null;
   }


### PR DESCRIPTION
Owner spotted in the v1.4.6 console: every task showed `stale 9674.6d` (~26.5 yrs). `staleness()` did `Date.parse(... || 0)` → with all activity timestamps null (Linear-mirrored tasks), the chain fell to `0` → `Date.parse(0)`=2000-01-01 → now-minus-2000 ≈ 9674d on every task. Fix: require a real timestamp; none → no stale badge.

Already **live in prod** via the disk-served UI (RELAY_UI_DIR); this lands it in the embedded build too. Frontend-only, no restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)