### PR TITLE
fix(linear): stop reconcile resurrecting terminal mirror tasks — phantom-stale (TSU-159)

### DIFF
--- a/internal/connector/linear/linear.go
+++ b/internal/connector/linear/linear.go
@@ -153,6 +153,19 @@ func looksLikeBlocked(name string) bool {
 	return strings.Contains(strings.ToLower(name), "block")
 }
 
+// isTerminalOrActive reports whether a relay mirror's current status means the
+// reconcile poll must NOT (re-)dispatch it: already in-progress (would double
+// claim+start) or terminal (done/cancelled — resurrecting it is the phantom-
+// stale bug). Other statuses (pending/accepted/blocked) remain dispatchable.
+func isTerminalOrActive(status string) bool {
+	switch status {
+	case "in-progress", "done", "cancelled":
+		return true
+	default:
+		return false
+	}
+}
+
 // Warmup fetches the viewer id (anti-loop) and the team's workflow states. It is
 // best-effort: failures are logged and retried lazily on first use. Safe to call
 // from a startup goroutine.

--- a/internal/connector/linear/linear_test.go
+++ b/internal/connector/linear/linear_test.go
@@ -580,3 +580,70 @@ func writeData(w http.ResponseWriter, data string) {
 	w.Header().Set("Content-Type", "application/json")
 	_, _ = w.Write([]byte(`{"data":` + data + `}`))
 }
+
+func TestIsTerminalOrActive(t *testing.T) {
+	for _, s := range []string{"in-progress", "done", "cancelled"} {
+		if !isTerminalOrActive(s) {
+			t.Errorf("isTerminalOrActive(%q) = false, want true (must not re-dispatch)", s)
+		}
+	}
+	for _, s := range []string{"pending", "accepted", "blocked", ""} {
+		if isTerminalOrActive(s) {
+			t.Errorf("isTerminalOrActive(%q) = true, want false (still dispatchable)", s)
+		}
+	}
+}
+
+// TestReconcileNoResurrectTerminal guards the phantom-stale fix: once a mirror
+// task is completed in the relay, a reconcile poll that still sees the Linear
+// issue in a started state (its PR wasn't auto-closed) must NOT re-dispatch it.
+func TestReconcileNoResurrectTerminal(t *testing.T) {
+	database := newTestDB(t)
+	c := newTestConn(t, database)
+
+	var dispatched []string
+	c.SetEventSink(func(e connector.TaskEvent) {
+		if e.Type == "task.dispatched" {
+			dispatched = append(dispatched, e.Agent)
+		}
+	})
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(readQuery(r), "TeamOpenIssues") {
+			writeData(w, `{"issues":{"pageInfo":{"hasNextPage":false,"endCursor":""},"nodes":[
+				{"id":"i-term","identifier":"TSU-98","number":98,"title":"merged work","priority":1,"url":"u1","state":{"id":"s1","name":"In Progress","type":"started"},"assignee":{"id":"u1","name":"analytics-lead","displayName":"analytics-lead"},"project":{"id":"proj-growth","name":"growth"},"labels":{"nodes":[]}}
+			]}}`)
+			return
+		}
+		writeData(w, `{}`)
+	}))
+	defer srv.Close()
+	c.gql.url = srv.URL
+
+	// First poll: dispatches once, mirror is created in-progress.
+	if _, err := c.ReconcileCycle(c.project); err != nil {
+		t.Fatalf("ReconcileCycle #1: %v", err)
+	}
+	if len(dispatched) != 1 {
+		t.Fatalf("first poll dispatched = %v, want 1", dispatched)
+	}
+
+	// Agent finishes the work → relay task done (the Linear issue still lags in
+	// the started state).
+	task, _ := database.GetTaskByLinearIssueID(c.project, "i-term")
+	if task == nil {
+		t.Fatal("mirror task not created")
+	}
+	if _, err := database.CompleteTask(task.ID, "analytics-lead", c.project, nil); err != nil {
+		t.Fatalf("CompleteTask: %v", err)
+	}
+
+	// Second poll: the issue is STILL started, but the mirror is terminal — it
+	// must NOT be resurrected (this was the phantom claim+start re-fire).
+	if _, err := c.ReconcileCycle(c.project); err != nil {
+		t.Fatalf("ReconcileCycle #2: %v", err)
+	}
+	if len(dispatched) != 1 {
+		t.Errorf("after completion, dispatched = %v, want still 1 (no resurrection)", dispatched)
+	}
+}

