### PR TITLE
feat(relay): GET /api/metrics ops snapshot for monitoring (TSU-141)

### DIFF
--- a/internal/db/metrics_test.go
+++ b/internal/db/metrics_test.go
@@ -1,0 +1,48 @@
+package db
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestMetricsSnapshot(t *testing.T) {
+	d := testDB(t)
+
+	for i := 0; i < 3; i++ {
+		if _, _, err := d.RegisterAgent("default", fmt.Sprintf("a%d", i), "m", "", nil, nil, false, nil, "[]", 0, RegisterOptions{}); err != nil {
+			t.Fatalf("register a%d: %v", i, err)
+		}
+	}
+	// One agent goes inactive — active count must exclude it.
+	if _, err := d.conn.Exec(`UPDATE agents SET status='inactive' WHERE name='a2'`); err != nil {
+		t.Fatalf("mark inactive: %v", err)
+	}
+	for i := 0; i < 4; i++ {
+		if _, err := d.InsertMessageWithDeliveries("default", "a0", "a1", "notification", "s", "m", "{}", "P2", 3600, nil, nil, []string{"a1"}); err != nil {
+			t.Fatalf("insert msg %d: %v", i, err)
+		}
+	}
+	if err := d.RecordAudit(auditEntry("default", "a0", "transition", "t1", "s")); err != nil {
+		t.Fatalf("audit: %v", err)
+	}
+
+	m := d.MetricsSnapshot()
+	if m.AgentsTotal != 3 {
+		t.Errorf("agents_total = %d, want 3", m.AgentsTotal)
+	}
+	if m.AgentsActive != 2 {
+		t.Errorf("agents_active = %d, want 2", m.AgentsActive)
+	}
+	if m.MessagesTotal != 4 {
+		t.Errorf("messages_total = %d, want 4", m.MessagesTotal)
+	}
+	if m.MessagesLastMinute != 4 {
+		t.Errorf("messages_last_minute = %d, want 4 (all just inserted)", m.MessagesLastMinute)
+	}
+	if m.DeliveriesUnacked != 4 {
+		t.Errorf("deliveries_unacked = %d, want 4", m.DeliveriesUnacked)
+	}
+	if m.AuditLogRows != 1 {
+		t.Errorf("audit_log_rows = %d, want 1", m.AuditLogRows)
+	}
+}

--- a/internal/db/stats.go
+++ b/internal/db/stats.go
@@ -1,5 +1,7 @@
 package db
 
