### PR TITLE
fix(linear): dispatch emits task.dispatched, not task.in_progress — routed agent never notified

### DIFF
--- a/internal/connector/linear/linear_test.go
+++ b/internal/connector/linear/linear_test.go
@@ -253,8 +253,8 @@ func TestDispatchDedupe(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(evts) != 1 || evts[0].Type != "task.in_progress" {
-		t.Fatalf("expected 1 task.in_progress event, got %#v", evts)
+	if len(evts) != 1 || evts[0].Type != "task.dispatched" {
+		t.Fatalf("expected 1 task.dispatched event, got %#v", evts)
 	}
 	if evts[0].Payload["assignee_is_agent"] != true {
 		t.Errorf("assignee_is_agent should be true")

--- a/internal/connector/linear/webhook.go
+++ b/internal/connector/linear/webhook.go
@@ -194,8 +194,16 @@ func (c *Connector) Ingest(payload []byte, sig string) ([]connector.TaskEvent, e
 // the webhook path (Ingest) and the reconcile poll (transition detection).
 func (c *Connector) dispatchEvent(taskID, title string, seed db.LinearMirrorSeed) connector.TaskEvent {
 	agent := c.routedAgent(seed)
+	// Emit "task.dispatched", NOT "task.in_progress". Routing a Linear issue to an
+	// agent is semantically a DISPATCH ("here is assigned work, go claim it") —
+	// the same signal relay-native dispatch_task emits — so it must fire the same
+	// agent-notification rule (auto-claim: task.dispatched + assignee_is_agent →
+	// message → assignee). Emitting "task.in_progress" only matched the (disabled)
+	// external-launcher webhook, so the routed agent was never notified and Linear
+	// dispatch silently never fired. "task.in_progress" is for an agent that has
+	// already started work (start_task), a different lifecycle moment.
 	return connector.TaskEvent{
-		Type:    "task.in_progress",
+		Type:    "task.dispatched",
 		Project: c.project,
 		Agent:   agent,
 		Payload: map[string]any{
@@ -203,7 +211,7 @@ func (c *Connector) dispatchEvent(taskID, title string, seed db.LinearMirrorSeed
 			"task_id":           taskID,
 			"linear_key":        seedLinearKey(seed),
 			"title":             title,
-			"line":              "In progress: " + title,
+			"line":              "Dispatched: " + title,
 			"priority":          seed.Priority,
 			"assignee_is_agent": isAgent(agent),
 		},


### PR DESCRIPTION
**Routing bug** (reported by cto, verified live): Linear→relay auto-dispatch never notified the routed agent. All 308 linear-source tasks had empty dispatch — it never fired.

### Root cause
`dispatchEvent` (when a routed issue transitions into a started/In-Progress state) emitted `Type: "task.in_progress"`. But the canonical "agent, here's assigned work" rule is **auto-claim on `task.dispatched`** (`{assignee_is_agent:true}` → message → assignee). The only seeded `task.in_progress` rule is the **disabled** external-launcher webhook. So the routed In-Progress issue matched no agent-facing rule → no P0 → the agent never heard about it.

### Why B (emit `task.dispatched`), not A (add a `task.in_progress` rule)
Routing an issue to an agent is semantically a **dispatch** — the exact signal `dispatch_task` (relay-native) already emits via `task.dispatched`. So the Linear path should plug into the **same** canonical event + rule, unifying both dispatch paths. `task.in_progress` is correctly reserved for an agent that has *started* work (`start_task`) — a different lifecycle moment.

Option A (add a second `task.in_progress`→message rule) would fork the convention and risk double-notifying; B is the canonical, minimal fix.

### No regressions
- The disabled external-launcher webhook on `task.in_progress` no longer matches the Linear path (it was disabled anyway).
- Nothing else consumed the connector's `task.in_progress` emission (only notification rules do).
- No double-fire: trovex-growth's existing auto-claim rule is the single matching rule.

### Note for cto
This relies on a `task.dispatched + assignee_is_agent → message → assignee` rule existing (the "auto-claim" rule on trovex-growth — confirmed present). It's **not** a seeded default; if you want every project to notify dispatched agents, seeding that as a default is a clean follow-up (skipped here to avoid double-firing trovex-growth's manual rule).

### Test (`-tags fts5`, green)
`TestDispatchDedupe` now asserts the emitted event is `task.dispatched` (+ `assignee_is_agent:true`). Full suite green; `gofmt`/`vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)