--- a/internal/connector/linear/reconcile.go
+++ b/internal/connector/linear/reconcile.go
@@ -65,9 +65,18 @@ func (c *Connector) ReconcileCycle(_ string) (int, error) {
 		// Dispatch on a genuine transition into a working "started" state (the
 		// agent target is already confirmed by the scope gate above; first sight
 		// in-progress counts: boot-time pickup).
+		//
+		// NEVER re-dispatch a mirror that's already in-progress (avoid a double
+		// claim+start) OR already TERMINAL (done/cancelled). The latter is the
+		// phantom-stale resurrection: an agent completes the relay task, but the
+		// Linear issue lags in a started state (its PR wasn't auto-closed), so
+		// every reconcile poll would otherwise re-fire claim+start on work that's
+		// done. The webhook path is safe (it gates on a real state change); the
+		// poll has no such signal, so it must not resurrect a terminal task. A
+		// genuine reopen arrives via the webhook with an actual state transition.
 		if c.onEvent != nil &&
 			iss.State != nil && iss.State.Type == "started" && !looksLikeReview(iss.State.Name) &&
-			(prior == nil || prior.Status != "in-progress") {
+			(prior == nil || !isTerminalOrActive(prior.Status)) {
 			c.onEvent(c.dispatchEvent(taskID, iss.Title, target, seed))
 		}
 	}


### PR DESCRIPTION
Item 2 of the activation queue, the **real phantom-stale fix** on the poll path.

## Root cause
Reconcile dispatches a started-state issue when `prior == nil || prior.Status != "in-progress"`. That guard only blocks an *already-in-progress* mirror — not a **terminal** one. So after an agent completes the relay task, **every reconcile poll** that still sees the Linear issue in a started state (its PR wasn't auto-closed by Linear's GitHub integration — branch not named with the issue id) **re-fires `claim+start`** on work that's already done. That's the phantom `claim+start` re-dispatch we keep seeing (e.g. TSU-223 re-firing after its PRs merged).

The webhook path is safe — it gates on a real `updatedFrom` state change. The **poll has no such signal**, so it must not resurrect a terminal task.

## Fix
Guard the poll dispatch with `isTerminalOrActive(prior.Status)`: skip when the mirror is `in-progress` (avoid double claim+start — the existing intent) **or** `done`/`cancelled` (the new phantom-stale guard). `pending`/`accepted`/`blocked` remain dispatchable. A genuine reopen still dispatches via the webhook with an actual transition.

## Tests
- `TestReconcileNoResurrectTerminal` — complete a mirror, poll again with the issue still started → **no** second dispatch.
- `TestIsTerminalOrActive` — predicate unit test.
Existing reconcile dispatch tests still pass.

## Scope notes for cto
- This kills the phantom **re-dispatch**. The phantom **stale alert** also needs the **stale-scanner threshold 3h→12h** — but that scanner is **not in WRAI.TH** (the relay only *consumes* `event:task-stale`; nothing in-repo emits it). It lives in the external scanner job — point me at it / it's ops-owned.
- This does not change the documented split-ownership (no new relay→Linear Done writeback). If TSU-159 also wants the relay to push Done to Linear on `complete_task` so issues close when the PR isn't auto-linked, that's a separate change to the deliberate "Linear's GH integration owns merge→Done" decision — confirm and I'll do it.

## review-wraith verdict: SHIP
Scope: internal/connector/linear/{reconcile.go,linear.go,linear_test.go}. Build/vet/test `-tags fts5` green; gofmt clean. Guarded conditional, no schema/DB-write change, no double-dispatch risk (strictly *removes* spurious dispatches). BLOCKERS: none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)