### PR TITLE
feat(install-smoke): clean-room install gate for wrai.th (TSU-224)

### DIFF
--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -124,3 +124,18 @@ jobs:
           sleep 2
           curl -sf http://localhost:8090/api/projects | grep -q '\[' && echo "FTS5 OK" || echo "FTS5 FAIL"
           kill %1 2>/dev/null || true
+
+  # TSU-224 suite install-smoke contract: a bare-image clean room that runs the
+  # documented install and asserts (via the shared install-smoke/assert.sh) that
+  # the binary, the public Claude Code skill, and the hooks actually landed, and
+  # that a re-run is idempotent. Gated to AFTER a Release (and manual dispatch):
+  # the installer downloads the shipped binary, so the skill subcommand must be
+  # in a published release for this to be green — a red build BLOCKS the release.
+  install-smoke:
+    name: Install smoke (clean room)
+    if: ${{ (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') || github.event_name == 'workflow_dispatch' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Build clean-room install smoke
+        run: docker build -f install-smoke/wraith.Dockerfile -t wraith-install-smoke .

--- a/install-smoke/assert.sh
+++ b/install-smoke/assert.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+# Shared install-smoke assertion — the SAME contract every suite tool's clean room runs
+# (trovex / yoru / dokan / wraith). A per-tool Dockerfile installs the tool from its one
+# documented command, then COPYs + runs this with the tool's parameters. Identical asserts
+# across all four keep the gate honest. See CONTRACT.md.
+#
+# Parameters (env):
+#   TOOL          tool name, for messages (required)
+#   TOOL_BIN      CLI command that must be on PATH (required)
+#   VERSION_FLAG  flag that prints version/help and exits 0 (default: --version)
+#   SKILL_FILE    a file that MUST exist after install — the Claude Code skill landing proof
+#                 (e.g. $HOME/.claude/skills/<tool>/SKILL.md). Required.
+#   HOOKS_FILE    optional: a settings.json that must exist (tool ships hooks)
+#   HOOKS_GREP    optional: a string that must appear in HOOKS_FILE (the hook registration)
+#
+# Exit 0 = all asserts pass. Any failure = non-zero + a one-line reason. No tool-specific logic.
+set -eu
+fail() { echo "ASSERT FAIL [$TOOL]: $1" >&2; exit 1; }
+: "${TOOL:?TOOL required}"; : "${TOOL_BIN:?TOOL_BIN required}"; : "${SKILL_FILE:?SKILL_FILE required}"
+VERSION_FLAG="${VERSION_FLAG:---version}"
+
+echo "[$TOOL] 1/4 CLI on PATH"
+command -v "$TOOL_BIN" >/dev/null 2>&1 || fail "$TOOL_BIN not on PATH after install"
+
+echo "[$TOOL] 2/4 $TOOL_BIN $VERSION_FLAG exits 0"
+"$TOOL_BIN" $VERSION_FLAG >/dev/null 2>&1 || fail "$TOOL_BIN $VERSION_FLAG did not exit 0"
+
+echo "[$TOOL] 3/4 Claude Code skill landed ($SKILL_FILE)"
+[ -f "$SKILL_FILE" ] || fail "skill file missing: $SKILL_FILE (Claude Code would not load the operator skill)"
+
+if [ -n "${HOOKS_FILE:-}" ]; then
+  echo "[$TOOL] 4/4 hooks registered ($HOOKS_FILE)"
+  [ -f "$HOOKS_FILE" ] || fail "hooks settings file missing: $HOOKS_FILE"
+  if [ -n "${HOOKS_GREP:-}" ]; then
+    grep -q "$HOOKS_GREP" "$HOOKS_FILE" || fail "hook not registered in $HOOKS_FILE (no match for: $HOOKS_GREP)"
+  fi
+else
+  echo "[$TOOL] 4/4 hooks — n/a (tool ships no hooks)"
+fi
+
+echo "ASSERT OK [$TOOL]"

--- a/install-smoke/wraith.Dockerfile
+++ b/install-smoke/wraith.Dockerfile
@@ -1,0 +1,48 @@
+# Clean-room install smoke for wrai.th / agent-relay (Linux / x86_64).
+#
+# Proves the documented one-command install lands the binary + the public Claude
+# Code skill + the activity hooks with ZERO errors on a bare image, and that
+# re-running is idempotent. This is the Linux clean-install signal that catches
+# "skills/hooks didn't land / install errored" — most of the 3h-to-run pain
+# (TSU-223 / the TSU-224 suite contract).
+#
+#   docker build -f install-smoke/wraith.Dockerfile -t wraith-install-smoke .
+#
+# A successful build == the gate is green. CI: build on every release tag; a red
+# install BLOCKS the release.
+#
+# Note: the installer downloads the prebuilt release binary, so the public skill
+# (`agent-relay skill install`) lands only once a release ships that subcommand —
+# this gate goes green on the first release carrying it (same release-gated shape
+# as dokan's). The relay's runtime service needs systemd, which a bare build
+# container lacks; `--no-service` keeps the install to "binary + skill + hooks"
+# (the install-time artifacts this contract asserts). The service-up + health
+# path is covered separately.
+FROM ubuntu:24.04
+ENV DEBIAN_FRONTEND=noninteractive HOME=/root
+
+# Documented prereqs only, plus curl + CA certs to fetch. No Go toolchain → the
+# installer takes the prebuilt-download path (the realistic end-user path). jq +
+# python3 are the installer's documented deps (hook + .mcp.json handling).
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends curl ca-certificates jq python3 \
+ && rm -rf /var/lib/apt/lists/*
+
+# Run the install from THIS repo's installer (so the gate tests the current
+# install.sh). --no-service: no systemd in a build container; the contract
+# asserts the install-time artifacts (CLI / skill / hooks), not a running relay.
+COPY install.sh /opt/wraith/install.sh
+COPY install-smoke/assert.sh /assert.sh
+RUN bash /opt/wraith/install.sh --no-service --skip-projects
+
+# Idempotency: a second run must not error or clobber.
+RUN bash /opt/wraith/install.sh --no-service --skip-projects
+
+# Shared assert contract (TSU-224). wrai.th ships activity hooks, so HOOKS_* are
+# set: settings.json must reference the relay's stop hook.
+ENV PATH="/root/.local/bin:${PATH}"
+RUN TOOL=wraith TOOL_BIN=agent-relay \
+    SKILL_FILE=/root/.claude/skills/agent-relay/SKILL.md \
+    HOOKS_FILE=/root/.claude/settings.json HOOKS_GREP=ingest-stop.sh \
+    sh /assert.sh \
+ && echo "INSTALL-SMOKE OK"


### PR DESCRIPTION
Item 1b of cto's TSU-223 queue — the wraith lane's clean-room install smoke against the TSU-224 suite contract.

## What
- **`install-smoke/assert.sh`** — the shared cross-tool assertion, verbatim from the contract (CLI on PATH, `--version` exits 0, the Claude Code skill landed, hooks registered). Identical across trovex/yoru/dokan/wraith keeps the gate honest.
- **`install-smoke/wraith.Dockerfile`** — bare `ubuntu:24.04`, documented prereqs only (curl/ca-certs/jq/python3, **no Go** → realistic prebuilt-download path). Runs the installer, runs it **again** (idempotency), then asserts: `agent-relay` on PATH, `~/.claude/skills/agent-relay/SKILL.md` present, `ingest-stop.sh` registered in `settings.json`.
- **`test-install.yml`** — an `install-smoke` job building the Dockerfile, **gated to after a successful Release + `workflow_dispatch`** (a red build blocks the release, per the contract).

## Dependency / why it's release-gated
The installer downloads the **shipped** binary, so `agent-relay skill install` must be in a published release for the skill assert to pass. So:
1. Merge #133 (public skill) →
2. cut a release →
3. this gate goes green on that release.
Pre-release it is not run (not wired to PR/push) — same release-gated shape as dokan's. This is intentional: the gate validates the real user artifact, not a local build.

## Validated
`assert.sh` `sh -n` clean; workflow YAML parses. Docker build itself runs in CI (Docker is not installed on the dev host — the gate's natural home is CI anyway).

## review-wraith verdict: SHIP
Scope: install-smoke/ (new) + test-install.yml (one gated job). No Go/DB/relay-runtime surface touched. BLOCKERS: none. Note: touches `.github/workflows/` — merge needs a maintainer with `workflow` scope.

Follow-up: the contract also wants a per-tool **dokan dogfood script** (deterministic receipt) — separate, not blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)