### PR TITLE
feat(metrics): dead-lettered event count in /api/metrics (TSU-147)

### DIFF
--- a/internal/db/stats.go
+++ b/internal/db/stats.go
@@ -113,6 +113,11 @@ type OpsMetrics struct {
 	TasksOpen                int64 `json:"tasks_open"`
 	AuditLogRows             int64 `json:"audit_log_rows"`
 	MemoriesRows             int64 `json:"memories_rows"`
+	// EventsDeadLettered counts notification/dispatch events the durable outbox
+	// gave up on after the retry cap (failEvent → MarkEventDead stamps a "DLQ:"
+	// last_error). A non-zero / growing value = deliveries are being dropped —
+	// the CTO-visible "no silent drops" gauge (TSU-147).
+	EventsDeadLettered int64 `json:"events_dead_lettered"`
 }
 
 // MetricsSnapshot returns a one-shot OpsMetrics. Best-effort: a failing count
@@ -138,5 +143,6 @@ func (d *DB) MetricsSnapshot() OpsMetrics {
 	scan(&m.TasksOpen, `SELECT COUNT(*) FROM tasks WHERE status NOT IN ('done', 'cancelled')`)
 	scan(&m.AuditLogRows, `SELECT COUNT(*) FROM audit_log`)
 	scan(&m.MemoriesRows, `SELECT COUNT(*) FROM memories`)
+	scan(&m.EventsDeadLettered, `SELECT COUNT(*) FROM events WHERE last_error LIKE 'DLQ:%'`)
 	return m
 }

--- a/internal/db/stats_test.go
+++ b/internal/db/stats_test.go
@@ -1,0 +1,37 @@
+package db
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// TestMetricsSnapshotDeadLettered covers the TSU-147 gauge: dead-lettered
+// events (those the outbox gave up on) are counted; live/retrying ones are not.
+func TestMetricsSnapshotDeadLettered(t *testing.T) {
+	database, err := NewTestDB(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("create test db: %v", err)
+	}
+	t.Cleanup(func() { _ = database.Close() })
+
+	// One event that retries then dead-letters, one that's just retrying.
+	deadID, _, err := database.InsertEvent("", "default", "event:x", "a", `{}`)
+	if err != nil {
+		t.Fatalf("insert dead event: %v", err)
+	}
+	liveID, _, err := database.InsertEvent("", "default", "event:y", "a", `{}`)
+	if err != nil {
+		t.Fatalf("insert live event: %v", err)
+	}
+	if err := database.MarkEventDead(deadID, "DLQ: all matched rules failed"); err != nil {
+		t.Fatalf("mark dead: %v", err)
+	}
+	if err := database.IncrementEventAttempt(liveID, "transient"); err != nil {
+		t.Fatalf("increment attempt: %v", err)
+	}
+
+	m := database.MetricsSnapshot()
+	if m.EventsDeadLettered != 1 {
+		t.Errorf("EventsDeadLettered = %d, want 1 (only the DLQ'd event counts)", m.EventsDeadLettered)
+	}
+}


### PR DESCRIPTION
TSU-147 (dispatch dead-letter + retry, no silent drops). The retry + dead-letter machinery **already exists** — the durable event outbox (`runSweeper`→`deliverEvent`→`failEvent`) retries failed deliveries and dead-letters them past the cap (`MarkEventDead`, `DLQ:` last_error). The missing half was the **CTO-visible count** TSU-147 asks for.

## Change
Add `EventsDeadLettered` to `OpsMetrics`/`MetricsSnapshot` (`COUNT(*) FROM events WHERE last_error LIKE 'DLQ:%'`) → `/api/metrics` now exposes a `events_dead_lettered` gauge. Growing value = deliveries dying / a task stalled unseen.

## Test
`TestMetricsSnapshotDeadLettered`: a dead-lettered event is counted; a still-retrying one is not.

## review-wraith verdict: SHIP
Scope: internal/db/stats.go (+ one field + one count) + test. Read-only count on the RO pool, best-effort scan (never 500s the scrape). No schema change, no write path. BLOCKERS: none. No release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)