### PR TITLE
fix(linear): reconcile poll dispatches delegate-assigned issues in unrouted projects (TSU-117)

### DIFF
--- a/internal/connector/linear/linear_test.go
+++ b/internal/connector/linear/linear_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"agent-relay/internal/config"
+	"agent-relay/internal/connector"
 	"agent-relay/internal/db"
 )
 
@@ -348,6 +349,59 @@ func TestReconcileCycle(t *testing.T) {
 	}
 	if c.lastReconcileAt.Load() == 0 {
 		t.Errorf("lastReconcileAt not stamped")
+	}
+}
+
+// Delegate-based routing: an issue in an UNROUTED project but directly assigned
+// to an agent must still be mirrored AND dispatched on the poll path (the only
+// path on a webhook-less localhost). A project-less, unassigned onboarding issue
+// must still be skipped as noise. Guards the scope-gate/dispatch-gate symmetry.
+func TestReconcileDispatchUnroutedAgentAssignee(t *testing.T) {
+	database := newTestDB(t)
+	c := newTestConn(t, database)
+
+	// No linear_routing entry for the growth project — routing is per-issue
+	// assignee (delegate), not a fixed project→agent map.
+	var dispatched []string
+	c.SetEventSink(func(e connector.TaskEvent) {
+		if e.Type == "task.dispatched" {
+			dispatched = append(dispatched, e.Agent)
+		}
+	})
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		query := readQuery(r)
+		switch {
+		case strings.Contains(query, "TeamOpenIssues"):
+			writeData(w, `{"issues":{"pageInfo":{"hasNextPage":false,"endCursor":""},"nodes":[
+				{"id":"i-growth","identifier":"TSU-97","number":97,"title":"GEO readout","priority":1,"url":"u1","state":{"id":"s1","name":"In Progress","type":"started"},"assignee":{"id":"u1","name":"analytics-lead","displayName":"analytics-lead"},"project":{"id":"proj-growth","name":"growth"},"labels":{"nodes":[]}},
+				{"id":"i-onboard","identifier":"TSU-1","number":1,"title":"Onboarding","priority":3,"url":"u2","state":{"id":"s2","name":"In Progress","type":"started"},"labels":{"nodes":[]}}
+			]}}`)
+		default:
+			writeData(w, `{}`)
+		}
+	}))
+	defer srv.Close()
+	c.gql.url = srv.URL
+
+	n, err := c.ReconcileCycle(c.project)
+	if err != nil {
+		t.Fatalf("ReconcileCycle: %v", err)
+	}
+	// Only the agent-assigned issue is in scope; the project-less unassigned
+	// onboarding issue is skipped.
+	if n != 1 {
+		t.Fatalf("upserted = %d, want 1 (agent-assigned only)", n)
+	}
+	if task, _ := database.GetTaskByLinearIssueID(c.project, "i-growth"); task == nil {
+		t.Fatal("agent-assigned unrouted issue should be mirrored")
+	}
+	if task, _ := database.GetTaskByLinearIssueID(c.project, "i-onboard"); task != nil {
+		t.Error("project-less unassigned issue should be skipped as noise")
+	}
+	// Dispatch fired to the per-issue delegate, not a fixed project route.
+	if len(dispatched) != 1 || dispatched[0] != "analytics-lead" {
+		t.Errorf("dispatched = %v, want [analytics-lead]", dispatched)
 	}
 }
 

--- a/internal/connector/linear/reconcile.go
+++ b/internal/connector/linear/reconcile.go
@@ -37,10 +37,16 @@ func (c *Connector) ReconcileCycle(_ string) (int, error) {
 		if iss.ID == "" {
 			continue
 		}
-		// Scope: only mirror/dispatch issues in a ROUTED project. Skips Linear's
-		// project-less team defaults (onboarding TSU-1..4) and any unrouted
-		// project — they were polluting the relay board as noise.
-		if !c.hasRoute(iss) {
+		// Scope: mirror/dispatch issues that are EITHER in a ROUTED project
+		// (owner-chosen agent per project) OR directly assigned to an agent
+		// (delegate-based routing — a project with many leads, each issue
+		// assigned to its own lead). This must stay symmetric with the dispatch
+		// condition below: an issue that would dispatch must not be pre-skipped
+		// here, or the poll path (the only path on a webhook-less localhost)
+		// silently drops it. Still skips Linear's project-less team defaults
+		// (onboarding TSU-1..4) and any unrouted, unassigned issue — those were
+		// polluting the relay board as noise.
+		if !c.hasRoute(iss) && !isAgent(issueAssignee(iss)) {
 			continue
 		}
 		prior, _ := c.db.GetTaskByLinearIssueID(c.project, iss.ID)


### PR DESCRIPTION
## What

The Linear **reconcile poll** scoped itself to ROUTED projects only:

```go
if !c.hasRoute(iss) { continue }   // skips before the dispatch check below
```

…but the dispatch condition already supports a bare agent assignee (`hasRoute || isAgent`). On a **webhook-less localhost the poll is the only dispatch path**, so issues in a **multi-lead project** (CMO's `growth`: each issue assigned to its own lead, no fixed project route) were **never mirrored or dispatched**.

## Fix

Make the scope gate symmetric with the dispatch gate — process an issue that is **EITHER in a routed project OR directly assigned to an agent**:

```go
if !c.hasRoute(iss) && !isAgent(issueAssignee(iss)) { continue }
```

- Enables **delegate-based routing** for multi-lead projects with **no `linear_routing` entry** (a route would force one fixed agent for the whole project — wrong for `growth`).
- Project-less, unassigned onboarding issues (TSU-1..4) **still skipped** as noise.
- Dispatch stays idempotent: dedupe on `prior.Status != "in-progress"` (no double P0).

## Test

`TestReconcileDispatchUnroutedAgentAssignee` — unrouted agent-assigned issue mirrors + dispatches to its per-issue delegate (`analytics-lead`); project-less unassigned issue skipped.

## CMO config note (mechanism, per TSU-117)

For `growth` dispatch to fire on the poll:
1. **Leave `growth` OUT of `linear_routing`** — per-issue assignee wins (multi-lead).
2. Set each issue's Linear **assignee** to the lead's **relay agent name** (e.g. `analytics-lead`, `content-lead`, `geo-lead`, `cro-lead`, `design-lead`, `social-lead`, `tech-copywriter`, `launch-lead`) — the relay reads the `assignee` field, not a custom "delegate" field.
3. **Move the issue to In Progress** → fires `task.dispatched` to that assignee.

## review-wraith verdict: SHIP-WITH-NITS
Scope: internal/connector/linear/reconcile.go (scope gate), linear_test.go (+regression)
Gate: build -tags fts5 OK / vet OK / gofmt OK / test -tags fts5 OK

BLOCKERS: none

NITS (non-blocking):
- `isAgent` treats any assignee name except `human`/`user` as an agent, so a human seat with a custom name assigned to a *started, unrouted* issue would now be mirrored + dispatched on the poll path (already true on the webhook path — this only makes the two paths consistent). Acceptable; flag if a stricter agent-name allowlist is wanted.