### PR TITLE
feat(relay): lead-machine autonomy notification rules (TSU-146)

### DIFF
--- a/internal/relay/notifications.go
+++ b/internal/relay/notifications.go
@@ -56,6 +56,7 @@ func NewNotifier(database *db.DB, registry *SessionRegistry, events *EventBus) *
 		digestLastFired: make(map[string]time.Time),
 	}
 	n.seedDefaults()
+	n.ensureAutonomyRules()
 	return n
 }
 
@@ -519,6 +520,13 @@ func (n *Notifier) resolveTargets(project, target string, payload map[string]any
 			return []string{d}
 		}
 		return nil
+	case "owner", "owner_of_record":
+		// the owner-of-record carried on the event payload — the lead-machine's
+		// re-nudge target for a stale deal/commitment (donna sets payload.owner).
+		if o := strVal(payload["owner"]); o != "" {
+			return []string{o}
+		}
+		return nil
 	}
 	// Role match (cto / cxx / lead / etc.): any agent whose role equals target.
 	if role := matchByRole(n.db, project, target); len(role) > 0 {
@@ -829,4 +837,82 @@ func (n *Notifier) seedDefaults() {
 		}
 	}
 	log.Printf("notifier: seeded %d default notification rules", len(defaults))
+}
+
+// lead-machine autonomy event names (TSU-146). donna's lead pipeline emits these
+// via POST /api/notification-events {name, project, agent, payload}; the relay
+// turns them into the messages that keep the machine turning without a human
+// poke. Payload contract: every event carries "line" (human summary);
+// deal-stale also carries "owner" (owner-of-record to re-nudge).
+const (
+	EvLeadNew    = "event:lead-new"
+	EvDealStale  = "event:deal-stale"
+	EvReviewAged = "event:review-aged"
+)
+
+// ensureAutonomyRules installs the lead-machine autonomy triggers (TSU-146)
+// idempotently BY NAME. Unlike seedDefaults (first-run only, when the table is
+// empty), this runs every startup so the rules land on an already-seeded prod
+// relay — but it never duplicates a rule a prior run created, and never touches
+// a rule an operator has since edited or disabled. New rules only.
+func (n *Notifier) ensureAutonomyRules() {
+	want := []models.NotificationRule{
+		{
+			// new lead captured → P0 to donna (the COO drives the follow-up).
+			Name:   "New lead → donna (P0)",
+			Event:  EvLeadNew,
+			Match:  `{}`,
+			Action: "message",
+			Target: "donna",
+			Opts:   `{"priority":"P0","ttl":86400,"template":"🆕 new lead: {line}"}`,
+		},
+		{
+			// deal/commitment stale past SLA → re-nudge the owner-of-record
+			// (carried on payload.owner; resolved by the "owner" target).
+			Name:   "Stale deal → owner re-nudge (P1)",
+			Event:  EvDealStale,
+			Match:  `{}`,
+			Action: "message",
+			Target: "owner",
+			Opts:   `{"priority":"P1","ttl":86400,"template":"⏳ stale deal — re-nudge: {line}"}`,
+		},
+		{
+			// review card aged past SLA → escalate to cto (process signal → cto,
+			// per the owner rule; cto carries it to the human if needed).
+			Name:   "Review aged → cto escalate (P1)",
+			Event:  EvReviewAged,
+			Match:  `{}`,
+			Action: "message",
+			Target: "cto",
+			Opts:   `{"priority":"P1","ttl":86400,"template":"🔎 review aged — escalating: {line}"}`,
+		},
+	}
+
+	existing, err := n.db.ListNotificationRules("default")
+	if err != nil {
+		log.Printf("notifier: ensure autonomy rules: list: %v", err)
+		return
+	}
+	have := make(map[string]bool, len(existing))
+	for _, r := range existing {
+		have[r.Name] = true
+	}
+
+	added := 0
+	for i := range want {
+		if have[want[i].Name] {
+			continue // already present (or operator-edited) — leave it alone
+		}
+		r := want[i]
+		r.Enabled = true
+		r.Project = "default" // fires across all event projects (see evaluator)
+		if _, err := n.db.CreateNotificationRule(&r); err != nil {
+			log.Printf("notifier: ensure autonomy rule %q: %v", r.Name, err)
+			continue
+		}
+		added++
+	}
+	if added > 0 {
+		log.Printf("notifier: ensured %d lead-machine autonomy rule(s)", added)
+	}
 }

