### PR TITLE
fix(update): atomic binary swap + staged restart — stop killing live MCP pipes (TSU-74)

### DIFF
--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"os"
 	"os/exec"
@@ -33,18 +34,32 @@ const (
 
 func runUpdate(args []string) {
 	force := false
+	// noRestart stages the new binary (atomic swap) WITHOUT restarting the
+	// service. The new binary applies on the next launch. This is the safe
+	// default for an auto-update fired mid-session by a release-watcher: it
+	// must never kill a live process (see installBinary / TSU-74).
+	noRestart := envFlag("AGENT_RELAY_NO_SELF_RESTART")
 	for _, a := range args {
 		if a == "--force" || a == "-f" {
 			force = true
 		}
+		if a == "--no-restart" || a == "--stage" {
+			noRestart = true
+		}
 		if a == "--help" || a == "-h" {
-			fmt.Print(`usage: agent-relay update [--force]
+			fmt.Print(`usage: agent-relay update [--force] [--no-restart]
 
-Check for updates and install the latest version.
+Check for updates and install the latest version. The binary is replaced
+atomically (rename, never in-place truncate), so a process already running the
+old binary — e.g. a live ` + "`agent-relay mcp`" + ` stdio pipe Claude Code spawned —
+keeps running uninterrupted; the new binary applies on its next launch.
 
 flags:
-  -f, --force   Update even if already on latest version
-  -h, --help    Show this help
+  -f, --force        Update even if already on latest version
+      --no-restart   Stage only: swap the binary but do NOT restart the service
+                     (alias: --stage). Also set via AGENT_RELAY_NO_SELF_RESTART.
+                     Use this for auto-update fired while an interactive MCP is live.
+  -h, --help         Show this help
 `)
 			return
 		}
@@ -110,8 +125,10 @@ flags:
 	// ingest hooks stale on the user's machine.
 	refreshSkillAndHooks(latestVersion)
 
-	// 6. Restart service
-	restartService()
+	// 6. Restart service (skipped in staged mode — the swap already happened
+	// atomically, so the new binary applies on the next launch with no live
+	// process killed).
+	restartService(noRestart)
 
 	// 7. Verify
 	fmt.Print("\n  verifying... ")
@@ -513,21 +530,71 @@ func writeExtracted(dst string, src io.Reader) error {
 	return err
 }
 
+// installBinary atomically replaces dst with the new binary at src.
+//
+// It writes a sibling temp file then rename(2)s it over dst. Rename swaps the
+// directory entry to a NEW inode; any process already executing the old binary
+// (critically, a live `agent-relay mcp` stdio pipe Claude Code spawned) keeps
+// running the old, now-unlinked inode and is never touched — the new binary
+// applies only on its next launch. The previous implementation used
+// `install -m 755` which truncates and rewrites the existing inode in place;
+// that corrupts a running executable's text segment → SIGBUS → the live MCP
+// pipe dies fleet-wide. That was the owner-reported TSU-74 footgun.
 func installBinary(src, dst string) bool {
-	// Try direct copy first
-	cmd := exec.Command("install", "-m", "755", src, dst)
-	if err := cmd.Run(); err != nil {
-		// Try with sudo
-		cmd = exec.Command("sudo", "install", "-m", "755", src, dst)
-		if err := cmd.Run(); err != nil {
-			fmt.Fprintf(os.Stderr, "  error: could not install binary to %s: %v\n", dst, err)
-			return false
-		}
+	if err := atomicReplace(src, dst); err == nil {
+		return true
 	}
-	return true
+	// Permission fallback (e.g. root-owned /usr/local/bin): stage a sibling temp
+	// via sudo, then rename it over dst with `mv -f`. mv on the same filesystem
+	// is a rename — same inode-swap guarantee, never an in-place truncate.
+	staged := dst + ".new"
+	if err := exec.Command("sudo", "install", "-m", "755", src, staged).Run(); err == nil {
+		if err := exec.Command("sudo", "mv", "-f", staged, dst).Run(); err == nil {
+			return true
+		}
+		_ = exec.Command("sudo", "rm", "-f", staged).Run()
+	}
+	fmt.Fprintf(os.Stderr, "  error: could not install binary to %s\n", dst)
+	return false
 }
 
-func restartService() {
+// atomicReplace copies src to a sibling temp file in dst's directory, then
+// renames it over dst. Both files must live on the same filesystem for rename(2)
+// to be atomic — using dst's own directory guarantees that. Returns an error
+// (rather than crashing) so installBinary can fall back to the sudo path.
+func atomicReplace(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = in.Close() }()
+
+	tmp, err := os.CreateTemp(filepath.Dir(dst), ".agent-relay-stage-*")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	// Best-effort cleanup if we bail before the rename; a no-op once renamed.
+	defer func() { _ = os.Remove(tmpName) }()
+
+	if _, err := io.Copy(tmp, in); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Chmod(tmpName, 0o755); err != nil {
+		return err
+	}
+	return os.Rename(tmpName, dst)
+}
+
+func restartService(noRestart bool) {
+	if noRestart {
+		fmt.Println("  staged — not restarting (new binary applies on next launch)")
+		return
+	}
 	fmt.Print("  restarting service... ")
 
 	switch runtime.GOOS {
@@ -540,8 +607,12 @@ func restartService() {
 		uid := os.Getuid()
 		// Stop
 		_ = exec.Command("launchctl", "bootout", fmt.Sprintf("gui/%d", uid), plist).Run()
-		// Small delay for clean shutdown
-		time.Sleep(500 * time.Millisecond)
+		// bootout is asynchronous: it returns before the old process has released
+		// the listen socket. A fixed sleep races it — if the port is still held
+		// when we bootstrap, the new process hits EADDRINUSE and log.Fatalf's,
+		// leaving NO relay running (fleet-wide outage until a manual restart).
+		// Wait for the port to actually free before starting the replacement.
+		waitPortFree(servePort(), 5*time.Second)
 		// Start
 		if err := exec.Command("launchctl", "bootstrap", fmt.Sprintf("gui/%d", uid), plist).Run(); err != nil {
 			_ = exec.Command("launchctl", "load", plist).Run()
@@ -559,5 +630,40 @@ func restartService() {
 
 	default:
 		fmt.Println("unsupported platform — restart manually")
+	}
+}
+
+// envFlag reports whether an env var is set to a truthy value (anything but
+// empty / "0" / "false").
+func envFlag(name string) bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(name))) {
+	case "", "0", "false", "no":
+		return false
+	}
+	return true
+}
+
+// servePort returns the port the relay serves on (PORT env, else the 8090
+// default — same resolution as startServer in main.go).
+func servePort() string {
+	if p := strings.TrimSpace(os.Getenv("PORT")); p != "" {
+		return p
+	}
+	return "8090"
+}
+
+// waitPortFree blocks until nothing is listening on 127.0.0.1:port, or timeout
+// elapses (best-effort — returns either way). A refused dial means the old
+// listener has released the socket and a replacement can bind safely.
+func waitPortFree(port string, timeout time.Duration) {
+	deadline := time.Now().Add(timeout)
+	addr := net.JoinHostPort("127.0.0.1", port)
+	for time.Now().Before(deadline) {
+		conn, err := net.DialTimeout("tcp", addr, 200*time.Millisecond)
+		if err != nil {
+			return // refused/unreachable = port is free
+		}
+		_ = conn.Close()
+		time.Sleep(150 * time.Millisecond)
 	}
 }

--- a/internal/cli/update_test.go
+++ b/internal/cli/update_test.go
@@ -5,9 +5,11 @@ import (
 	"compress/gzip"
 	"crypto/sha256"
 	"encoding/hex"
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 func writeTarGz(t *testing.T, path, entry string, content []byte) {
@@ -75,5 +77,95 @@ func TestVerifyChecksum(t *testing.T) {
 	// Missing entry → error.
 	if _, err := verifyChecksum(arc, "nonexistent.tar.gz", sumsPath); err == nil {
 		t.Fatal("expected error for missing checksum entry")
+	}
+}
+
+// TestAtomicReplaceKeepsOldInode is the core TSU-74 guarantee: replacing the
+// binary must NOT disturb a process already running the old one (a live
+// `agent-relay mcp` stdio pipe). An in-place truncate-write would corrupt that
+// process's text segment (SIGBUS); an atomic rename swaps the directory entry to
+// a new inode and leaves the old, now-unlinked inode intact for the running
+// process. We simulate "a process holding the binary open" with a kept file
+// descriptor and assert it still reads the OLD bytes after the swap.
+func TestAtomicReplaceKeepsOldInode(t *testing.T) {
+	dir := t.TempDir()
+	dst := filepath.Join(dir, "agent-relay")
+	if err := os.WriteFile(dst, []byte("OLD-BINARY"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// A live process (e.g. the stdio MCP Claude spawned) holds the binary open.
+	held, err := os.Open(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = held.Close() }()
+
+	src := filepath.Join(dir, "new")
+	if err := os.WriteFile(src, []byte("NEW-BINARY"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := atomicReplace(src, dst); err != nil {
+		t.Fatalf("atomicReplace: %v", err)
+	}
+
+	// The held fd must still see the OLD inode — the running MCP survives untouched.
+	got, err := io.ReadAll(held)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "OLD-BINARY" {
+		t.Errorf("held fd should still read the old inode, got %q", got)
+	}
+
+	// The path now resolves to the NEW binary, with exec perms restored.
+	onDisk, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(onDisk) != "NEW-BINARY" {
+		t.Errorf("dst should be the new binary, got %q", onDisk)
+	}
+	st, err := os.Stat(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st.Mode().Perm() != 0o755 {
+		t.Errorf("new binary perms = %v, want 0755", st.Mode().Perm())
+	}
+
+	// No staging temp left behind.
+	entries, _ := os.ReadDir(dir)
+	for _, e := range entries {
+		if filepath.Ext(e.Name()) == "" && len(e.Name()) > 0 && e.Name()[0] == '.' {
+			t.Errorf("leftover staging temp: %s", e.Name())
+		}
+	}
+}
+
+func TestWaitPortFreeReturnsWhenFree(t *testing.T) {
+	// Nothing listening on this port → waitPortFree must return well within the
+	// timeout (not block for the full duration).
+	start := time.Now()
+	waitPortFree("1", 2*time.Second) // port 1 is privileged/unused → dial refused
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Errorf("waitPortFree blocked %v on a free port, expected near-instant", elapsed)
+	}
+}
+
+func TestEnvFlag(t *testing.T) {
+	const k = "AGENT_RELAY_TEST_FLAG"
+	for _, tc := range []struct {
+		val  string
+		want bool
+	}{
+		{"", false}, {"0", false}, {"false", false}, {"no", false},
+		{"1", true}, {"true", true}, {"yes", true}, {"on", true},
+	} {
+		t.Setenv(k, tc.val)
+		if got := envFlag(k); got != tc.want {
+			t.Errorf("envFlag(%q) = %v, want %v", tc.val, got, tc.want)
+		}
 	}
 }


### PR DESCRIPTION
**TSU-74** (relay task `3494d353`) — owner-reported P0: the fleet auto-updaters killed the owner's live Claude MCPs on a release spree. Two root causes, both fixed.

### A) Atomic binary swap (the stdio-MCP killer)
`installBinary` used `install -m 755 src dst` — an **in-place truncate + rewrite of the running binary's inode**. A process already executing that binary (critically, a live `agent-relay mcp` stdio pipe Claude Code spawned) gets its text segment corrupted mid-flight → **SIGBUS → the MCP pipe dies with no recovery**.

Fix: write a sibling temp in `dst`'s dir → `chmod 0755` → `os.Rename` over `dst`. Rename swaps the directory entry to a **new inode**; the running process keeps executing the old, now-unlinked inode untouched, and the new binary applies only on its **next launch**. This is exactly "stage, don't hot-restart a live stdio MCP" — and stdio gets apply-on-next-spawn for free, zero disruption. sudo fallback uses `mv -f` (rename, never truncate).

### B) Restart race (the HTTP `/mcp` fleet hit)
`restartService` did `bootout` → fixed `500ms` sleep → `bootstrap`. `bootout` is async; if the old listener still held the port, the new process hit **EADDRINUSE → `log.Fatalf` → NO relay running** (fleet-wide outage until a manual restart). Now polls the port until it is actually free (bounded 5s) before bootstrap.

### Safe default for watchers
`--no-restart` / `--stage` flag + `AGENT_RELAY_NO_SELF_RESTART` env → an auto-update fired mid-session by a release-watcher **stages only** and never restarts a live process.

### Tests (`-tags fts5`, green)
- `TestAtomicReplaceKeepsOldInode` — a held fd still reads the OLD bytes after the swap (the running-MCP survival guarantee); path resolves to the new binary with `0755`; no staging temp left behind.
- `TestWaitPortFreeReturnsWhenFree` — returns promptly on a free port (no full-timeout block).
- `TestEnvFlag`.

### Gate
`go build/vet/test -tags fts5` green; `gofmt -l` clean. golangci-lint not installed locally → CI runs it.

Follow-up (this task, separate): amend the auto-updater contract doc (trovex `293872050`) with the background-SERVICE-vs-live-stdio-MCP distinction + stage-by-default recommendation, for cto to fan to the trovex/dokan/yoru lanes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)