### PR TITLE
ci(announce): publish-gate poll 120s→12min (fix skipped release announce)

### DIFF
--- a/.github/workflows/announce-release.yml
+++ b/.github/workflows/announce-release.yml
@@ -41,14 +41,17 @@ jobs:
           # --- publish-gate: WAIT for a published, non-prerelease GitHub Release ---
           # tag-push fires this workflow BEFORE the Release object exists (race) — poll for it.
           rel=""
-          for i in $(seq 1 10); do
+          # 60×12s = 12min: a PAT-created Release object can land minutes after the
+          # tag push, and the old 10×12s (120s) gate gave up first — v1.6.0's
+          # auto-announce was SKIPPED that way. Sync'd with dokan's gate.
+          for i in $(seq 1 60); do
             rel=$(gh api "repos/${REPO}/releases/tags/${TAG}" 2>/dev/null || true)
             if [ -n "$rel" ] \
                && [ "$(printf '%s' "$rel" | jq -r '.draft')" = "false" ] \
                && [ "$(printf '%s' "$rel" | jq -r '.prerelease')" != "true" ]; then
               break
             fi
-            echo "Release for ${TAG} not published yet (attempt $i/10) — waiting 12s..." >&2
+            echo "Release for ${TAG} not published yet (attempt $i/60) — waiting 12s..." >&2
             rel=""; sleep 12
           done
           if [ -z "$rel" ]; then


### PR DESCRIPTION
cto-reported: v1.6.0's auto-announce was **skipped**. The publish-gate polled the GitHub Release object only **10×12s (120s)**, but a PAT-created Release can land minutes after the tag push — the gate gave up before it appeared and exited "no published release".

## Fix
Bump the poll to **60×12s (12min)**, matching dokan's announce gate. A slow Release object now still announces.

One-line change (`seq 1 10`→`seq 1 60` + the attempt message). YAML validated.

## review-wraith verdict: SHIP
Scope: .github/workflows/announce-release.yml (poll count only). No logic/secret change. BLOCKERS: none. Needs a maintainer with `workflow` scope to merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)