### PR TITLE
fix(install): honest post-install summary — don't claim 'relay is running' (TSU-223)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1071,9 +1071,28 @@ print_summary() {
   echo "${GREEN}${BOLD}  ║      Installation complete!            ║${RESET}"
   echo "${GREEN}${BOLD}  ╚═══════════════════════════════════════╝${RESET}"
   echo
-  info "The relay is running on ${BOLD}http://localhost:${PORT}${RESET}"
+  # Be honest about service state: only the auto-start path actually launches a
+  # relay. With --no-service nothing is running yet — claiming otherwise is the
+  # #1 source of "I followed the steps and nothing works" confusion.
+  local bin_path="${BIN_DIR}/${BINARY_NAME}"
+  local relay_cmd="$BINARY_NAME"
+  case ":${PATH}:" in
+    *":${BIN_DIR}:"*) ;;                 # on PATH — bare command works
+    *) relay_cmd="$bin_path" ;;          # not on PATH — use the full path
+  esac
+
+  if [[ "$NO_SERVICE" == true ]]; then
+    warn "No auto-start service was installed (--no-service). The relay is ${BOLD}not running yet${RESET}."
+    info "Start it: ${BOLD}${relay_cmd} serve${RESET}   (or re-run without --no-service for auto-start on login)"
+  else
+    info "The relay auto-starts on login and is starting now on ${BOLD}http://localhost:${PORT}${RESET}"
+    info "Check it: ${BOLD}${relay_cmd} status${RESET}"
+  fi
   echo
   info "Next steps:"
+  if [[ ":${PATH}:" != *":${BIN_DIR}:"* ]]; then
+    echo "  0. Add the binary to your PATH: ${BOLD}export PATH=\"${BIN_DIR}:\$PATH\"${RESET} (append to your shell profile)"
+  fi
   echo "  1. Open Claude Code in any configured project"
   echo "  2. Use ${BOLD}/relay${RESET} to check your inbox"
   echo "  3. Use ${BOLD}/relay send <agent> <message>${RESET} to talk to another agent"


### PR DESCRIPTION
Part of TSU-223 (activation gate: wraith install.sh — one command, zero errors, clean-env proof).

## Reproduction (clean isolated HOME, prod untouched)
Ran `install.sh` from scratch with a fresh `HOME`, alt port, bin-dir forced into the sandbox (so the prod `/usr/local/bin/agent-relay` is never touched):
- **Build-from-source path** (Go present) → EXIT 0, builds v1.5.0, hooks + `/relay` (+ `tools-reference.md`) land.
- **Prebuilt-download path** (Go absent) → EXIT 0, fetches v1.5.0, checksum-verified, same artifacts land.
- **Re-run** → EXIT 0, no hook-event duplication, no errors. Idempotent.

So on current `main` the install is healthy on both paths. The one real defect matching the owner's "unclear steps" report:

## Bug
`print_summary` always printed **"The relay is running on http://localhost:PORT"** — even with `--no-service`, when nothing was launched. It also assumed the binary was on PATH, so the `ar`/`agent-relay` next-steps silently fail when it lands in `~/.local/bin` (not on PATH).

## Fix
- `--no-service`: state plainly the relay is **not running yet** + give the exact `<bin> serve` command (full path when not on PATH) + how to enable auto-start.
- service path: "auto-starts on login + starting now on :PORT" + `<bin> status`.
- Prepend a **step 0: add to PATH** line with the exact `export` when `BIN_DIR` isn't on PATH.

Shell-only; `bash -n` clean.

## Clean-env proof (after fix, --no-service path)
```
! No auto-start service was installed (--no-service). The relay is not running yet.
:: Start it: <HOME>/.local/bin/agent-relay serve   (or re-run without --no-service for auto-start on login)

:: Next steps:
  0. Add the binary to your PATH: export PATH="<HOME>/.local/bin:$PATH" (append to your shell profile)
  1. Open Claude Code in any configured project
  2. Use /relay to check your inbox
```

## Note for cto / owner
I could **not** reproduce the "skills not copied / errored / crashed" failures on current `main` (both install paths clean + idempotent, `/relay` + `tools-reference.md` land in `~/.claude/commands/`). Likely fixed since the report, or env/version-specific. If it still reproduces, I need the env (OS/arch, version installed, the error text) to chase it. This PR fixes the concrete "unclear steps" defect I could confirm.

## review-wraith verdict: SHIP
Scope: install.sh print_summary (shell-only). Gate: bash -n OK; no Go files touched (CI Go/lint unaffected). BLOCKERS: none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)