### PR TITLE
feat(install): ship a public end-user Claude Code skill (TSU-223)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -772,6 +772,16 @@ SKILL_EOF
 
   rm -rf "$tmpdir"
   success "Installed /relay command at ${DIM}${skill_path}${RESET}"
+
+  # Public end-user skill → ~/.claude/skills/agent-relay/SKILL.md. The binary
+  # carries it as a baked-in template (single source of truth), so let it write
+  # the file rather than curling a copy — guarantees it matches this version.
+  local _bin="${BIN_DIR}/${BINARY_NAME}"
+  if [[ -x "$_bin" ]] && "$_bin" skill install >/dev/null 2>&1; then
+    success "Installed ${BOLD}agent-relay${RESET} skill at ${DIM}${HOME}/.claude/skills/agent-relay/SKILL.md${RESET}"
+  else
+    warn "Could not install the agent-relay skill (run ${BOLD}agent-relay skill install${RESET} after adding the binary to PATH)"
+  fi
 }
 
 # ── Step 5: Scan and configure projects ──────────────────────────────────────
@@ -1025,6 +1035,13 @@ verify_installation() {
     success "Skill: /relay command installed"
   else
     warn "Skill: not found"
+  fi
+
+  # Check public end-user skill
+  if [[ -f "$HOME/.claude/skills/agent-relay/SKILL.md" ]]; then
+    success "Skill: agent-relay skill installed"
+  else
+    warn "Skill: agent-relay skill not found"
   fi
 
   # Check port availability and service status

--- a/install.sh
+++ b/install.sh
@@ -1071,9 +1071,28 @@ print_summary() {
   echo "${GREEN}${BOLD}  ║      Installation complete!            ║${RESET}"
   echo "${GREEN}${BOLD}  ╚═══════════════════════════════════════╝${RESET}"
   echo
-  info "The relay is running on ${BOLD}http://localhost:${PORT}${RESET}"
+  # Be honest about service state: only the auto-start path actually launches a
+  # relay. With --no-service nothing is running yet — claiming otherwise is the
+  # #1 source of "I followed the steps and nothing works" confusion.
+  local bin_path="${BIN_DIR}/${BINARY_NAME}"
+  local relay_cmd="$BINARY_NAME"
+  case ":${PATH}:" in
+    *":${BIN_DIR}:"*) ;;                 # on PATH — bare command works
+    *) relay_cmd="$bin_path" ;;          # not on PATH — use the full path
+  esac
+
+  if [[ "$NO_SERVICE" == true ]]; then
+    warn "No auto-start service was installed (--no-service). The relay is ${BOLD}not running yet${RESET}."
+    info "Start it: ${BOLD}${relay_cmd} serve${RESET}   (or re-run without --no-service for auto-start on login)"
+  else
+    info "The relay auto-starts on login and is starting now on ${BOLD}http://localhost:${PORT}${RESET}"
+    info "Check it: ${BOLD}${relay_cmd} status${RESET}"
+  fi
   echo
   info "Next steps:"
