### PR TITLE
fix(relay): message + audit_log retention GC — prevent unbounded table growth (TSU-127)

### DIFF
--- a/internal/db/audit.go
+++ b/internal/db/audit.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"agent-relay/internal/models"
+	"fmt"
 	"time"
 
 	"github.com/google/uuid"
@@ -63,4 +64,17 @@ func (d *DB) ListAudit(project, resourceID string, limit int) ([]models.AuditEnt
 		out = append(out, e)
 	}
 	return out, rows.Err()
+}
+
+// PurgeOldAuditLog hard-deletes audit entries older than maxAge so the audit_log
+// table doesn't grow unbounded. The audit trail is the accountability record, so
+// it's retained far longer than messages (see AuditLogRetention). Returns the
+// number of rows deleted.
+func (d *DB) PurgeOldAuditLog(maxAge time.Duration) (int64, error) {
+	cutoff := time.Now().UTC().Add(-maxAge).Format(memoryTimeFmt)
+	res, err := d.conn.Exec(`DELETE FROM audit_log WHERE datetime(created_at) < datetime(?)`, cutoff)
+	if err != nil {
+		return 0, fmt.Errorf("purge audit log: %w", err)
+	}
+	return res.RowsAffected()
 }

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -320,6 +320,8 @@ func migrate(conn *sql.DB) error {
 	_, _ = conn.Exec(`CREATE INDEX IF NOT EXISTS idx_messages_conversation ON messages(conversation_id)`)
 	_, _ = conn.Exec(`CREATE INDEX IF NOT EXISTS idx_messages_task ON messages(task_id)`)
 	_, _ = conn.Exec(`CREATE INDEX IF NOT EXISTS idx_messages_priority ON messages(priority)`)
+	// Drives the retention GC purge of soft-expired messages (PurgeExpiredMessages).
+	_, _ = conn.Exec(`CREATE INDEX IF NOT EXISTS idx_messages_expired ON messages(expired_at) WHERE expired_at IS NOT NULL`)
 	_, _ = conn.Exec(`CREATE INDEX IF NOT EXISTS idx_conversations_project ON conversations(project)`)
 
 	// Remove old global UNIQUE constraint on agents.name (existing DBs only).

--- a/internal/db/messages.go
+++ b/internal/db/messages.go
@@ -342,3 +342,36 @@ func (d *DB) ExpireMessages() (int, error) {
 	n, _ := result.RowsAffected()
 	return int(n), nil
 }
+
+// PurgeExpiredMessages hard-deletes messages that were soft-expired (TTL elapsed
+// via ExpireMessages) more than `grace` ago, together with their deliveries and
+// read receipts. Soft-expiry only hides a message from inboxes; without this the
+// messages/deliveries/message_reads tables grow unbounded over long-running
+// fleet operation. Messages with ttl_seconds=0 (never expire) are never purged.
+// Runs in one transaction on the single writer; returns the message count.
+func (d *DB) PurgeExpiredMessages(grace time.Duration) (int64, error) {
+	cutoff := time.Now().UTC().Add(-grace).Format("2006-01-02T15:04:05.000000Z")
+	const sel = `SELECT id FROM messages WHERE expired_at IS NOT NULL AND datetime(expired_at) < datetime(?)`
+
+	tx, err := d.conn.Begin()
+	if err != nil {
+		return 0, fmt.Errorf("purge messages begin: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	// Children first (sqlite FK cascade is off by default).
+	if _, err := tx.Exec(`DELETE FROM deliveries WHERE message_id IN (`+sel+`)`, cutoff); err != nil {
+		return 0, fmt.Errorf("purge deliveries: %w", err)
+	}
+	if _, err := tx.Exec(`DELETE FROM message_reads WHERE message_id IN (`+sel+`)`, cutoff); err != nil {
+		return 0, fmt.Errorf("purge message_reads: %w", err)
+	}
+	res, err := tx.Exec(`DELETE FROM messages WHERE expired_at IS NOT NULL AND datetime(expired_at) < datetime(?)`, cutoff)
+	if err != nil {
+		return 0, fmt.Errorf("purge messages: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return 0, fmt.Errorf("purge messages commit: %w", err)
+	}
+	return res.RowsAffected()
+}

--- a/internal/db/retention_test.go
+++ b/internal/db/retention_test.go
@@ -1,0 +1,118 @@
+package db
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func retentionTestDB(t *testing.T) *DB {
+	t.Helper()
+	d, err := NewTestDB(filepath.Join(t.TempDir(), "retention.db"))
+	if err != nil {
+		t.Fatalf("NewTestDB: %v", err)
+	}
+	t.Cleanup(func() { _ = d.Close() })
+	return d
+}
+
+func countRows(t *testing.T, d *DB, q string, args ...any) int {
+	t.Helper()
+	var n int
+	if err := d.conn.QueryRow(q, args...).Scan(&n); err != nil {
+		t.Fatalf("count (%s): %v", q, err)
+	}
+	return n
+}
+
+// PurgeExpiredMessages hard-deletes messages soft-expired longer than the grace
+// window, along with their deliveries and read receipts — but leaves messages
+// still inside the grace window (and never-expired ttl=0 messages) untouched.
+func TestPurgeExpiredMessages(t *testing.T) {
+	d := retentionTestDB(t)
+
+	// Three messages, each gets a delivery row from InsertMessage.
+	old, err := d.InsertMessage("default", "a", "b", "notification", "s", "old", "{}", "P2", 3600, nil, nil)
+	if err != nil {
+		t.Fatalf("insert old: %v", err)
+	}
+	recent, err := d.InsertMessage("default", "a", "b", "notification", "s", "recent", "{}", "P2", 3600, nil, nil)
+	if err != nil {
+		t.Fatalf("insert recent: %v", err)
+	}
+	persistent, err := d.InsertMessage("default", "a", "b", "notification", "s", "persistent", "{}", "P2", 0, nil, nil)
+	if err != nil {
+		t.Fatalf("insert persistent: %v", err)
+	}
+
+	// A read receipt on the old message, so we can confirm it's reclaimed too.
+	if _, err := d.conn.Exec(
+		`INSERT INTO message_reads (message_id, agent_name, project, read_at) VALUES (?, 'b', 'default', ?)`,
+		old.ID, time.Now().UTC().Format(memoryTimeFmt)); err != nil {
+		t.Fatalf("seed read receipt: %v", err)
+	}
+
+	// Soft-expire: old = 10 days ago (past the 7d grace), recent = 1 day ago (within).
+	tenDaysAgo := time.Now().UTC().Add(-10 * 24 * time.Hour).Format(memoryTimeFmt)
+	oneDayAgo := time.Now().UTC().Add(-1 * 24 * time.Hour).Format(memoryTimeFmt)
+	if _, err := d.conn.Exec(`UPDATE messages SET expired_at = ? WHERE id = ?`, tenDaysAgo, old.ID); err != nil {
+		t.Fatalf("expire old: %v", err)
+	}
+	if _, err := d.conn.Exec(`UPDATE messages SET expired_at = ? WHERE id = ?`, oneDayAgo, recent.ID); err != nil {
+		t.Fatalf("expire recent: %v", err)
+	}
+
+	purged, err := d.PurgeExpiredMessages(7 * 24 * time.Hour)
+	if err != nil {
+		t.Fatalf("PurgeExpiredMessages: %v", err)
+	}
+	if purged != 1 {
+		t.Fatalf("purged = %d, want 1 (only the message expired past grace)", purged)
+	}
+
+	// Old message + its children are gone.
+	if n := countRows(t, d, `SELECT COUNT(*) FROM messages WHERE id = ?`, old.ID); n != 0 {
+		t.Errorf("old message not purged: %d rows", n)
+	}
+	if n := countRows(t, d, `SELECT COUNT(*) FROM deliveries WHERE message_id = ?`, old.ID); n != 0 {
+		t.Errorf("old deliveries not purged: %d rows", n)
+	}
+	if n := countRows(t, d, `SELECT COUNT(*) FROM message_reads WHERE message_id = ?`, old.ID); n != 0 {
+		t.Errorf("old read receipts not purged: %d rows", n)
+	}
+	// Recent (within grace) and persistent (ttl=0) survive.
+	if n := countRows(t, d, `SELECT COUNT(*) FROM messages WHERE id IN (?, ?)`, recent.ID, persistent.ID); n != 2 {
+		t.Errorf("recent/persistent messages wrongly purged: %d of 2 survive", n)
+	}
+}
+
+// PurgeOldAuditLog deletes audit entries older than maxAge, keeps newer ones.
+func TestPurgeOldAuditLog(t *testing.T) {
+	d := retentionTestDB(t)
+
+	if err := d.RecordAudit(auditEntry("p1", "user", "transition", "task-old", "old")); err != nil {
+		t.Fatalf("record old: %v", err)
+	}
+	if err := d.RecordAudit(auditEntry("p1", "user", "transition", "task-new", "new")); err != nil {
+		t.Fatalf("record new: %v", err)
+	}
+	// Backdate the old entry past the 90d window.
+	oldTS := time.Now().UTC().Add(-100 * 24 * time.Hour).Format(memoryTimeFmt)
+	if _, err := d.conn.Exec(`UPDATE audit_log SET created_at = ? WHERE resource_id = 'task-old'`, oldTS); err != nil {
+		t.Fatalf("backdate: %v", err)
+	}
+
+	purged, err := d.PurgeOldAuditLog(90 * 24 * time.Hour)
+	if err != nil {
+		t.Fatalf("PurgeOldAuditLog: %v", err)
+	}
+	if purged != 1 {
+		t.Fatalf("purged = %d, want 1", purged)
+	}
+	if n := countRows(t, d, `SELECT COUNT(*) FROM audit_log WHERE resource_id = 'task-old'`); n != 0 {
+		t.Errorf("old audit row not purged: %d", n)
+	}
+	if n := countRows(t, d, `SELECT COUNT(*) FROM audit_log WHERE resource_id = 'task-new'`); n != 1 {
+		t.Errorf("recent audit row wrongly purged: %d", n)
+	}
+}

--- a/internal/relay/cleanup.go
+++ b/internal/relay/cleanup.go
@@ -26,6 +26,23 @@ const (
 	// before it's noticed (the data-loss restore leaned on a 07:53 snapshot that
 	// was the oldest of only 3, nearly gone). Disk: ~snapshot-size × 12.
 	BackupKeep = 12
+
+	// Retention policy (TSU-127). Soft-expiry (ExpireMessages/ExpireDeliveries)
+	// only HIDES rows from inboxes; these windows govern HARD reclamation so the
+	// tables don't grow unbounded over long-running fleet operation:
+	//
+	//   messages/deliveries/message_reads — purged MessageRetention after a
+	//     message's TTL elapses (ttl_seconds=0 = never expires = never purged).
+	//   audit_log — kept AuditLogRetention (accountability record; far longer).
+	//   token_usage — 30d (PurgeOldTokenUsage).
+	//   events — bounded by PruneDeliveredEvents(keep).
+	//   activity — ephemeral, never persisted (in-memory ingest Detector + SSE).
+	//
+	// MessageRetention: a soft-expired message stays recoverable/inspectable for
+	// a week past its TTL before the row is reclaimed.
+	MessageRetention = 7 * 24 * time.Hour
+	// AuditLogRetention: 90 days of accountability trail before reclamation.
+	AuditLogRetention = 90 * 24 * time.Hour
 )
 
 // StartCleanup runs a background goroutine that marks stale agents as inactive.
@@ -70,6 +87,18 @@ func StartCleanup(database *db.DB, done <-chan struct{}) {
 					log.Printf("purge token usage error: %v", err)
 				} else if purged > 0 {
 					log.Printf("purged %d old token usage record(s)", purged)
+				}
+				// Hard-reclaim soft-expired messages (+ their deliveries/reads) and
+				// stale audit rows so the tables stay bounded (TSU-127).
+				if purged, err := database.PurgeExpiredMessages(MessageRetention); err != nil {
+					log.Printf("purge expired messages error: %v", err)
+				} else if purged > 0 {
+					log.Printf("purged %d expired message(s)", purged)
+				}
+				if purged, err := database.PurgeOldAuditLog(AuditLogRetention); err != nil {
+					log.Printf("purge audit log error: %v", err)
+				} else if purged > 0 {
+					log.Printf("purged %d old audit log record(s)", purged)
 				}
 				database.Optimize()
 


### PR DESCRIPTION
## Audit finding

`ExpireMessages`/`ExpireDeliveries` only **soft-mark** rows (`expired_at` / `state='expired'`) to hide them from inboxes — the `messages`/`deliveries`/`message_reads` rows are **never reclaimed**, and `audit_log` had **no retention at all**. Over long-running fleet operation these tables grow without bound.

Already bounded (confirmed): `token_usage` (30d purge), `events` (`PruneDeliveredEvents(keep)`), activity (ephemeral, never persisted — in-memory ingest Detector + SSE).

## Changes

- **`PurgeExpiredMessages(grace)`** — hard-deletes messages soft-expired more than `grace` ago + their deliveries and read receipts, in one writer transaction (children first; sqlite FK cascade is off). `ttl_seconds=0` (never expires) → never purged.
- **`PurgeOldAuditLog(maxAge)`** — reclaims audit rows past the window. **Closes the AIMS "audit_log no retention policy" gap.**
- Wired both into the 5-min cleanup loop.
- **Documented retention policy** (cleanup const block): messages **7d** past TTL · audit_log **90d** · token_usage 30d · events bounded by keep · activity ephemeral.
- Partial index `idx_messages_expired` drives the purge.

## Safety

- Periodic GC (not a per-request hot-path write); single-writer tx.
- Only deletes messages soft-expired **>7 days** — long gone from inboxes; does **not** touch the unread/unacked surfacing logic (no TSU-73 regression).
- Additive + idempotent (index `IF NOT EXISTS`); older DBs unaffected.

## Tests

- `TestPurgeExpiredMessages` — reclaims a past-grace message + its delivery + read receipt; leaves within-grace and `ttl=0` messages.
- `TestPurgeOldAuditLog` — deletes past-window rows, keeps recent.

## review-wraith verdict: SHIP
Scope: internal/db/{messages,audit,db}.go + internal/relay/cleanup.go + retention_test.go
Gate: build -tags fts5 OK / vet OK / gofmt OK / test -tags fts5 OK (full suite)

BLOCKERS: none

NITS:
- A `ttl=0` reply whose expired parent is purged leaves a dangling `reply_to` (thread of a 7-day-expired message); acceptable, low-risk.

No release (CTO-only); prod relay carries this on the next supervised cut.