### PR TITLE
fix(notifications): pass custom event:* payload through to delivery body (TSU-38)

### DIFF
--- a/internal/relay/notifications.go
+++ b/internal/relay/notifications.go
@@ -316,6 +316,15 @@ func (n *Notifier) buildPayload(rule models.NotificationRule, event string, sem 
 		line = strVal(sem["title"])
 	}
 	out["line"] = line
+	// Custom agent-authored events (event:*) carry an arbitrary structured
+	// payload (e.g. lead-ready → {email,tier,personId,...}). The fixed fields
+	// above would drop it, so a 'message' action delivered an empty body and the
+	// consumer got nothing usable (TSU-38). Pass the full event payload through so
+	// doMessage serializes it into the message content and webhook/slack
+	// consumers receive the structured data, not just the one-line summary.
+	if strings.HasPrefix(event, "event:") {
+		out["payload"] = sem
+	}
 	return out
 }
 
@@ -398,9 +407,17 @@ func (n *Notifier) doMessage(rule models.NotificationRule, project string, paylo
 	if subject == "" {
 		subject = rule.Event
 	}
-	// Content intentionally empty: the line IS the message (tiny payloads by
-	// design); duplicating it as body just doubles the inbox noise.
+	// Content intentionally empty for built-in events: the line IS the message
+	// (tiny payloads by design); duplicating it as body just doubles inbox noise.
+	// For custom event:* deliveries, serialize the structured payload into the
+	// body so the recipient's consumer can read its fields (TSU-38) — the line
+	// alone can't carry {email,tier,personId,...}.
 	content := ""
+	if p, ok := payload["payload"]; ok {
+		if b, err := json.Marshal(p); err == nil {
+			content = string(b)
+		}
+	}
 	ttl := opts.TTL
 	if ttl == 0 {
 		ttl = 14400

--- a/internal/relay/notifications_test.go
+++ b/internal/relay/notifications_test.go
@@ -4,6 +4,7 @@ import (
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"os"
 	"testing"
 
@@ -97,6 +98,67 @@ func TestBuildPayloadTemplate(t *testing.T) {
 	}
 	if got["linear_key"] != nil {
 		t.Fatalf("expected nil linear_key, got %v", got["linear_key"])
+	}
+}
+
+// TestBuildPayloadEventPassthrough is the TSU-38 guarantee at the build layer:
+// a custom event:* carries its full structured payload through, while a built-in
+// event does not (it stays a tiny fixed-field payload).
+func TestBuildPayloadEventPassthrough(t *testing.T) {
+	n := &Notifier{}
+	sem := map[string]any{"agent": "donna", "email": "x@y.com", "tier": "A", "score": 91}
+
+	got := n.buildPayload(models.NotificationRule{}, "event:lead-ready", sem, ruleOpts{})
+	p, ok := got["payload"].(map[string]any)
+	if !ok {
+		t.Fatalf("event:* should pass payload through, got %v", got["payload"])
+	}
+	if p["email"] != "x@y.com" || p["tier"] != "A" {
+		t.Fatalf("payload fields not preserved: %v", p)
+	}
+
+	// Built-in events stay lean — no payload passthrough.
+	builtin := n.buildPayload(models.NotificationRule{}, EvTaskDone, sem, ruleOpts{})
+	if _, exists := builtin["payload"]; exists {
+		t.Fatalf("built-in event must not carry a payload passthrough, got %v", builtin["payload"])
+	}
+}
+
+// TestEventPayloadPassthroughToMessage is the end-to-end TSU-38 guarantee: a
+// message-action rule firing on a custom event delivers the structured payload
+// into the recipient's inbox message body, not an empty body.
+func TestEventPayloadPassthroughToMessage(t *testing.T) {
+	h := testHandlers(t)
+	n := NewNotifier(h.db, h.registry, h.events)
+	_, _ = h.HandleRegisterAgent(ctx, call(map[string]any{"project": "p1", "name": "donna"}))
+
+	rule := models.NotificationRule{
+		Project: "p1", Name: "lead-ready→donna", Event: "event:lead-ready",
+		Match: "{}", Action: "message", Target: "donna",
+	}
+	sem := map[string]any{
+		"agent": "donna", "email": "lead@acme.com", "tier": "A",
+		"personId": "p_123", "score": 91, "bookUrl": "https://cal/x",
+	}
+	n.fireRule(rule, "event:lead-ready", "p1", sem, false)
+
+	msgs, err := h.db.GetInbox("p1", "donna", true, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(msgs) != 1 {
+		t.Fatalf("expected 1 delivered message, got %d", len(msgs))
+	}
+	var body map[string]any
+	if err := json.Unmarshal([]byte(msgs[0].Content), &body); err != nil {
+		t.Fatalf("message body is not the JSON payload: %q (%v)", msgs[0].Content, err)
+	}
+	// The relay normalizes all message-content keys to snake_case
+	// (normalize.JSONKeys), so consumers read person_id / book_url, not the
+	// emitter's camelCase. Values pass through verbatim.
+	if body["email"] != "lead@acme.com" || body["tier"] != "A" ||
+		body["person_id"] != "p_123" || body["book_url"] != "https://cal/x" {
+		t.Fatalf("structured fields missing from delivered body: %v", body)
 	}
 }
 


### PR DESCRIPTION
**TSU-38** — the event:* delivery-flattening gap that blocks the lead-machine → donna seam (found while answering fullstack-lead's routing question).

### Problem
The rule engine flattened every event to a fixed field set (`event/agent/task_id/linear_key/title/line`). For agent-authored custom events (`event:lead-ready` → `{email,tier,personId,noteId,score,source,why,draftTemplate,bookUrl}`), the structured payload was **dropped**: a `message` action delivered subject=line + **empty body**, so donna's consumer got nothing usable.

### Fix
- `buildPayload`: for `event:*` events, pass the full event payload through under `"payload"` (built-in events stay lean — no change).
- `doMessage`: serialize that payload into the message **content**, so the recipient's consumer reads the structured fields from its inbox. `webhook`/`slack` actions receive it too (they marshal the same built payload).

### ⚠️ Key-casing note (for donna's consumer)
The relay normalizes all message-content keys to **snake_case** (`normalize.JSONKeys`), so the consumer reads `person_id` / `note_id` / `draft_template` / `book_url`, **not** the emitter's camelCase. Values pass through verbatim. fullstack-lead/donna: align the consumer to snake_case keys.

### Routing recap (unchanged, for fullstack-lead)
Still need the rule itself: `POST /api/notification-rules { project:'trovex-growth', event:'event:lead-ready', action:'message', target:'donna' }`. This PR makes that rule actually carry the payload.

### Tests (`-tags fts5`, green)
- `TestBuildPayloadEventPassthrough` — `event:*` carries payload; built-in `EvTaskDone` does not.
- `TestEventPayloadPassthroughToMessage` — end-to-end `fireRule` → donna's inbox body is the JSON payload with the structured fields.

### Gate
`go build/vet/test -tags fts5` green; `gofmt -l` clean. CI runs golangci-lint.

Closes the relay-side AX work: TSU-74 ✅ · TSU-73 ✅ (#120) · TSU-75 ✅ (#121) · **TSU-38 (this)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)