### PR TITLE
feat(cost): per-day $ rollup /cost/daily (TSU-153)

### DIFF
--- a/internal/db/cost.go
+++ b/internal/db/cost.go
@@ -110,3 +110,66 @@ func (d *DB) GetCostByAgent(project, since string) ([]AgentCost, error) {
 	sort.Slice(out, func(i, j int) bool { return out[i].USD > out[j].USD })
 	return out, nil
 }
+
+// DayCost is the per-day token + dollar rollup over a window.
+type DayCost struct {
+	Day    string  `json:"day"` // YYYY-MM-DD (UTC)
+	Tokens int64   `json:"tokens"`
+	USD    float64 `json:"usd"`
+}
+
+// GetCostByDay rolls up real-token usage into $ per UTC day since a time, pricing
+// each (day, model) group at its tier — the "spend by day" half of the fleet
+// cost-model (TSU-153). Same pricing + legacy-bytes fallback as GetCostByAgent;
+// sorted oldest→newest for a timeseries chart.
+func (d *DB) GetCostByDay(project, since string) ([]DayCost, error) {
+	fallback := strings.TrimSpace(d.GetSetting("cost_default_model"))
+	if fallback == "" {
+		fallback = "opus"
+	}
+	rows, err := d.ro().Query(`
+		SELECT strftime('%Y-%m-%d', created_at) AS day, COALESCE(model, ''),
+		       SUM(input_tokens), SUM(output_tokens), SUM(cache_read_tokens), SUM(cache_creation_tokens), SUM(bytes)
+		FROM token_usage
+		WHERE project = ? AND created_at >= ?
+		GROUP BY day, model`,
+		project, since,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("cost by day: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	agg := map[string]*DayCost{}
+	for rows.Next() {
+		var day, model string
+		var in, out, cr, cc, bytes int64
+		if err := rows.Scan(&day, &model, &in, &out, &cr, &cc, &bytes); err != nil {
+			return nil, fmt.Errorf("scan cost by day: %w", err)
+		}
+		dc := agg[day]
+		if dc == nil {
+			dc = &DayCost{Day: day}
+			agg[day] = dc
+		}
+		rate := rateForModel(model, fallback)
+		if in+out+cr+cc > 0 {
+			dc.Tokens += in + out + cr + cc
+			dc.USD += costUSD(rate, in, out, cr, cc)
+		} else if bytes > 0 {
+			est := bytes / 4
+			dc.Tokens += est
+			dc.USD += costUSD(rate, est, 0, 0, 0)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	out := make([]DayCost, 0, len(agg))
+	for _, dc := range agg {
+		out = append(out, *dc)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Day < out[j].Day })
+	return out, nil
+}

--- a/internal/db/cost_test.go
+++ b/internal/db/cost_test.go
@@ -86,3 +86,40 @@ func TestGetCostByAgent_BytesFallback(t *testing.T) {
 		t.Fatalf("bytes-fallback cost = %.4f, want 5.00", costs[0].USD)
 	}
 }
+
+// TestGetCostByDay covers TSU-153 "spend by day": real-token usage rolled up to
+// $ per UTC day, priced per model tier, sorted oldest→newest.
+func TestGetCostByDay(t *testing.T) {
+	d := testDB(t)
+	const project = "p1"
+	const since = "2020-01-01T00:00:00.000000Z"
+
+	if err := d.InsertTokenUsageBatch([]TokenRecord{
+		// 2026-06-26: opus 1M output = $25
+		{Project: project, Agent: "alice", Model: "claude-opus-4-8", Output: 1_000_000, CreatedAt: "2026-06-26T09:00:00.000000Z"},
+		// 2026-06-26: sonnet 1M input = $3 (same day, different agent/model → coalesces into the day)
+		{Project: project, Agent: "bob", Model: "claude-sonnet-4-6", Input: 1_000_000, CreatedAt: "2026-06-26T20:00:00.000000Z"},
+		// 2026-06-27: sonnet 1M output = $15
+		{Project: project, Agent: "alice", Model: "claude-sonnet-4-6", Output: 1_000_000, CreatedAt: "2026-06-27T10:00:00.000000Z"},
+	}); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	days, err := d.GetCostByDay(project, since)
+	if err != nil {
+		t.Fatalf("cost by day: %v", err)
+	}
+	if len(days) != 2 {
+		t.Fatalf("want 2 day buckets, got %d: %+v", len(days), days)
+	}
+	// Ascending by day.
+	if days[0].Day != "2026-06-26" || days[1].Day != "2026-06-27" {
+		t.Fatalf("days not sorted ascending: %q, %q", days[0].Day, days[1].Day)
+	}
+	if math.Abs(days[0].USD-28.0) > 1e-6 { // $25 + $3
+		t.Fatalf("2026-06-26 cost = %.4f, want 28.00", days[0].USD)
+	}
+	if math.Abs(days[1].USD-15.0) > 1e-6 {
+		t.Fatalf("2026-06-27 cost = %.4f, want 15.00", days[1].USD)
+	}
+}

--- a/internal/relay/api.go
+++ b/internal/relay/api.go
@@ -171,6 +171,8 @@ func (r *Relay) ServeAPI(w http.ResponseWriter, req *http.Request) {
 		r.apiGetTokenTimeSeries(w, req)
 	case path == "/cost" && req.Method == http.MethodGet:
 		r.apiGetCostByAgent(w, req)
+	case path == "/cost/daily" && req.Method == http.MethodGet:
+		r.apiGetCostByDay(w, req)
 	case path == "/quotas" && req.Method == http.MethodGet:
 		r.apiListQuotas(w, req)
 	case path == "/quotas" && req.Method == http.MethodPost:
@@ -1898,6 +1900,25 @@ func (r *Relay) apiGetCostByAgent(w http.ResponseWriter, req *http.Request) {
 	}
 	if data == nil {
 		data = []db.AgentCost{}
+	}
+	writeJSON(w, data)
+}
+
+// apiGetCostByDay returns the per-day $ rollup (TSU-153 "spend by day").
+// Path: /cost/daily?project=&period=
+func (r *Relay) apiGetCostByDay(w http.ResponseWriter, req *http.Request) {
+	project := req.URL.Query().Get("project")
+	if project == "" {
+		project = "default"
+	}
+	since := db.PeriodToSince(req.URL.Query().Get("period"))
+	data, err := r.DB.GetCostByDay(project, since)
+	if err != nil {
+		apiError(w, http.StatusInternalServerError, "failed to get cost by day", err)
+		return
+	}
+	if data == nil {
+		data = []db.DayCost{}
 	}
 	writeJSON(w, data)
 }


### PR DESCRIPTION
Closes TSU-153 (fleet cost-model). Most of it already shipped under TSU-53: per-agent $ rollup (`GetCostByAgent` / `GET /cost`, sorted by $ = **top-cost agents**; per-agent = **by lane** in this fleet) + token timeseries. The one literal gap was **"spend by day" in dollars**.

## Change
- `GetCostByDay(project, since)` — group by UTC day × model, priced per tier with the same cache-aware math + legacy `bytes/4` fallback as `GetCostByAgent`, sorted oldest→newest.
- `GET /cost/daily?project=&period=`.

Together: `/cost` (by lane / top-cost) + `/cost/daily` (by day) = the CTO's fleet cost-model menu item.

## Test
`TestGetCostByDay` — two UTC days roll up to the right per-day $, ascending.

## review-wraith verdict: SHIP
Scope: internal/db/cost.go (+GetCostByDay) + one API route/handler + test. Read-only on the RO pool, same proven pricing helpers. No schema/write change. BLOCKERS: none. No release.

Note: TSU-153 was ~90% pre-built (TSU-53); this is the by-day closure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)