### PR TITLE
fix(messaging): scoped reply-path grant — answer a DM across the auth-wall (TSU-75)

### DIFF
--- a/internal/db/orgs.go
+++ b/internal/db/orgs.go
@@ -423,7 +423,39 @@ func (d *DB) CanMessage(project, sender, target string) (bool, error) {
 		return true, nil
 	}
 
+	// Reply-path grant (TSU-75): a message opens a scoped channel back to its
+	// author. If `target` has previously had a message delivered to `sender`,
+	// allow `sender` to message `target` — otherwise an agent literally cannot
+	// answer a DM from outside its team, and the auth-wall only surfaces AFTER
+	// it has composed the reply. The grant is scoped to that one sender: it does
+	// not open `sender` to anyone else.
+	var replyPath int
+	_ = d.ro().QueryRow(
+		`SELECT COUNT(*) FROM deliveries d
+		 JOIN messages m ON d.message_id = m.id
+		 WHERE d.project = ? AND d.to_agent = ? AND m.from_agent = ?`,
+		project, sender, target,
+	).Scan(&replyPath)
+	if replyPath > 0 {
+		return true, nil
+	}
+
 	return false, nil
+}
+
+// CanReplyTo reports whether `sender` has a scoped reply-path to `target` —
+// i.e. `target` has previously had a message delivered to `sender`. Exposed so
+// the send path can give a precise, pre-check-style reason when a send is
+// blocked. Mirrors the reply-path branch in CanMessage.
+func (d *DB) CanReplyTo(project, sender, target string) bool {
+	var n int
+	_ = d.ro().QueryRow(
+		`SELECT COUNT(*) FROM deliveries d
+		 JOIN messages m ON d.message_id = m.id
+		 WHERE d.project = ? AND d.to_agent = ? AND m.from_agent = ?`,
+		project, sender, target,
+	).Scan(&n)
+	return n > 0
 }
 
 // HasTeams returns true if any teams exist for the project (to skip permission check when no teams are configured).

--- a/internal/relay/handlers_messaging.go
+++ b/internal/relay/handlers_messaging.go
@@ -79,7 +79,7 @@ func (h *Handlers) HandleSendMessage(ctx context.Context, req mcp.CallToolReques
 				return mcp.NewToolResultError(fmt.Sprintf("permission check failed: %v", err)), nil
 			}
 			if !allowed {
-				return mcp.NewToolResultError(fmt.Sprintf("not authorized to message '%s' — no shared team, reports_to chain, or notify channel", to)), nil
+				return mcp.NewToolResultError(fmt.Sprintf("not authorized to message '%s' — no shared team, reports_to chain, notify channel, or reply-path (they haven't messaged you). Ask an admin/executive to relay, or have '%s' message you first (that grants a scoped reply-path).", to, to)), nil
 			}
 		}
 	}

--- a/internal/relay/handlers_test.go
+++ b/internal/relay/handlers_test.go
@@ -321,6 +321,42 @@ func TestSendMessageMissingTo(t *testing.T) {
 	expectError(t, res)
 }
 
+// TestDMReplyPathGrant is the TSU-75 guarantee: receiving a DM opens a scoped
+// reply-path back to the sender, so an agent can always answer a message even
+// across the team auth-wall — and the grant does NOT open it to anyone else.
+func TestDMReplyPathGrant(t *testing.T) {
+	h := testHandlers(t)
+	// alice = executive → admin team (can message anyone; also makes hasTeams true
+	// so the permission check is enforced). bob/carol are plain agents.
+	_, _ = h.HandleRegisterAgent(ctx, call(map[string]any{"project": "p1", "name": "alice", "is_executive": true}))
+	_, _ = h.HandleRegisterAgent(ctx, call(map[string]any{"project": "p1", "name": "bob"}))
+	_, _ = h.HandleRegisterAgent(ctx, call(map[string]any{"project": "p1", "name": "carol"}))
+
+	send := func(from, to string) *mcp.CallToolResult {
+		res, _ := h.HandleSendMessage(ctx, call(map[string]any{
+			"project": "p1", "as": from, "to": to, "content": "hi",
+		}))
+		return res
+	}
+
+	// Auth-wall: bob cannot DM alice before she opens a channel.
+	if res := send("bob", "alice"); !res.IsError {
+		t.Fatal("expected bob→alice blocked before any contact")
+	}
+	// alice (admin) DMs bob — opens a scoped reply-path.
+	if res := send("alice", "bob"); res.IsError {
+		t.Fatalf("alice→bob should be allowed (admin): %s", expectError(t, res))
+	}
+	// bob can now reply to alice.
+	if res := send("bob", "alice"); res.IsError {
+		t.Fatalf("bob→alice should be allowed via reply-path: %s", expectError(t, res))
+	}
+	// Scoped: bob still cannot DM carol (carol never messaged bob).
+	if res := send("bob", "carol"); !res.IsError {
+		t.Fatal("expected bob→carol still blocked — reply-path must be scoped to the sender")
+	}
+}
+
 func TestMarkRead(t *testing.T) {
 	h := testHandlers(t)
 	_, _ = h.HandleRegisterAgent(ctx, call(map[string]any{"project": "p1", "name": "bot-a", "role": "dev"}))


### PR DESCRIPTION
**TSU-75** — DM auth-wall: a message should grant the recipient a scoped reply-path to the sender (not a post-compose failure).

### Problem
With teams configured, `CanMessage` blocked any send lacking a shared team / `reports_to` chain / notify-channel. So an agent that received a DM from **outside its team could not reply at all** — and the rejection only surfaced *after* it had composed the reply.

### Fix
- **Scoped reply-path grant** (`CanMessage`): allow `sender → target` when `target` has previously had a message **delivered to** `sender`. Receiving a message opens a channel back to its author. The grant is **scoped to that one sender** — it does not open `sender` to anyone else. (Implemented via the `deliveries ⋈ messages` relation, so it covers direct, team, and broadcast-origin messages.)
- **`CanReplyTo` helper** mirrors the branch for callers that want the reason.
- **Pre-check-style error**: the blocked-send message now names the reply-path and tells the agent how to get one (have the target message them, or ask an admin/executive to relay) instead of a dead-end "not authorized".

### Test (`-tags fts5`, green)
`TestDMReplyPathGrant` — `bob` can't DM `alice` until she messages him; then his reply is allowed; the grant stays **scoped** (`bob` still can't DM `carol`, who never contacted him).

### Gate
`go build/vet/test -tags fts5` green; `gofmt -l` clean. CI runs golangci-lint.

Roadmap: TSU-74 ✅ → TSU-73 (#120) → **TSU-75 (this)** → TSU-38 payload-passthrough next. With this, the AX roadmap relay sweep is code-complete pending merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)