### PR TITLE
fix(linear): route by Issue.delegate (guarded, fallback to assignee) (TSU-121)

### DIFF
--- a/internal/connector/linear/graphql.go
+++ b/internal/connector/linear/graphql.go
@@ -5,8 +5,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log"
 	"net/http"
 	"strings"
+	"sync/atomic"
 	"time"
 )
 
@@ -20,6 +22,12 @@ type graphqlClient struct {
 	apiKey string
 	url    string
 	http   *http.Client
+
+	// delegateUnsupported latches true the first time the Issue.delegate field
+	// is rejected by the schema, so the reconcile poll permanently falls back to
+	// the delegate-less query. A missing/renamed field must NEVER 400 the whole
+	// poll (that would be a fleet-wide dispatch outage).
+	delegateUnsupported atomic.Bool
 }
 
 func newGraphQLClient(apiKey string) *graphqlClient {
@@ -149,6 +157,16 @@ type gqlIssue struct {
 		Name        string `json:"name"`
 		DisplayName string `json:"displayName"`
 	} `json:"assignee"`
+	// Delegate is Linear's agent-delegation field: when a user assigns an issue
+	// to an agent, the human stays the assignee (primary owner) and the agent is
+	// set as the delegate. Routing prefers this over assignee. Only populated by
+	// the reconcile GraphQL query (and only when the schema supports the field);
+	// Issue webhooks don't carry it, so the webhook path falls back to assignee.
+	Delegate *struct {
+		ID          string `json:"id"`
+		Name        string `json:"name"`
+		DisplayName string `json:"displayName"`
+	} `json:"delegate"`
 	Parent *struct {
 		ID string `json:"id"`
 	} `json:"parent"`
@@ -180,6 +198,12 @@ func (i gqlIssue) parentLinearID() string {
 // so auto-dispatch covers issues that aren't in the active cycle. Flat issues
 // query (not nested through team→cycle) stays under the complexity budget even
 // with per-issue cycle/project expanded.
+//
+// Two variants share one node-field block: the default fetches Issue.delegate
+// (Linear's agent-delegation field) for delegate-based routing; the fallback
+// omits it. openTeamIssues uses the delegate variant and latches to the fallback
+// only if the schema rejects the field — so a missing field can never break the
+// poll. Keep the two `nodes {…}` blocks identical apart from the delegate line.
 const teamOpenIssuesQuery = `query TeamOpenIssues($key: String!, $after: String) {
   issues(
     filter: { team: { key: { eq: $key } }, state: { type: { nin: ["completed", "canceled"] } } }
@@ -197,6 +221,42 @@ const teamOpenIssuesQuery = `query TeamOpenIssues($key: String!, $after: String)
     }
   }
 }`
+
+// teamOpenIssuesQueryDelegate is teamOpenIssuesQuery + the delegate field.
+const teamOpenIssuesQueryDelegate = `query TeamOpenIssues($key: String!, $after: String) {
+  issues(
+    filter: { team: { key: { eq: $key } }, state: { type: { nin: ["completed", "canceled"] } } }
+    first: 50, after: $after
+  ) {
+    pageInfo { hasNextPage endCursor }
+    nodes {
+      id identifier number title description priority estimate url
+      state { id name type }
+      assignee { id name displayName }
+      delegate { id name displayName }
+      project { id name }
+      parent { id }
+      cycle { id name startsAt endsAt }
+      labels { nodes { name } }
+    }
+  }
+}`
+
+// isFieldError reports whether a GraphQL error looks like a schema/validation
+// rejection of a field (an HTTP 400 or a "cannot query field" message) — as
+// opposed to a transient network/5xx/rate-limit error. Only a field error
+// latches the delegate fallback; transient errors propagate and the poll retries
+// next interval (unchanged behavior), so a network blip can't permanently
+// disable delegate routing.
+func isFieldError(err error) bool {
+	if err == nil {
+		return false
+	}
+	s := strings.ToLower(err.Error())
+	return strings.Contains(s, "status 400") ||
+		strings.Contains(s, "cannot query field") ||
+		strings.Contains(s, "delegate")
+}
 
 // openTeamIssues returns every open (not completed/canceled) issue in the team,
 // paginated. Used by the reconcile poll so dispatch isn't limited to the active
@@ -218,8 +278,24 @@ func (c *graphqlClient) openTeamIssues(ctx context.Context, teamKey string) ([]g
 		if after != nil {
 			vars["after"] = *after
 		}
-		if err := c.do(ctx, teamOpenIssuesQuery, vars, &out); err != nil {
-			return nil, err
+		query := teamOpenIssuesQueryDelegate
+		if c.delegateUnsupported.Load() {
+			query = teamOpenIssuesQuery
+		}
+		if err := c.do(ctx, query, vars, &out); err != nil {
+			// Guard: a missing/renamed Issue.delegate field must never break the
+			// poll. On a field-shaped error from the delegate query, latch the
+			// fallback and retry this page with the delegate-less query. Any other
+			// (transient) error propagates unchanged.
+			if query == teamOpenIssuesQueryDelegate && isFieldError(err) {
+				c.delegateUnsupported.Store(true)
+				log.Printf("[linear] Issue.delegate unsupported (%v) — falling back to assignee-only routing", err)
+				if err := c.do(ctx, teamOpenIssuesQuery, vars, &out); err != nil {
+					return nil, err
+				}
+			} else {
+				return nil, err
+			}
 		}
 		issues = append(issues, out.Issues.Nodes...)
 		if !out.Issues.PageInfo.HasNextPage {

--- a/internal/connector/linear/linear_test.go
+++ b/internal/connector/linear/linear_test.go
@@ -405,6 +405,95 @@ func TestReconcileDispatchUnroutedAgentAssignee(t *testing.T) {
 	}
 }
 
+// Delegate-preferred routing: Linear assigns agents via Issue.delegate while the
+// human stays the assignee. An issue with a HUMAN assignee + an AGENT delegate
+// must dispatch to the DELEGATE, not the human.
+func TestReconcileDispatchDelegatePreferred(t *testing.T) {
+	database := newTestDB(t)
+	c := newTestConn(t, database)
+
+	var dispatched []string
+	c.SetEventSink(func(e connector.TaskEvent) {
+		if e.Type == "task.dispatched" {
+			dispatched = append(dispatched, e.Agent)
+		}
+	})
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		query := readQuery(r)
+		if strings.Contains(query, "TeamOpenIssues") {
+			writeData(w, `{"issues":{"pageInfo":{"hasNextPage":false,"endCursor":""},"nodes":[
+				{"id":"i-deleg","identifier":"TSU-99","number":99,"title":"Delegated","priority":1,"url":"u1","state":{"id":"s1","name":"In Progress","type":"started"},"assignee":{"id":"u-h","name":"loicmancino.work","displayName":"loicmancino.work"},"delegate":{"id":"u-a","name":"content-lead","displayName":"content-lead"},"project":{"id":"proj-growth","name":"growth"},"labels":{"nodes":[]}}
+			]}}`)
+			return
+		}
+		writeData(w, `{}`)
+	}))
+	defer srv.Close()
+	c.gql.url = srv.URL
+
+	if _, err := c.ReconcileCycle(c.project); err != nil {
+		t.Fatalf("ReconcileCycle: %v", err)
+	}
+	if len(dispatched) != 1 || dispatched[0] != "content-lead" {
+		t.Errorf("dispatched = %v, want [content-lead] (delegate beats human assignee)", dispatched)
+	}
+}
+
+// Guard: if Linear's schema rejects the delegate field, the poll must latch a
+// fallback to the delegate-less query and keep working (dispatch on assignee) —
+// a missing field can NEVER 400 the whole poll (no fleet-wide dispatch outage).
+func TestReconcileDelegateFieldFallback(t *testing.T) {
+	database := newTestDB(t)
+	c := newTestConn(t, database)
+
+	var dispatched []string
+	c.SetEventSink(func(e connector.TaskEvent) {
+		if e.Type == "task.dispatched" {
+			dispatched = append(dispatched, e.Agent)
+		}
+	})
+
+	var delegateAttempts, fallbackAttempts int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		query := readQuery(r)
+		switch {
+		case strings.Contains(query, "delegate"):
+			// Schema without the field — GraphQL field error.
+			delegateAttempts++
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"errors":[{"message":"Cannot query field \"delegate\" on type \"Issue\"."}]}`))
+		case strings.Contains(query, "TeamOpenIssues"):
+			// Fallback (delegate-less) query — agent assignee, dispatches fine.
+			fallbackAttempts++
+			writeData(w, `{"issues":{"pageInfo":{"hasNextPage":false,"endCursor":""},"nodes":[
+				{"id":"i-fb","identifier":"TSU-100","number":100,"title":"Fallback","priority":1,"url":"u1","state":{"id":"s1","name":"In Progress","type":"started"},"assignee":{"id":"u1","name":"analytics-lead","displayName":"analytics-lead"},"project":{"id":"proj-growth","name":"growth"},"labels":{"nodes":[]}}
+			]}}`)
+		default:
+			writeData(w, `{}`)
+		}
+	}))
+	defer srv.Close()
+	c.gql.url = srv.URL
+
+	n, err := c.ReconcileCycle(c.project)
+	if err != nil {
+		t.Fatalf("ReconcileCycle must survive a bad delegate field, got: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("upserted = %d, want 1 (fallback query succeeded)", n)
+	}
+	if delegateAttempts != 1 || fallbackAttempts != 1 {
+		t.Errorf("attempts: delegate=%d fallback=%d, want 1/1", delegateAttempts, fallbackAttempts)
+	}
+	if !c.gql.delegateUnsupported.Load() {
+		t.Error("delegateUnsupported should latch true after a field error")
+	}
+	if len(dispatched) != 1 || dispatched[0] != "analytics-lead" {
+		t.Errorf("dispatched = %v, want [analytics-lead] (assignee fallback)", dispatched)
+	}
+}
+
 // --- writer retry/backoff (stubbed GraphQL) ---
 
 func TestPushInReviewRetry(t *testing.T) {

--- a/internal/connector/linear/reconcile.go
+++ b/internal/connector/linear/reconcile.go
@@ -37,16 +37,14 @@ func (c *Connector) ReconcileCycle(_ string) (int, error) {
 		if iss.ID == "" {
 			continue
 		}
-		// Scope: mirror/dispatch issues that are EITHER in a ROUTED project
-		// (owner-chosen agent per project) OR directly assigned to an agent
-		// (delegate-based routing — a project with many leads, each issue
-		// assigned to its own lead). This must stay symmetric with the dispatch
-		// condition below: an issue that would dispatch must not be pre-skipped
-		// here, or the poll path (the only path on a webhook-less localhost)
-		// silently drops it. Still skips Linear's project-less team defaults
-		// (onboarding TSU-1..4) and any unrouted, unassigned issue — those were
-		// polluting the relay board as noise.
-		if !c.hasRoute(iss) && !isAgent(issueAssignee(iss)) {
+		// Scope: mirror/dispatch issues whose resolved target is an agent — a
+		// configured project route, the issue's delegate (Linear's agent-
+		// delegation field, for multi-lead projects), or a direct agent assignee.
+		// dispatchTarget folds all three (resolved once, reused for dispatch
+		// below). Skips Linear's project-less team defaults (onboarding TSU-1..4)
+		// and any issue with no agent target — those were polluting the board.
+		target := c.dispatchTarget(iss)
+		if !isAgent(target) {
 			continue
 		}
 		prior, _ := c.db.GetTaskByLinearIssueID(c.project, iss.ID)
@@ -64,13 +62,13 @@ func (c *Connector) ReconcileCycle(_ string) (int, error) {
 		if iss.State != nil && iss.State.Type == "completed" {
 			_ = c.db.MarkLinearDone(taskID)
 		}
-		// Dispatch on a genuine transition into a working "started" state with
-		// an agent assignee (first sight in-progress counts: boot-time pickup).
+		// Dispatch on a genuine transition into a working "started" state (the
+		// agent target is already confirmed by the scope gate above; first sight
+		// in-progress counts: boot-time pickup).
 		if c.onEvent != nil &&
 			iss.State != nil && iss.State.Type == "started" && !looksLikeReview(iss.State.Name) &&
-			(c.hasRoute(iss) || isAgent(issueAssignee(iss))) &&
 			(prior == nil || prior.Status != "in-progress") {
-			c.onEvent(c.dispatchEvent(taskID, iss.Title, seed))
+			c.onEvent(c.dispatchEvent(taskID, iss.Title, target, seed))
 		}
 	}
 

--- a/internal/connector/linear/webhook.go
+++ b/internal/connector/linear/webhook.go
@@ -185,15 +185,16 @@ func (c *Connector) Ingest(payload []byte, sig string) ([]connector.TaskEvent, e
 	// emit when the state actually changed in this update.
 	var events []connector.TaskEvent
 	if c.shouldDispatch(env, iss) {
-		events = append(events, c.dispatchEvent(taskID, iss.Title, seed))
+		events = append(events, c.dispatchEvent(taskID, iss.Title, c.dispatchTarget(iss), seed))
 	}
 	return events, nil
 }
 
 // dispatchEvent builds the semantic task.in_progress launch event. Shared by
-// the webhook path (Ingest) and the reconcile poll (transition detection).
-func (c *Connector) dispatchEvent(taskID, title string, seed db.LinearMirrorSeed) connector.TaskEvent {
-	agent := c.routedAgent(seed)
+// the webhook path (Ingest) and the reconcile poll (transition detection). The
+// dispatch target agent is resolved by the caller (c.dispatchTarget) — it has
+// the full issue, including the delegate field the seed doesn't carry.
+func (c *Connector) dispatchEvent(taskID, title, agent string, seed db.LinearMirrorSeed) connector.TaskEvent {
 	// Emit "task.dispatched", NOT "task.in_progress". Routing a Linear issue to an
 	// agent is semantically a DISPATCH ("here is assigned work, go claim it") —
 	// the same signal relay-native dispatch_task emits — so it must fire the same
@@ -235,9 +236,10 @@ func (c *Connector) shouldDispatch(env webhookEnvelope, iss gqlIssue) bool {
 	if !stateChanged(env.UpdatedFrom) {
 		return false
 	}
-	// Dispatch when the issue's project has a configured route (owner-chosen
-	// agent per project) OR it's directly assigned to an agent.
-	return c.hasRoute(iss) || isAgent(issueAssignee(iss))
+	// Dispatch when the resolved target is an agent: a configured project route,
+	// the issue's delegate (Linear's agent-delegation field), or a direct agent
+	// assignee. dispatchTarget folds all three in priority order.
+	return isAgent(c.dispatchTarget(iss))
 }
 
 // stateChanged reports whether updatedFrom carries a prior state (the transition
@@ -337,6 +339,20 @@ func issueAssignee(iss gqlIssue) string {
 	return strings.ToLower(strings.TrimSpace(name))
 }
 
+// issueDelegate returns the lowercased name of the issue's delegate (Linear's
+// agent-delegation field), or "" when none. Only the reconcile GraphQL query
+// populates this; Issue webhooks don't carry it.
+func issueDelegate(iss gqlIssue) string {
+	if iss.Delegate == nil {
+		return ""
+	}
+	name := iss.Delegate.DisplayName
+	if name == "" {
+		name = iss.Delegate.Name
+	}
+	return strings.ToLower(strings.TrimSpace(name))
+}
+
 func issueProjectID(iss gqlIssue) string {
 	if iss.Project != nil && iss.Project.ID != "" {
 		return iss.Project.ID
@@ -358,22 +374,23 @@ func (c *Connector) linearRouting() map[string]string {
 	return m
 }
 
-// routedAgent resolves the dispatch target: the agent configured for the issue's
-// Linear project (owner-chosen, one per project), falling back to the issue's
-// own assignee when that project has no routing entry.
-func (c *Connector) routedAgent(seed db.LinearMirrorSeed) string {
-	if seed.LinearProjectID != nil {
-		if a := c.linearRouting()[*seed.LinearProjectID]; a != "" {
+// dispatchTarget resolves the agent to dispatch an issue to, in priority order:
+//  1. the agent configured for the issue's Linear project (owner-chosen route,
+//     one fixed agent per project — wins for single-lane dev projects);
+//  2. the issue's delegate (Linear's agent-delegation field — the human stays
+//     assignee, the agent is the delegate; this is how multi-lead projects route
+//     each issue to its own lead without a fixed project route);
+//  3. the issue's assignee (when it's an agent directly).
+func (c *Connector) dispatchTarget(iss gqlIssue) string {
+	if pid := issueProjectID(iss); pid != "" {
+		if a := c.linearRouting()[pid]; a != "" {
 			return strings.ToLower(strings.TrimSpace(a))
 		}
 	}
-	return seedAssignee(seed)
-}
-
-// hasRoute reports whether the issue's project has a configured routing target.
-func (c *Connector) hasRoute(iss gqlIssue) bool {
-	pid := issueProjectID(iss)
-	return pid != "" && c.linearRouting()[pid] != ""
+	if d := issueDelegate(iss); d != "" {
+		return d
+	}
+	return issueAssignee(iss)
 }
 
 func issueKey(iss gqlIssue, teamKey string) string {
@@ -401,13 +418,6 @@ func marshalLabels(l labelList) string {
 func isAgent(name string) bool {
 	n := strings.ToLower(strings.TrimSpace(name))
 	return n != "" && n != "human" && n != "user"
-}
-
-func seedAssignee(s db.LinearMirrorSeed) string {
-	if s.Assignee != nil {
-		return *s.Assignee
-	}
-	return ""
 }
 
 func seedLinearKey(s db.LinearMirrorSeed) any {


### PR DESCRIPTION
## What

Linear assigns **agents** via a distinct **`Issue.delegate`** field, not `assignee` — the human stays the assignee (primary owner), the agent is the delegate. The connector only read `assignee`, so a delegated issue routed to the **human**, not the lead. Proper follow-up to #125 (which fixed the reconcile scope gate but still read assignee).

## Changes

- Fetch `Issue.delegate { id name displayName }` in the reconcile query.
- **`dispatchTarget(iss)`** resolves the agent in priority order: **project route > delegate > assignee**. Replaces `routedAgent(seed)`; webhook + reconcile both use it (webhooks don't carry delegate → fall back to assignee, no behavior change).
- **GUARDED** (the key safety requirement): `openTeamIssues` uses the delegate query but **latches a permanent fallback to the delegate-less query** on a field/validation error (HTTP 400 / "cannot query field"). A missing/renamed field can **never 400 the whole poll** → no fleet-wide dispatch outage. Transient errors propagate unchanged (poll retries next interval), so a network blip can't disable delegate routing.
- Reconcile scope gate now keys on `dispatchTarget` (resolved **once**, reused for dispatch), staying symmetric with the dispatch condition.

## Tests

- `TestReconcileDispatchDelegatePreferred` — human assignee + agent delegate → dispatches to the **delegate**.
- `TestReconcileDelegateFieldFallback` — delegate query returns a field error → poll latches fallback, still dispatches on assignee, `delegateUnsupported` flips true.

## Now both TSU-117 paths land

- (a) lead-as-assignee already works via #125 (merged).
- (b) **this PR** — lead-as-delegate (Linear's native agent model) now works too, safely.

## Release

No tag/publish (CTO-only). Prod relay `/tmp/arelay-real` carries this only after a CTO-cut release — **SIGNAL: ready for release WRAI.TH** (bundle TSU-117 #125 + TSU-121 if/when you cut).

## review-wraith verdict: SHIP
Scope: internal/connector/linear/{graphql,webhook,reconcile}.go + linear_test.go
Gate: build -tags fts5 OK / vet OK / gofmt OK / test -tags fts5 OK (full suite)

BLOCKERS: none

NITS (non-blocking):
- `isAgent` still treats any non-`human`/`user` name as an agent; delegate-priority reduces the chance of routing to a human, but a human assignee with no delegate on an unrouted started issue would still be picked up (pre-existing, consistent webhook+poll). Flag if a strict agent-name allowlist is wanted.
- Exact `Issue.delegate` subfield shape is docs-confirmed, not live-schema-verified; the latched fallback makes a wrong guess safe (poll degrades to assignee, never breaks).