--- a/internal/relay/notifications_autonomy_test.go
+++ b/internal/relay/notifications_autonomy_test.go
@@ -1,0 +1,84 @@
+package relay
+
+import (
+	"path/filepath"
+	"testing"
+
+	"agent-relay/internal/db"
+)
+
+func newAutonomyTestDB(t *testing.T) *db.DB {
+	t.Helper()
+	database, err := db.NewTestDB(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("create test db: %v", err)
+	}
+	t.Cleanup(func() { _ = database.Close() })
+	return database
+}
+
+// TestResolveOwnerTarget covers the lead-machine "owner-of-record" target used
+// by the stale-deal re-nudge rule (TSU-146).
+func TestResolveOwnerTarget(t *testing.T) {
+	n := &Notifier{db: newAutonomyTestDB(t)}
+
+	got := n.resolveTargets("default", "owner", map[string]any{"owner": "loic"})
+	if len(got) != 1 || got[0] != "loic" {
+		t.Fatalf("owner target: want [loic], got %v", got)
+	}
+	if got := n.resolveTargets("default", "owner", map[string]any{}); got != nil {
+		t.Fatalf("owner target with no payload.owner: want nil, got %v", got)
+	}
+}
+
+// TestEnsureAutonomyRulesIdempotent verifies the rules land on an already-seeded
+// table and that re-running never duplicates them (the prod-relay path, where
+// seedDefaults is a no-op because the table is non-empty).
+func TestEnsureAutonomyRulesIdempotent(t *testing.T) {
+	database := newAutonomyTestDB(t)
+	n := &Notifier{db: database}
+
+	names := map[string]bool{
+		"New lead → donna (P0)":            true,
+		"Stale deal → owner re-nudge (P1)": true,
+		"Review aged → cto escalate (P1)":  true,
+	}
+
+	count := func() map[string]int {
+		rules, err := database.ListNotificationRules("default")
+		if err != nil {
+			t.Fatalf("list rules: %v", err)
+		}
+		seen := map[string]int{}
+		for _, r := range rules {
+			if names[r.Name] {
+				seen[r.Name]++
+			}
+		}
+		return seen
+	}
+
+	n.ensureAutonomyRules()
+	n.ensureAutonomyRules() // idempotent: a second pass must add nothing
+
+	seen := count()
+	if len(seen) != len(names) {
+		t.Fatalf("want %d autonomy rules present, got %d: %v", len(names), len(seen), seen)
+	}
+	for name, c := range seen {
+		if c != 1 {
+			t.Errorf("rule %q present %d times, want exactly 1 (idempotency broken)", name, c)
+		}
+	}
+
+	// Each must be enabled and target the right recipient.
+	rules, _ := database.ListNotificationRules("default")
+	for _, r := range rules {
+		if !names[r.Name] {
+			continue
+		}
+		if !r.Enabled {
+			t.Errorf("autonomy rule %q seeded disabled", r.Name)
+		}
+	}
+}


### PR DESCRIPTION
The relay half of donna's lead-machine — data-driven notification rules that keep the machine turning without a human poke.

## Rules added
| Event | Action | Target | Priority |
|---|---|---|---|
| `event:lead-new` | message | **donna** | P0 |
| `event:deal-stale` | message | **owner-of-record** (`payload.owner`) | P1 |
| `event:review-aged` | message | **cto** (escalate) | P1 |

## Contract for donna's pipeline
Emit via the existing endpoint:
```
POST /api/notification-events
{ "name": "lead-new" | "deal-stale" | "review-aged",
  "project": "...", "agent": "donna",
  "payload": { "line": "<human summary>", "owner": "<owner-of-record, deal-stale only>" } }
```
- Every payload carries **`line`** (the human summary used by the `{line}` template).
- `deal-stale` also carries **`owner`** — the owner-of-record to re-nudge. Added an `owner` target that resolves `payload.owner`.

## Idempotency (the prod-relay subtlety)
`seedDefaults` only runs on an **empty** table — prod already has rules, so new defaults never appear there. So these install via `ensureAutonomyRules()`, which runs **every startup** and creates each rule **by name only when absent**: lands on an already-seeded prod relay, never duplicates across restarts, never touches a rule an operator later edits/disables. Rules are project `default` so they fire across all event projects (per the evaluator's project filter).

## Tests
- `TestResolveOwnerTarget` — the new `owner` target.
- `TestEnsureAutonomyRulesIdempotent` — rules land once, a second pass adds nothing, all enabled.
Full suite green `-tags fts5`; gofmt clean.

## review-wraith verdict: SHIP
Scope: internal/relay/notifications.go (+ owner target, + ensureAutonomyRules) + test. Pure rules-engine config + one target resolver case; no schema/DB-write/dispatch/auth change. Idempotent ensure, no duplicate fires. No release (prod carries it at the supervised cut). BLOCKERS: none.

Note: rules fire only once donna emits the events — coordinate the event names with the donna lane (contract above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)