+  if [[ ":${PATH}:" != *":${BIN_DIR}:"* ]]; then
+    echo "  0. Add the binary to your PATH: ${BOLD}export PATH=\"${BIN_DIR}:\$PATH\"${RESET} (append to your shell profile)"
+  fi
   echo "  1. Open Claude Code in any configured project"
   echo "  2. Use ${BOLD}/relay${RESET} to check your inbox"
   echo "  3. Use ${BOLD}/relay send <agent> <message>${RESET} to talk to another agent"

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -112,6 +112,15 @@ func runInit(args []string) {
 	if project != "" {
 		fmt.Printf("  project: %s (set as default via URL param)\n", project)
 	}
+
+	// Land the public end-user skill so a fresh Claude Code session knows how to
+	// drive relay setup + usage. Best-effort — never fail `init` over it.
+	if home, err := os.UserHomeDir(); err == nil {
+		if err := InstallPublicSkill(home); err == nil {
+			fmt.Printf("  skill: ~/.claude/skills/%s/SKILL.md\n", PublicSkillName)
+		}
+	}
+
 	fmt.Println("\nnext steps:")
 	fmt.Println("  1. Run /mcp in Claude Code to reload MCP connections")
 	fmt.Println("  2. Call whoami() with a unique salt to identify your session")

--- a/internal/cli/skill.go
+++ b/internal/cli/skill.go
@@ -1,0 +1,181 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// PublicSkillName is the directory under ~/.claude/skills/ that holds the
+// shipped end-user skill.
+const PublicSkillName = "agent-relay"
+
+// PublicSkillMD is the PUBLIC "how to self-host + use wrai.th" Claude Code
+// skill, written verbatim by `agent-relay skill install` (and `init`, and the
+// auto-updater's refresh) to ~/.claude/skills/agent-relay/SKILL.md.
+//
+// This is the PUBLIC user-facing skill, NOT the private maintainer persona and
+// NOT the /relay slash command. It teaches a fresh Claude Code session to drive
+// relay setup + usage for the user. Hard rails baked into the copy (keep them
+// true if you edit): the relay is a single self-hosted Go binary (sqlite, no
+// required external services); no hosted/cloud/sign-up; no private paths or
+// internal fleet/project references (public/AGPL split); Linear is optional.
+const PublicSkillMD = `---
+name: agent-relay
+description: >-
+  Set up and use wrai.th (agent-relay) — a self-hosted MCP relay that lets a
+  fleet of Claude Code (and other) agents coordinate: shared inbox + messaging,
+  a task board, scoped memory, and a live activity stream. Use when the user
+  wants to install or configure the relay, register an agent, check their inbox,
+  message or dispatch work to another agent, manage tasks, or stand up a
+  multi-agent project. The relay is self-hosted only — a single binary on the
+  user's own machine; there is no hosted service or sign-up.
+---
+
+# wrai.th (agent-relay) — self-hosted agent coordination
+
+wrai.th is a single Go binary that runs an MCP server on localhost. Agents
+register, message each other, share memory, and pick up tasks from a board —
+all over MCP, backed by one SQLite file. It is **self-hosted only**: the user
+runs the relay on their own box. There is no hosted relay, no cloud, no sign-up.
+
+When this skill is active, drive the user through whichever part they need. Run
+the real commands, read their output, and fix problems — don't just narrate.
+
+## 1. Is the relay installed and running?
+
+` + "```bash" + `
+agent-relay --version
+curl -fsS http://localhost:8090/api/health   # {"status":"ok",...} when up
+` + "```" + `
+
+If ` + "`agent-relay`" + ` is not found, install it (one command — builds from source
+when Go + a C compiler are present, else downloads a checksum-verified prebuilt):
+
+` + "```bash" + `
+curl -fsSL https://raw.githubusercontent.com/TsukumoHQ/WRAI.TH/main/install.sh | bash
+` + "```" + `
+
+If the binary is installed but the health check fails, start it:
+
+` + "```bash" + `
+agent-relay serve     # foreground; or rely on the auto-start service the installer set up
+` + "```" + `
+
+If ` + "`agent-relay`" + ` isn't on PATH, the installer put it in ` + "`~/.local/bin`" + ` — add
+that to PATH or call it by full path.
+
+## 2. Wire this machine's hooks
+
+The relay only sees what agents do once the hooks are installed. They feed it
+activity, real token usage, and identity that survives ` + "`/clear`" + `. Idempotent —
+the installer already ran this; re-run to be sure:
+
+` + "```bash" + `
+agent-relay hooks install     # writes hooks + merges ~/.claude/settings.json
+agent-relay hooks status      # show what's installed / wired
+` + "```" + `
+
+Identity binds on the working directory (cwd), not the session id — so ` + "`/clear`" + `
+keeps your identity, and one agent = one worktree.
+
+## 3. Register the MCP server for this project
+
+` + "```bash" + `
+agent-relay init [project-name]   # writes/merges .mcp.json in the repo
+` + "```" + `
+
+Then run ` + "`/mcp`" + ` in Claude Code to load the relay tools. Existing ` + "`.mcp.json`" + `
+files are merged, not overwritten (a ` + "`.bak`" + ` is kept).
+
+Tools use progressive disclosure to stay cheap. If a tool seems missing (e.g.
+` + "`tool 'register_agent' not found`" + `), you're in discovery mode: call
+` + "`discover_tools(category)`" + ` then ` + "`call_tool(tool, args)`" + `, or append
+` + "`?tools=full`" + ` to the relay URL in ` + "`.mcp.json`" + ` and re-run ` + "`/mcp`" + `.
+
+## 4. Identify and register this agent
+
+` + "```" + `
+whoami({ salt: "<three-random-words>" })       // returns a stable session id
+register_agent({ name: "<agent-name>", project: "<project>", cwd: "<$PWD>" })
+` + "```" + `
+
+Pass ` + "`cwd`" + ` — it binds your session so per-turn token usage attributes to you.
+Add ` + "`role`" + `, ` + "`reports_to`" + `, or ` + "`is_executive: true`" + ` as needed.
+
+## 5. Coordinate
+
+- **Inbox:** ` + "`get_inbox({ as: \"<agent>\" })`" + ` — non-destructive; ` + "`mark_read`" + ` /
+  ` + "`ack_delivery`" + ` clear it. Unread = not yet acknowledged.
+- **Message:** ` + "`send_message({ as, to, type: \"notification\"|\"question\", subject, content })`" + `.
+- **Tasks:** ` + "`dispatch_task`" + ` → ` + "`claim_task`" + ` → ` + "`start_task`" + ` → ` + "`review_task`" + `
+  (PR-up) → ` + "`complete_task`" + `; ` + "`block_task`" + ` / ` + "`resume_task`" + ` / ` + "`cancel_task`" + `
+  for the rest. ` + "`list_tasks`" + ` to see the board.
+- **Memory:** ` + "`set_memory`" + ` / ` + "`search_memory`" + ` / ` + "`get_memory`" + ` — scoped
+  (` + "`agent`" + ` / ` + "`project`" + `) shared knowledge that rides along in ` + "`get_session_context()`" + `.
+- **Context:** ` + "`get_session_context()`" + ` returns your profile, memories, pending
+  tasks, and unread messages in one call — read it first on boot.
+
+## 6. Stand up a multi-agent project
+
+` + "`create_project({ name, cwd })`" + ` returns an onboarding plan you execute: wire
+hooks, learn the relay, analyze the codebase, store memories, create the org
+(teams / profiles / a CTO agent), set up the board, and spawn worker agents.
+Follow it step by step.
+
+## Honesty rails
+
+- Self-hosted only. Never tell the user to "sign up" or point at a hosted /
+  managed service — there is none.
+- One binary, one SQLite file, no required external services. The web UI is
+  embedded; an optional Linear mirror exists but is off by default.
+- The activity stream is ephemeral (in-memory, served over SSE); messages,
+  tasks, and memory are the durable state.
+`
+
+// RunSkill installs or inspects the public end-user Claude Code skill.
+//
+//	agent-relay skill install   write the skill → ~/.claude/skills/agent-relay/SKILL.md
+//	agent-relay skill status    show whether it's installed
+func RunSkill(args []string) {
+	sub := "status"
+	if len(args) > 0 {
+		sub = args[0]
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "cannot find home dir: %v\n", err)
+		os.Exit(1)
+	}
+	skillPath := filepath.Join(home, ".claude", "skills", PublicSkillName, "SKILL.md")
+
+	switch sub {
+	case "install":
+		if err := InstallPublicSkill(home); err != nil {
+			fmt.Fprintf(os.Stderr, "install skill: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Printf("✓ installed /%s skill → %s\n", PublicSkillName, skillPath)
+	case "status":
+		if _, err := os.Stat(skillPath); err == nil {
+			fmt.Printf("✓ skill installed → %s\n", skillPath)
+		} else {
+			fmt.Printf("✗ skill not installed (run `agent-relay skill install`)\n")
+		}
+	default:
+		fmt.Println("usage: agent-relay skill [install|status]")
+		os.Exit(1)
+	}
+}
+
+// InstallPublicSkill writes the bundled public skill to
+// ~/.claude/skills/agent-relay/SKILL.md (idempotent — the const is the single
+// source of truth, so a re-run/refresh just rewrites the canonical copy).
+// Exposed so `init` and the auto-updater can refresh the skill alongside hooks.
+func InstallPublicSkill(home string) error {
+	dir := filepath.Join(home, ".claude", "skills", PublicSkillName)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(PublicSkillMD), 0o644)
+}

--- a/internal/cli/skill_test.go
+++ b/internal/cli/skill_test.go
@@ -1,0 +1,56 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestInstallPublicSkill(t *testing.T) {
+	home := t.TempDir()
+	if err := InstallPublicSkill(home); err != nil {
+		t.Fatalf("InstallPublicSkill: %v", err)
+	}
+
+	path := filepath.Join(home, ".claude", "skills", PublicSkillName, "SKILL.md")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("skill not written to %s: %v", path, err)
+	}
+	got := string(data)
+
+	// Valid SKILL.md frontmatter with the public skill name.
+	if !strings.HasPrefix(got, "---\nname: "+PublicSkillName+"\n") {
+		t.Errorf("missing/!valid frontmatter; head=%q", got[:min(60, len(got))])
+	}
+	if !strings.Contains(got, "description:") {
+		t.Error("frontmatter missing description (skills activate on it)")
+	}
+
+	// Teaches real setup + usage, not just prose.
+	for _, want := range []string{"agent-relay hooks install", "register_agent", "get_inbox", "self-hosted"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("skill should mention %q", want)
+		}
+	}
+
+	// Idempotent re-run.
+	if err := InstallPublicSkill(home); err != nil {
+		t.Fatalf("re-run InstallPublicSkill: %v", err)
+	}
+}
+
+// TestPublicSkillNoPrivateLeak guards the public/AGPL split: the shipped skill
+// must not carry private fleet/persona/internal references.
+func TestPublicSkillNoPrivateLeak(t *testing.T) {
+	lower := strings.ToLower(PublicSkillMD)
+	for _, bad := range []string{
+		"trovex-growth", "wraith-dev", "copy-gate", "release-cto",
+		"tsukumohq/skills", "linear_routing", "loicmancino", "helios-code",
+	} {
+		if strings.Contains(lower, bad) {
+			t.Errorf("public skill leaks private reference %q", bad)
+		}
+	}
+}

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -395,6 +395,11 @@ func refreshSkillAndHooks(version string) {
 		}
 	}
 
