### PR TITLE
fix(inbox): non-destructive peek + no P0/first-read truncation — stop silent msg loss (TSU-73)

### DIFF
--- a/internal/db/deliveries.go
+++ b/internal/db/deliveries.go
@@ -53,7 +53,15 @@ func (d *DB) MarkDeliveriesSurfaced(ids []string) {
 }
 
 // GetInboxViaDeliveries returns messages for an agent using the deliveries table.
-// It marks returned deliveries as 'surfaced'.
+//
+// It is a NON-DESTRUCTIVE peek: it marks returned 'queued' deliveries as
+// 'surfaced' for analytics/first-read tracking, but surfacing no longer hides a
+// message from the next unread poll. "Unread" means NOT acknowledged (queued OR
+// surfaced); a message only leaves the unread view via an explicit mark_read /
+// ack_delivery. Previously unread filtered state='queued' and the fetch's
+// auto-surface flipped it out of unread after one read — so the single unread
+// view (truncated by the handler) was the only chance to see a message, and its
+// full content was silently lost (TSU-73).
 func (d *DB) GetInboxViaDeliveries(project, agentName string, unreadOnly bool, limit int, filters ...InboxFilter) ([]models.Message, error) {
 	if limit <= 0 {
 		limit = 50
@@ -70,14 +78,16 @@ func (d *DB) GetInboxViaDeliveries(project, agentName string, unreadOnly bool, l
 		FROM deliveries d
 		JOIN messages m ON d.message_id = m.id
 		WHERE d.project = ? AND d.to_agent = ?
-		  AND d.state IN ('queued', 'surfaced')
+		  AND d.state != 'expired'
 		  AND m.expired_at IS NULL
 		  AND (m.ttl_seconds = 0 OR datetime(m.created_at, '+' || m.ttl_seconds || ' seconds') > datetime('now'))
 	`
 	args := []any{project, agentName}
 
 	if unreadOnly {
-		query += " AND d.state = 'queued'"
+		// Unread = not yet acknowledged. A non-destructive peek: surfaced
+		// messages stay visible until an explicit mark_read / ack_delivery.
+		query += " AND d.state IN ('queued', 'surfaced')"
 	}
 	if f.MinPriority != "" {
 		query += " AND m.priority <= ?"
@@ -155,14 +165,15 @@ func (d *DB) FetchInboxDeliveries(project, agentName string, unreadOnly bool, li
 		FROM deliveries d
 		JOIN messages m ON d.message_id = m.id
 		WHERE d.project = ? AND d.to_agent = ?
-		  AND d.state IN ('queued', 'surfaced')
+		  AND d.state != 'expired'
 		  AND m.expired_at IS NULL
 		  AND (m.ttl_seconds = 0 OR datetime(m.created_at, '+' || m.ttl_seconds || ' seconds') > datetime('now'))
 	`
 	args := []any{project, agentName}
 
 	if unreadOnly {
-		query += " AND d.state = 'queued'"
+		// Unread = not yet acknowledged (see GetInboxViaDeliveries).
+		query += " AND d.state IN ('queued', 'surfaced')"
 	}
 	if f.MinPriority != "" {
 		query += " AND m.priority <= ?"

--- a/internal/relay/handlers_messaging.go
+++ b/internal/relay/handlers_messaging.go
@@ -221,7 +221,16 @@ func (h *Handlers) HandleGetInbox(ctx context.Context, req mcp.CallToolRequest) 
 	formatted := make([]map[string]any, len(messages))
 	for i, m := range messages {
 		content := m.Content
-		if !fullContent && len(content) > 300 {
+		// Truncation safety net (TSU-73): a P0 is never truncated, and a message
+		// is delivered in full on its FIRST surfacing (delivery still 'queued', or
+		// legacy unread). Subsequent peeks of a longer message preview-truncate to
+		// save context — the full text is one full_content=true re-fetch away,
+		// because the inbox is now a non-destructive peek (the message stays unread
+		// until an explicit mark_read / ack_delivery).
+		firstRead := (m.DeliveryState != nil && *m.DeliveryState == "queued") ||
+			(m.DeliveryState == nil && m.ReadAt == nil)
+		isP0 := m.Priority == "P0"
+		if !fullContent && !isP0 && !firstRead && len(content) > 300 {
 			content = content[:300] + "..."
 		}
 		entry := map[string]any{
@@ -403,6 +412,14 @@ func (h *Handlers) HandleMarkRead(ctx context.Context, req mcp.CallToolRequest) 
 	count, err := h.db.MarkRead(ids, agent, project)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("failed to mark read: %v", err)), nil
+	}
+
+	// mark_read is the explicit clear for the deliveries inbox: acknowledge each
+	// delivery so the message leaves the (non-destructive) unread view. Without
+	// this, mark_read only wrote message_reads and the deliveries-path inbox kept
+	// showing the message as unread forever (TSU-73). Best-effort per id.
+	for _, id := range ids {
+		_ = h.db.AcknowledgeDeliveryByMessage(id, agent, project)
 	}
 
 	return h.resultJSONTracked(project, agent, "mark_read", map[string]any{

--- a/internal/relay/handlers_test.go
+++ b/internal/relay/handlers_test.go
@@ -353,6 +353,91 @@ func TestMarkRead(t *testing.T) {
 	}
 }
 
+// TestInboxNonDestructivePeek is the core TSU-73 guarantee: fetching the inbox
+// must NOT consume messages. Two consecutive unread peeks both return the
+// message; only an explicit mark_read clears it. Previously the fetch auto-
+// surfaced (queued→surfaced) and unread filtered queued-only, so the message
+// dropped out of the unread view after a single read → silent loss.
+func TestInboxNonDestructivePeek(t *testing.T) {
+	h := testHandlers(t)
+	_, _ = h.HandleRegisterAgent(ctx, call(map[string]any{"project": "p1", "name": "bot-a"}))
+	_, _ = h.HandleRegisterAgent(ctx, call(map[string]any{"project": "p1", "name": "bot-b"}))
+	_, _ = h.HandleSendMessage(ctx, call(map[string]any{
+		"project": "p1", "as": "bot-a", "to": "bot-b", "content": "hello",
+	}))
+
+	unreadCount := func() float64 {
+		res, _ := h.HandleGetInbox(ctx, call(map[string]any{
+			"format": "json", "project": "p1", "as": "bot-b", "unread_only": true,
+		}))
+		return parseJSON(t, res)["count"].(float64)
+	}
+
+	if c := unreadCount(); c != 1 {
+		t.Fatalf("first peek: expected 1 unread, got %v", c)
+	}
+	if c := unreadCount(); c != 1 {
+		t.Fatalf("second peek: message vanished after first fetch (read-on-fetch loss), got %v unread", c)
+	}
+
+	// Grab the id, then explicit mark_read must clear it from unread.
+	res, _ := h.HandleGetInbox(ctx, call(map[string]any{
+		"format": "json", "project": "p1", "as": "bot-b", "unread_only": true,
+	}))
+	id := parseJSON(t, res)["messages"].([]any)[0].(map[string]any)["id"].(string)
+	_, _ = h.HandleMarkRead(ctx, call(map[string]any{
+		"project": "p1", "as": "bot-b", "message_ids": []any{id},
+	}))
+	if c := unreadCount(); c != 0 {
+		t.Fatalf("after mark_read: expected 0 unread, got %v", c)
+	}
+}
+
+// TestInboxTruncationP0AndFirstRead covers the TSU-73 truncation safety nets:
+// a long message is delivered in full on its FIRST surfacing (then preview-
+// truncated on later peeks), and a P0 is NEVER truncated.
+func TestInboxTruncationP0AndFirstRead(t *testing.T) {
+	h := testHandlers(t)
+	_, _ = h.HandleRegisterAgent(ctx, call(map[string]any{"project": "p1", "name": "bot-a"}))
+	_, _ = h.HandleRegisterAgent(ctx, call(map[string]any{"project": "p1", "name": "bot-b"}))
+	long := strings.Repeat("x", 500)
+
+	contentByPriority := func(prio string) string {
+		res, _ := h.HandleGetInbox(ctx, call(map[string]any{
+			"format": "json", "project": "p1", "as": "bot-b", "unread_only": true,
+		}))
+		for _, mm := range parseJSON(t, res)["messages"].([]any) {
+			m := mm.(map[string]any)
+			if m["priority"] == prio {
+				return m["content"].(string)
+			}
+		}
+		return ""
+	}
+
+	// Long P2: full on first surfacing, truncated (300 + "...") afterwards.
+	_, _ = h.HandleSendMessage(ctx, call(map[string]any{
+		"project": "p1", "as": "bot-a", "to": "bot-b", "priority": "P2", "content": long,
+	}))
+	if c := contentByPriority("P2"); len(c) != 500 {
+		t.Fatalf("first read of long P2 should be full (500), got %d", len(c))
+	}
+	if c := contentByPriority("P2"); len(c) != 303 {
+		t.Fatalf("second read of long P2 should be truncated to 303, got %d", len(c))
+	}
+
+	// Long P0: never truncated, on first read or any later peek.
+	_, _ = h.HandleSendMessage(ctx, call(map[string]any{
+		"project": "p1", "as": "bot-a", "to": "bot-b", "priority": "P0", "content": long,
+	}))
+	if c := contentByPriority("P0"); len(c) != 500 {
+		t.Fatalf("P0 first read should be full (500), got %d", len(c))
+	}
+	if c := contentByPriority("P0"); len(c) != 500 {
+		t.Fatalf("P0 must NEVER truncate, even after surfacing, got %d", len(c))
+	}
+}
+
 func TestMarkReadMissingIDs(t *testing.T) {
 	h := testHandlers(t)
 	res, _ := h.HandleMarkRead(ctx, call(map[string]any{


### PR DESCRIPTION
**TSU-73** — read-on-fetch + truncate = silent message loss. The #1 agent-UX footgun, convergent across every interview.

### Root cause
The deliveries-backed inbox consumed messages on read:
- `get_inbox(unread_only)` (the **default**) filtered delivery `state='queued'`, and the fetch **auto-surfaced** them (`queued→surfaced`) as a side effect (`GetInboxViaDeliveries` line 134).
- So a message appeared in the unread view **exactly once** — and the handler truncated content to 300 chars on that view.
- After the first fetch it was `surfaced`, no longer `unread`; full content was unrecoverable unless you'd saved the id. **Read-on-fetch + truncate = silent loss.** (Bit the fleet; I hit it twice while diagnosing.)

### Fix (3 parts) — aligns the deliveries path to the legacy `message_reads` path, which was already non-destructive
1. **Non-destructive peek**: `unread` = NOT acknowledged (`queued` OR `surfaced`). Surfacing still happens (analytics / first-read marker) but no longer hides a message from the next unread poll. `unread_only=false` now also returns acknowledged messages, so full content is always re-fetchable.
2. **mark_read is the explicit clear**: it now also `AcknowledgeDeliveryByMessage` (it previously only wrote `message_reads`, which the deliveries-path inbox ignored, so it had no effect there). `ack_delivery` already did this.
3. **Truncation safety nets**: a **P0 is never truncated**, and any message is delivered **in full on its first surfacing** (delivery still `queued`); later peeks preview-truncate to save context — full text one `full_content=true` re-fetch away.

### ⚠️ Behavior change (please confirm)
An unread poll now **re-shows every unacked message** until the agent explicitly `mark_read` / `ack_delivery` — the inbox is a *peek*, not a queue-drain. This is the intended TSU-73 model (matches the "explicit mark_read, not a get_inbox side-effect" spec) but it changes poll-loop expectations fleet-wide: agents that never ack will keep seeing their backlog. Flagging in case you want a cap or an auto-ack-after-N-surfaces follow-up.

### Tests (`-tags fts5`, green)
- `TestInboxNonDestructivePeek` — two consecutive unread peeks both return the message; `mark_read` clears it.
- `TestInboxTruncationP0AndFirstRead` — long P2 full on first read then truncated (303); long P0 never truncated.
- Existing `TestMarkRead` / `TestSendAndGetInbox` still green.

### Gate
`go build/vet/test -tags fts5` green; `gofmt -l` clean. CI runs golangci-lint.

Roadmap: TSU-73 (this) → TSU-75 (DM auth-wall reply-path) → TSU-38 payload-passthrough.

🤖 Generated with [Claude Code](https://claude.com/claude-code)