+import "time"
+
 // Stats holds aggregate relay statistics.
 type Stats struct {
 	Agents      int
@@ -95,4 +97,46 @@ func (d *DB) UnreadCount() (int, error) {
 	var n int
 	err := d.ro().QueryRow("SELECT COUNT(*) FROM messages WHERE read_at IS NULL").Scan(&n)
 	return n, err
+}
+
+// OpsMetrics is a lightweight fleet-health snapshot for the ops/metrics endpoint
+// (TSU-141). All counts come from the read pool; a monitor scrapes this to track
+// fleet activity, message throughput, GC pressure, and table growth.
+type OpsMetrics struct {
+	AgentsActive             int64 `json:"agents_active"`
+	AgentsTotal              int64 `json:"agents_total"`
+	MessagesTotal            int64 `json:"messages_total"`
+	MessagesLastMinute       int64 `json:"messages_last_minute"`
+	MessagesLastHour         int64 `json:"messages_last_hour"`
+	MessagesExpiredPendingGC int64 `json:"messages_expired_pending_gc"`
+	DeliveriesUnacked        int64 `json:"deliveries_unacked"`
+	TasksOpen                int64 `json:"tasks_open"`
+	AuditLogRows             int64 `json:"audit_log_rows"`
+	MemoriesRows             int64 `json:"memories_rows"`
+}
+
+// MetricsSnapshot returns a one-shot OpsMetrics. Best-effort: a failing count
+// leaves its field at zero rather than failing the whole scrape, so a monitoring
+// endpoint never 500s on one bad query.
+func (d *DB) MetricsSnapshot() OpsMetrics {
+	var m OpsMetrics
+	ro := d.ro()
+	scan := func(dst *int64, query string, args ...any) {
+		_ = ro.QueryRow(query, args...).Scan(dst)
+	}
+	now := time.Now().UTC()
+	minAgo := now.Add(-time.Minute).Format(memoryTimeFmt)
+	hourAgo := now.Add(-time.Hour).Format(memoryTimeFmt)
+
+	scan(&m.AgentsTotal, `SELECT COUNT(*) FROM agents`)
+	scan(&m.AgentsActive, `SELECT COUNT(*) FROM agents WHERE status = 'active'`)
+	scan(&m.MessagesTotal, `SELECT COUNT(*) FROM messages`)
+	scan(&m.MessagesLastMinute, `SELECT COUNT(*) FROM messages WHERE created_at > ?`, minAgo)
+	scan(&m.MessagesLastHour, `SELECT COUNT(*) FROM messages WHERE created_at > ?`, hourAgo)
+	scan(&m.MessagesExpiredPendingGC, `SELECT COUNT(*) FROM messages WHERE expired_at IS NOT NULL`)
+	scan(&m.DeliveriesUnacked, `SELECT COUNT(*) FROM deliveries WHERE state IN ('queued', 'surfaced')`)
+	scan(&m.TasksOpen, `SELECT COUNT(*) FROM tasks WHERE status NOT IN ('done', 'cancelled')`)
+	scan(&m.AuditLogRows, `SELECT COUNT(*) FROM audit_log`)
+	scan(&m.MemoriesRows, `SELECT COUNT(*) FROM memories`)
+	return m
 }

--- a/internal/relay/api.go
+++ b/internal/relay/api.go
@@ -178,6 +178,10 @@ func (r *Relay) ServeAPI(w http.ResponseWriter, req *http.Request) {
 	// Agentic analytics (stats panel)
 	case path == "/stats" && req.Method == http.MethodGet:
 		r.apiGetAgentStats(w, req)
+	// Ops/metrics snapshot for monitoring (TSU-141): agent count, msg rate, GC
+	// pressure, table growth, DB/snapshot health, Linear freshness.
+	case path == "/metrics" && req.Method == http.MethodGet:
+		r.apiGetMetrics(w, req)
 	// Notification rules (configurable event→action→target rules engine)
 	case path == "/notification-rules" && req.Method == http.MethodGet:
 		r.apiGetNotificationRules(w, req)

--- a/internal/relay/metrics_api.go
+++ b/internal/relay/metrics_api.go
@@ -1,0 +1,57 @@
+package relay
+
+import (
+	"net/http"
+	"os"
+	"time"
+)
+
+// apiGetMetrics serves GET /api/metrics — a lightweight JSON ops snapshot so a
+// monitor can scrape relay health without shelling in (TSU-141). Sits behind the
+// auth chain (loopback-exempt): a local scraper needs no token, a remote one
+// needs RELAY_API_KEY. Read-only + best-effort: never 500s on one bad count.
+func (r *Relay) apiGetMetrics(w http.ResponseWriter, _ *http.Request) {
+	m := r.DB.MetricsSnapshot()
+	out := map[string]any{
+		"version":        r.Version,
+		"uptime_seconds": int64(time.Since(r.StartedAt).Seconds()),
+		"agents": map[string]any{
+			"active": m.AgentsActive,
+			"total":  m.AgentsTotal,
+		},
+		"messages": map[string]any{
+			"total":              m.MessagesTotal,
+			"last_minute":        m.MessagesLastMinute,
+			"last_hour":          m.MessagesLastHour,
+			"rate_per_minute":    m.MessagesLastMinute,
+			"expired_pending_gc": m.MessagesExpiredPendingGC,
+		},
+		"deliveries": map[string]any{"unacked": m.DeliveriesUnacked},
+		"tasks":      map[string]any{"open": m.TasksOpen},
+		"tables": map[string]any{
+			"audit_log": m.AuditLogRows,
+			"memories":  m.MemoriesRows,
+		},
+		"db": dbFileMetrics(r.DB.Path()),
+	}
+	// Linear connector freshness (last reconcile/webhook, writer failures) when active.
+	if c := r.LinearConnector(); c != nil {
+		out["linear"] = c.Status()
+	}
+	writeJSON(w, out)
+}
+
+// dbFileMetrics reports the live DB file size and the freshness of the newest
+// rotated snapshot (.bak.0) — surfaces backup/GC health (TSU-137/TSU-127) to
+// monitoring. Missing files are simply omitted.
+func dbFileMetrics(path string) map[string]any {
+	out := map[string]any{}
+	if fi, err := os.Stat(path); err == nil {
+		out["size_bytes"] = fi.Size()
+	}
+	if fi, err := os.Stat(path + ".bak.0"); err == nil {
+		out["snapshot_size_bytes"] = fi.Size()
+		out["snapshot_age_seconds"] = int64(time.Since(fi.ModTime()).Seconds())
+	}
+	return out
+}

--- a/internal/relay/metrics_api_test.go
+++ b/internal/relay/metrics_api_test.go
@@ -1,0 +1,39 @@
+package relay
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"agent-relay/internal/db"
+)
+
+func TestApiGetMetrics(t *testing.T) {
+	r := testRelay(t)
+	if _, _, err := r.DB.RegisterAgent("default", "a0", "m", "", nil, nil, false, nil, "[]", 0, db.RegisterOptions{}); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+
+	w := doAPI(r, "GET", "/metrics", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+
+	var out map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &out); err != nil {
+		t.Fatalf("metrics not valid JSON: %v", err)
+	}
+	for _, key := range []string{"version", "uptime_seconds", "agents", "messages", "deliveries", "tasks", "db"} {
+		if _, ok := out[key]; !ok {
+			t.Errorf("metrics missing %q", key)
+		}
+	}
+	agents, ok := out["agents"].(map[string]any)
+	if !ok {
+		t.Fatalf("agents block malformed: %T", out["agents"])
+	}
+	// One registered agent → active count 1 (JSON numbers decode to float64).
+	if got, _ := agents["active"].(float64); got != 1 {
+		t.Errorf("agents.active = %v, want 1", agents["active"])
+	}
+}


### PR DESCRIPTION
## What

A monitor can now scrape relay health without shelling in — a single read-only, best-effort JSON endpoint. Sits behind the auth chain (loopback-exempt like the rest of the API): a **local** scraper needs no token, a **remote** one needs `RELAY_API_KEY`.

`GET /api/metrics` →
```json
{
  "version": "...", "uptime_seconds": N,
  "agents": {"active": N, "total": M},
  "messages": {"total":, "last_minute":, "last_hour":, "rate_per_minute":, "expired_pending_gc":},
  "deliveries": {"unacked": N},
  "tasks": {"open": N},
  "tables": {"audit_log": N, "memories": N},
  "db": {"size_bytes":, "snapshot_size_bytes":, "snapshot_age_seconds":},
  "linear": { ...Status() when connector active... }
}
```

## Design

- **`db.MetricsSnapshot()`** — all counts from the read pool; **best-effort** (a failing count leaves its field zero rather than 500-ing the whole scrape).
- **`apiGetMetrics`** — wraps it with version, uptime, DB file size + newest snapshot age/size (backup health, TSU-137), and the Linear connector `Status()` when active.
- Route added to `ServeAPI`.

Surfaces the reliability arc to monitoring: **msg rate** (TSU-134), **GC pressure** (`expired_pending_gc`, TSU-127), **backup freshness** (TSU-137).

## Safety

Read-only; behind auth; no schema change; no hot-path write.

## Tests

- `TestMetricsSnapshot` — active excludes inactive, last-minute rate, unacked deliveries, audit counts.
- `TestApiGetMetrics` — 200 + expected JSON shape via the **real `ServeAPI` dispatch**.

## review-wraith verdict: SHIP
Scope: internal/db/stats.go (+test), internal/relay/metrics_api.go (+test), api.go route
Gate: build -tags fts5 OK / vet OK / gofmt OK / test -tags fts5 OK (full suite)

BLOCKERS: none
NITS:
- JSON shape (not Prometheus text). Matches the existing JSON API + dashboard; a `/metrics` Prometheus exposition format can be a follow-up if a Prom scraper is wanted.

No release (CTO-only).