+	// Public end-user skill → ~/.claude/skills/agent-relay/SKILL.md. Baked into
+	// the binary (const), so refresh it from there — no download, always current
+	// with the just-installed binary.
+	pubSkillOK := InstallPublicSkill(home) == nil
+
 	// Activity hooks → ~/.claude/hooks/ (executable)
 	hooksDir := filepath.Join(home, ".claude", "hooks")
 	_ = os.MkdirAll(hooksDir, 0o755)
@@ -420,7 +425,11 @@ func refreshSkillAndHooks(version string) {
 		settingsPath := filepath.Join(home, ".claude", "settings.json")
 		wired, _ = mergeHookSettings(hooksDir, settingsPath)
 	}
-	fmt.Printf("skill %d/2, hooks %d/%d (wired %d new)\n", skillOK, hookOK, len(hooks), wired)
+	pubStr := "ok"
+	if !pubSkillOK {
+		pubStr = "fail"
+	}
+	fmt.Printf("skill %d/2 (public %s), hooks %d/%d (wired %d new)\n", skillOK, pubStr, hookOK, len(hooks), wired)
 }
 
 // verifyChecksum compares the SHA-256 of file against the entry for name in a

--- a/main.go
+++ b/main.go
@@ -53,6 +53,9 @@ func main() {
 		case "hooks":
 			cli.RunHooks(hookScripts, os.Args[2:])
 			return
+		case "skill":
+			cli.RunSkill(os.Args[2:])
+			return
 		case "init", "update", "status", "agents", "inbox", "send", "thread", "stats", "conversations", "memories":
 			cli.Run(os.Args[1:])
 			return


### PR DESCRIPTION
Item 1 of cto's TSU-223 follow-up queue — the **public skill half** of the activation gate.

## Why
The installer landed only the `/relay` slash command (`~/.claude/commands/relay.md`). There was **no auto-activating skill** at `~/.claude/skills/` — so a fresh Claude Code session was never taught how to drive relay setup/usage. That's the "skills not copied" complaint.

## What (mirrors yoru's shipped-skill model — a template the CLI writes verbatim, #148)
- **`internal/cli/skill.go`** — `PublicSkillMD` const (public, AGPL-split-safe: **no** fleet/persona/private refs) + `agent-relay skill install|status`, writing `~/.claude/skills/agent-relay/SKILL.md`. The binary is the single source of truth for the body.
- **`main.go`** — dispatch the `skill` command.
- **`install.sh`** — step 4 lands the skill via the just-installed binary (`<bin> skill install`); the verify step asserts `~/.claude/skills/agent-relay/SKILL.md`.
- **`agent-relay init`** writes the skill too; the **auto-updater** refreshes it from the baked-in const alongside `/relay` docs + hooks.

The skill teaches: install → `hooks install` → `init`/`/mcp` → `whoami`/`register_agent` (cwd!) → inbox/send/tasks/memory → `create_project`, with honesty rails (self-hosted only, single binary + sqlite, optional Linear).

## Public/AGPL split
`PublicSkillMD` is the PUBLIC user skill — distinct from the private `wraith-dev` persona and the `/relay` command. A guard test (`TestPublicSkillNoPrivateLeak`) fails the build if it ever grows a `trovex-growth`/`wraith-dev`/`copy-gate`/`TsukumoHQ/skills`/etc reference.

## Proof (clean isolated HOME, prod untouched)
- `agent-relay skill install` → lands `SKILL.md` (valid `name: agent-relay` frontmatter), `skill status` reports it, idempotent re-run OK.
- install.sh end-to-end (binary carrying `skill`) → `✓ Installed agent-relay skill …` + verify `✓ Skill: agent-relay skill installed`, file present.
- Note: a from-`main` clean build warns until this merges (the cloned binary lacks `skill` pre-merge) — by design; post-merge the built binary has it.

## Gate
`go build/vet/test -tags fts5 ./...` green; `gofmt` clean; `bash -n install.sh` OK.

## review-wraith verdict: SHIP
Scope: internal/cli/{skill.go,skill_test.go,init.go,update.go}, main.go, install.sh. New `skill` CLI command + install/update/init wiring; no DB/messaging/dispatch/auth/MCP-tool surface touched. BLOCKERS: none.

Follow-up (item 1b): install-smoke clean-room container vs dokan's install-smoke CONTRACT.md+assert.sh — separate CI artifact, next PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)