### PR TITLE
fix(relay): autonomy rule fires on event:lead-ready (match live emitter)

### DIFF
--- a/internal/relay/notifications.go
+++ b/internal/relay/notifications.go
@@ -845,7 +845,11 @@ func (n *Notifier) seedDefaults() {
 // poke. Payload contract: every event carries "line" (human summary);
 // deal-stale also carries "owner" (owner-of-record to re-nudge).
 const (
-	EvLeadNew    = "event:lead-new"
+	// EvLeadReady is the canonical event the lead pipeline emits when a lead is
+	// ready for surfacing — donna's lead-trigger emits name:"lead-ready" (verified
+	// live via the GAP3 smoke). It is NOT "lead-new": the rule must match what the
+	// emitter actually sends or the route never connects.
+	EvLeadReady  = "event:lead-ready"
 	EvDealStale  = "event:deal-stale"
 	EvReviewAged = "event:review-aged"
 )
@@ -858,13 +862,13 @@ const (
 func (n *Notifier) ensureAutonomyRules() {
 	want := []models.NotificationRule{
 		{
-			// new lead captured → P0 to donna (the COO drives the follow-up).
-			Name:   "New lead → donna (P0)",
-			Event:  EvLeadNew,
+			// lead ready for surfacing → P0 to donna (the COO drives the follow-up).
+			Name:   "Lead ready → donna (P0)",
+			Event:  EvLeadReady,
 			Match:  `{}`,
 			Action: "message",
 			Target: "donna",
-			Opts:   `{"priority":"P0","ttl":86400,"template":"🆕 new lead: {line}"}`,
+			Opts:   `{"priority":"P0","ttl":86400,"template":"🆕 lead ready: {line}"}`,
 		},
 		{
 			// deal/commitment stale past SLA → re-nudge the owner-of-record

--- a/internal/relay/notifications_autonomy_test.go
+++ b/internal/relay/notifications_autonomy_test.go
@@ -39,7 +39,7 @@ func TestEnsureAutonomyRulesIdempotent(t *testing.T) {
 	n := &Notifier{db: database}
 
 	names := map[string]bool{
-		"New lead → donna (P0)":            true,
+		"Lead ready → donna (P0)":          true,
 		"Stale deal → owner re-nudge (P1)": true,
 		"Review aged → cto escalate (P1)":  true,
 	}


### PR DESCRIPTION
cto GAP-3 catch: the lead pipeline (395) emits `name:"lead-ready"`, but the #136 autonomy rule was seeded for `event:lead-new` — a name mismatch that would never connect once it ships.

## Fix
Rename the event const + rule to `event:lead-ready` ("Lead ready → donna (P0)"). `deal-stale` / `review-aged` unchanged. Test updated.

## Live state / GAP-3 result
- The GAP-3 smoke **PASSED** — `lead-ready` → donna's notifier inbox in ~1s, payload snake_cased, targeted `agent='donna'` (confirmed by donna-dev).
- That route is live via a **manually-created** rule (`event:lead-ready→donna` on trovex-growth) — prod hasn't redeployed with `ensureAutonomyRules`, so my baked-in rule isn't live yet.
- **Heads-up:** once v1.6.1 ships this PR, `ensureAutonomyRules` seeds `event:lead-ready→donna` on project `default` (fires all projects). The manual trovex-growth rule should be **removed at deploy** or donna gets a double fire.

## review-wraith verdict: SHIP
Scope: internal/relay/notifications.go (const+rule rename) + test. No schema/logic change beyond the event name. BLOCKERS: none. No release (rides v1.6.1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)