### PR TITLE
feat(relay): federation — relay-to-relay direct messaging between peers

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"encoding/json"
 	"os"
 	"strconv"
 	"strings"
@@ -44,9 +45,29 @@ type Config struct {
 	LinearTeamKey       string        // LINEAR_TEAM_KEY: team key (e.g. SYN); reconcile + state scope
 	LinearReconcileIval time.Duration // RELAY_LINEAR_RECONCILE_INTERVAL: active-cycle poll (default 5m)
 
+	// --- Federation (relay-to-relay message forwarding) ---
+	// FederationPeers lists trusted remote relays this instance can forward DMs
+	// to and accept DMs from. Loaded from RELAY_FEDERATION_PEERS as a JSON array;
+	// each peer carries a Label (local alias, used in `agent@label` addressing), a
+	// base URL, a shared Token (peer-specific credential, NOT the global API key),
+	// and the target Project on that peer. Empty = federation off (byte-identical
+	// to today). Each peer's Token authenticates its inbound POSTs to this relay's
+	// /api/federation/inbound route independently of RELAY_API_KEY.
+	FederationPeers []FederationPeer // RELAY_FEDERATION_PEERS (JSON array)
+
 	// Version is the build tag (from main.Version). Surfaced in /api/health
 	// and MCP server info. Set by the caller before relay.New.
 	Version string
+}
+
+// FederationPeer is one trusted remote relay. Label is a local alias (the "@peer"
+// in addressing); Token is a per-peer shared secret; Project is the namespace on
+// the peer that forwarded messages land in (default "default").
+type FederationPeer struct {
+	Label   string `json:"label"`
+	URL     string `json:"url"`
+	Token   string `json:"token"`
+	Project string `json:"project"`
 }
 
 // LinearActive reports whether the Linear connector should run: mirror mode on
@@ -91,6 +112,25 @@ func Load() Config {
 
 	if v := strings.ToLower(strings.TrimSpace(os.Getenv("RELAY_REQUIRE_REGISTERED"))); v == "1" || v == "true" || v == "yes" {
 		cfg.RequireRegistered = true
+	}
+
+	// Federation peers: JSON array in RELAY_FEDERATION_PEERS. A malformed value or
+	// entries missing label/url/token are skipped (fail-open to "no such peer"),
+	// never fatal — a bad env var must not stop the relay from booting.
+	if v := strings.TrimSpace(os.Getenv("RELAY_FEDERATION_PEERS")); v != "" {
+		var peers []FederationPeer
+		if err := json.Unmarshal([]byte(v), &peers); err == nil {
+			for _, p := range peers {
+				p.Label = strings.ToLower(strings.TrimSpace(p.Label))
+				p.URL = strings.TrimSpace(p.URL)
+				p.Token = strings.TrimSpace(p.Token)
+				p.Project = strings.TrimSpace(p.Project)
+				if p.Label == "" || p.URL == "" || p.Token == "" {
+					continue
+				}
+				cfg.FederationPeers = append(cfg.FederationPeers, p)
+			}
+		}
 	}
 
 	cfg.LinearAPIKey = os.Getenv("LINEAR_API_KEY")

--- a/internal/relay/api.go
+++ b/internal/relay/api.go
@@ -67,6 +67,8 @@ func (r *Relay) ServeAPI(w http.ResponseWriter, req *http.Request) {
 		r.apiGetAllMessages(w, req)
 	case path == "/messages" && req.Method == http.MethodPost:
 		r.apiPostMessage(w, req)
+	case path == "/federation/inbound" && req.Method == http.MethodPost:
+		r.apiFederationInbound(w, req)
 	case path == "/messages/all-projects" && req.Method == http.MethodGet:
 		r.apiGetAllMessagesAllProjects(w)
 	case path == "/messages/latest-all" && req.Method == http.MethodGet:

--- a/internal/relay/federation.go
+++ b/internal/relay/federation.go
@@ -1,0 +1,265 @@
+package relay
+
+import (
+	"bytes"
+	"context"
+	"crypto/subtle"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"agent-relay/internal/config"
+
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// Federation forwards direct messages between two independent relay instances.
+//
+// Model (mirrors the same-instance sendCrossProject pattern, extended across the
+// network): each relay holds a static registry of trusted peers. A local agent
+// addresses a remote recipient as "name@peerlabel"; this relay POSTs the message
+// to that peer's /api/federation/inbound, presenting the peer's shared Token. On
+// the receiving side the token identifies the origin peer (constant-time match),
+// the message is inserted into the local DB via the normal durable path, and the
+// recipient picks it up through its unchanged deliveries-based inbox. The sender
+// is stamped as "origagent@<receiver's label for us>" so replies route back
+// symmetrically. Delivery is pull-based, so no cross-relay push is required.
+//
+// Federation is off unless at least one valid peer is configured; when off the
+// send path and inbound route behave as if the feature did not exist.
+type Federation struct {
+	peersByLabel map[string]config.FederationPeer
+	peers        []config.FederationPeer // preserves order for token matching
+	client       *http.Client
+}
+
+// fedMessage is the wire payload for a forwarded direct message. SourceRelay is
+// intentionally NOT carried here — the receiver derives the origin from the
+// presented token, so a peer cannot spoof its identity in the body.
+type fedMessage struct {
+	From     string `json:"from"`     // origin agent name on the sending relay
+	To       string `json:"to"`       // recipient agent name on the receiving relay
+	Project  string `json:"project"`  // target project namespace on the receiver
+	Type     string `json:"type"`     // message type (default "notification")
+	Subject  string `json:"subject"`  // message subject
+	Content  string `json:"content"`  // message body (required)
+	Priority string `json:"priority"` // P0..P3 (default P2)
+	TTL      int    `json:"ttl_seconds"`
+	ReplyTo  string `json:"reply_to,omitempty"`
+}
+
+// NewFederation builds the peer registry from config. Entries are pre-validated
+// by config.Load (label/url/token non-empty); this just indexes them. A nil or
+// empty peer list yields a disabled Federation (Enabled() == false).
+func NewFederation(peers []config.FederationPeer) *Federation {
+	f := &Federation{
+		peersByLabel: make(map[string]config.FederationPeer, len(peers)),
+		client:       &http.Client{Timeout: 5 * time.Second},
+	}
+	for _, p := range peers {
+		label := strings.ToLower(strings.TrimSpace(p.Label))
+		if label == "" || p.URL == "" || p.Token == "" {
+			continue
+		}
+		if _, dup := f.peersByLabel[label]; dup {
+			continue // first definition wins; ignore duplicate labels
+		}
+		f.peersByLabel[label] = p
+		f.peers = append(f.peers, p)
+	}
+	return f
+}
+
+// Enabled reports whether any peer is configured.
+func (f *Federation) Enabled() bool {
+	return f != nil && len(f.peersByLabel) > 0
+}
+
+// PeerByLabel resolves an outbound peer by its local alias.
+func (f *Federation) PeerByLabel(label string) (config.FederationPeer, bool) {
+	if f == nil {
+		return config.FederationPeer{}, false
+	}
+	p, ok := f.peersByLabel[strings.ToLower(strings.TrimSpace(label))]
+	return p, ok
+}
+
+// PeerByToken resolves the origin peer for an inbound request from its presented
+// token, using a constant-time compare against every configured token so the
+// match cost does not leak which peer (if any) a token belongs to.
+func (f *Federation) PeerByToken(token string) (config.FederationPeer, bool) {
+	if f == nil || token == "" {
+		return config.FederationPeer{}, false
+	}
+	tok := []byte(token)
+	var match config.FederationPeer
+	found := false
+	for _, p := range f.peers {
+		if subtle.ConstantTimeCompare([]byte(p.Token), tok) == 1 {
+			match = p
+			found = true
+			// no early break: keep the loop's timing independent of position
+		}
+	}
+	return match, found
+}
+
+// Forward POSTs a message to a peer relay's inbound route. Best-effort with a
+// short timeout; a non-2xx or transport error is returned to the caller so the
+// send tool can report the failure rather than silently drop.
+func (f *Federation) Forward(ctx context.Context, peer config.FederationPeer, msg fedMessage) error {
+	body, err := json.Marshal(msg)
+	if err != nil {
+		return fmt.Errorf("marshal: %w", err)
+	}
+	url := strings.TrimRight(peer.URL, "/") + "/api/federation/inbound"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Relay-Federation-Token", peer.Token)
+	resp, err := f.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		return fmt.Errorf("peer %q returned %d", peer.Label, resp.StatusCode)
+	}
+	return nil
+}
+
+// splitPeerAddr splits "name@peerlabel" into (name, label, true). It returns
+// false for any address without a single valid "@peer" suffix — broadcast ("*"),
+// "team:"/"conversation:" prefixes, or a bare name — so those keep their local
+// meaning. An empty name or label is treated as not-a-peer-address.
+func splitPeerAddr(to string) (name, label string, ok bool) {
+	at := strings.LastIndex(to, "@")
+	if at <= 0 || at == len(to)-1 {
+		return "", "", false
+	}
+	if strings.HasPrefix(to, "team:") || strings.HasPrefix(to, "conversation:") {
+		return "", "", false
+	}
+	return to[:at], to[at+1:], true
+}
+
+// sendFederated forwards a direct message to an agent on a peer relay. The reply
+// path is preserved by the receiver, which stamps the sender as
+// "<from>@<its own label for this relay>".
+func (h *Handlers) sendFederated(ctx context.Context, project, from, peerLabel, toName, msgType, subject, content, priority string, ttlSeconds int, replyTo *string) (*mcp.CallToolResult, error) {
+	peer, ok := h.federation.PeerByLabel(peerLabel)
+	if !ok {
+		return mcp.NewToolResultError(fmt.Sprintf("unknown peer relay %q — configure it in RELAY_FEDERATION_PEERS", peerLabel)), nil
+	}
+	targetProject := peer.Project
+	if targetProject == "" {
+		targetProject = "default"
+	}
+	fm := fedMessage{
+		From:     from,
+		To:       strings.ToLower(strings.TrimSpace(toName)),
+		Project:  targetProject,
+		Type:     msgType,
+		Subject:  subject,
+		Content:  content,
+		Priority: priority,
+		TTL:      ttlSeconds,
+	}
+	if replyTo != nil {
+		fm.ReplyTo = *replyTo
+	}
+	if err := h.federation.Forward(ctx, peer, fm); err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("federated send to %q failed: %v", peerLabel, err)), nil
+	}
+	h.events.Emit(MCPEvent{Type: "message", Action: "federated", Agent: from, Project: project, Target: fmt.Sprintf("%s@%s", fm.To, peerLabel), Label: subject})
+	return h.resultJSONTracked(project, from, "send_message", map[string]any{
+		"sent": "federated",
+		"to":   fmt.Sprintf("%s@%s", fm.To, peerLabel),
+		"peer": peerLabel,
+	})
+}
+
+// apiFederationInbound accepts a forwarded message from a trusted peer relay.
+// Auth is the peer's own token (X-Relay-Federation-Token), matched constant-time
+// — this route is exempt from the global RELAY_API_KEY check so peers never hold
+// the admin key. The message is inserted into the local project via the same
+// durable path as every other message and surfaces in the recipient's inbox.
+func (r *Relay) apiFederationInbound(w http.ResponseWriter, req *http.Request) {
+	if !r.Federation.Enabled() {
+		http.Error(w, `{"error":"federation not enabled"}`, http.StatusNotFound)
+		return
+	}
+	peer, ok := r.Federation.PeerByToken(req.Header.Get("X-Relay-Federation-Token"))
+	if !ok {
+		http.Error(w, `{"error":"unauthorized peer"}`, http.StatusUnauthorized)
+		return
+	}
+
+	var fm fedMessage
+	if err := json.NewDecoder(req.Body).Decode(&fm); err != nil {
+		http.Error(w, `{"error":"invalid json"}`, http.StatusBadRequest)
+		return
+	}
+	to := strings.ToLower(strings.TrimSpace(fm.To))
+	if to == "" || strings.TrimSpace(fm.Content) == "" {
+		http.Error(w, `{"error":"'to' and 'content' are required"}`, http.StatusBadRequest)
+		return
+	}
+	project := strings.TrimSpace(fm.Project)
+	if project == "" {
+		project = "default"
+	}
+
+	// The recipient must already exist locally: federation delivers to known
+	// agents only, so a compromised/misconfigured peer cannot spray messages to
+	// arbitrary phantom names (and auto-create projects) on this relay.
+	if agent, _ := r.DB.GetAgent(project, to); agent == nil {
+		http.Error(w, `{"error":"recipient not found on this relay"}`, http.StatusNotFound)
+		return
+	}
+
+	msgType := strings.TrimSpace(fm.Type)
+	if msgType == "" {
+		msgType = "notification"
+	}
+	priority := mapPriority(fm.Priority)
+	ttl := fm.TTL
+	if ttl <= 0 {
+		ttl = 14400
+	}
+	// Sender is qualified with the origin's local label so the recipient can
+	// reply straight back with `to: "<from>@<peer.Label>"`.
+	fromLabel := fmt.Sprintf("%s@%s", strings.ToLower(strings.TrimSpace(fm.From)), peer.Label)
+
+	meta := map[string]any{
+		"source_relay": peer.Label,
+		"source_agent": fm.From,
+		"federated":    true,
+	}
+	metaBytes, _ := json.Marshal(meta)
+
+	var replyTo *string
+	if s := strings.TrimSpace(fm.ReplyTo); s != "" {
+		replyTo = &s
+	}
+
+	msg, err := r.DB.InsertMessageWithDeliveries(project, fromLabel, to, msgType, subject(fm.Subject), fm.Content, string(metaBytes), priority, ttl, replyTo, nil, []string{to})
+	if err != nil {
+		apiError(w, http.StatusInternalServerError, "failed to deliver federated message", err)
+		return
+	}
+
+	// Best-effort wake-up; the message is already durable if this no-ops.
+	r.Registry.Notify(project, to, fromLabel, fm.Subject, msg.ID)
+	r.Events.Emit(MCPEvent{Type: "message", Action: "federated_in", Agent: fromLabel, Project: project, Target: to, Label: fm.Subject})
+
+	writeJSON(w, map[string]any{"delivered": true, "message_id": msg.ID})
+}
+
+// subject trims a federated subject; kept trivial but centralizes the choice to
+// pass it through verbatim (no default) so an empty subject stays empty.
+func subject(s string) string { return strings.TrimSpace(s) }

--- a/internal/relay/federation_test.go
+++ b/internal/relay/federation_test.go
@@ -1,0 +1,252 @@
+package relay
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"agent-relay/internal/config"
+	"agent-relay/internal/db"
+
+	"github.com/mark3labs/mcp-go/server"
+)
+
+// newFedRelay builds a wired Relay with a Federation registry for the given
+// peers, mirroring relay.New's wiring (Handlers and Relay share one Federation).
+func newFedRelay(t *testing.T, peers []config.FederationPeer) *Relay {
+	t.Helper()
+	database, err := db.NewTestDB(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("create test db: %v", err)
+	}
+	t.Cleanup(func() { _ = database.Close() })
+
+	mcpSrv := server.NewMCPServer("test", "0.0.0")
+	events := NewEventBus()
+	registry := NewSessionRegistry(mcpSrv)
+	handlers := NewHandlers(database, registry, nil, events)
+	fed := NewFederation(peers)
+	handlers.federation = fed
+
+	return &Relay{
+		MCPServer:  mcpSrv,
+		DB:         database,
+		Registry:   registry,
+		Events:     events,
+		Handlers:   handlers,
+		Federation: fed,
+		Config:     config.Config{},
+	}
+}
+
+func TestSplitPeerAddr(t *testing.T) {
+	cases := []struct {
+		in         string
+		name, peer string
+		ok         bool
+	}{
+		{"bob@relayb", "bob", "relayb", true},
+		{"plain", "", "", false},
+		{"*", "", "", false},
+		{"team:eng", "", "", false},
+		{"conversation:abc", "", "", false},
+		{"@nope", "", "", false},
+		{"trailing@", "", "", false},
+		{"a@b@c", "a@b", "c", true}, // last @ wins
+	}
+	for _, c := range cases {
+		name, peer, ok := splitPeerAddr(c.in)
+		if ok != c.ok || name != c.name || peer != c.peer {
+			t.Errorf("splitPeerAddr(%q) = (%q,%q,%v), want (%q,%q,%v)", c.in, name, peer, ok, c.name, c.peer, c.ok)
+		}
+	}
+}
+
+func TestPeerLookup(t *testing.T) {
+	fed := NewFederation([]config.FederationPeer{
+		{Label: "RelayB", URL: "http://x", Token: "tok-secret", Project: "default"},
+	})
+	if !fed.Enabled() {
+		t.Fatal("federation should be enabled with one peer")
+	}
+	if _, ok := fed.PeerByLabel("relayb"); !ok { // label lowercased at build
+		t.Error("PeerByLabel should resolve case-insensitively")
+	}
+	if _, ok := fed.PeerByToken("tok-secret"); !ok {
+		t.Error("PeerByToken should match the configured token")
+	}
+	if _, ok := fed.PeerByToken("wrong"); ok {
+		t.Error("PeerByToken must reject an unknown token")
+	}
+	if _, ok := fed.PeerByToken(""); ok {
+		t.Error("PeerByToken must reject an empty token")
+	}
+}
+
+func TestFederationDisabledByDefault(t *testing.T) {
+	fed := NewFederation(nil)
+	if fed.Enabled() {
+		t.Fatal("federation must be disabled with no peers")
+	}
+	r := newFedRelay(t, nil)
+	w := doAPI(r, http.MethodPost, "/federation/inbound", `{"to":"x","content":"y"}`)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("disabled inbound should 404, got %d", w.Code)
+	}
+}
+
+func TestFederationInboundAuthAndDelivery(t *testing.T) {
+	r := newFedRelay(t, []config.FederationPeer{
+		{Label: "relaya", URL: "http://a", Token: "shared-tok", Project: "default"},
+	})
+	// Recipient must exist locally.
+	if _, _, err := r.DB.RegisterAgent("default", "bob", "dev", "", nil, nil, false, nil, "[]", 0, db.RegisterOptions{}); err != nil {
+		t.Fatalf("register bob: %v", err)
+	}
+
+	body := `{"from":"alice","to":"bob","project":"default","subject":"hi","content":"hello bob","priority":"P1"}`
+
+	// Bad token → 401.
+	req := httptest.NewRequest(http.MethodPost, "/api/federation/inbound", strings.NewReader(body))
+	req.Header.Set("X-Relay-Federation-Token", "nope")
+	w := httptest.NewRecorder()
+	r.ServeAPI(w, req)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("bad token should 401, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// Unknown recipient → 404.
+	req = httptest.NewRequest(http.MethodPost, "/api/federation/inbound", strings.NewReader(`{"from":"alice","to":"ghost","content":"x"}`))
+	req.Header.Set("X-Relay-Federation-Token", "shared-tok")
+	w = httptest.NewRecorder()
+	r.ServeAPI(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("unknown recipient should 404, got %d", w.Code)
+	}
+
+	// Happy path → delivered.
+	req = httptest.NewRequest(http.MethodPost, "/api/federation/inbound", strings.NewReader(body))
+	req.Header.Set("X-Relay-Federation-Token", "shared-tok")
+	w = httptest.NewRecorder()
+	r.ServeAPI(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("delivery should 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	inbox, err := r.DB.GetInboxViaDeliveries("default", "bob", false, 10)
+	if err != nil {
+		t.Fatalf("read inbox: %v", err)
+	}
+	if len(inbox) != 1 {
+		t.Fatalf("bob should have 1 message, got %d", len(inbox))
+	}
+	m := inbox[0]
+	if m.From != "alice@relaya" { // stamped with the origin peer's local label
+		t.Errorf("from = %q, want alice@relaya", m.From)
+	}
+	if m.Content != "hello bob" || m.Priority != "P1" {
+		t.Errorf("unexpected message: content=%q priority=%q", m.Content, m.Priority)
+	}
+	if !strings.Contains(m.Metadata, `"source_relay":"relaya"`) || !strings.Contains(m.Metadata, `"federated":true`) {
+		t.Errorf("metadata missing federation markers: %s", m.Metadata)
+	}
+}
+
+// TestFederationRoundTrip drives a real two-relay hop: alice on relay A sends to
+// "bob@relayb"; A forwards over HTTP to B's inbound route; bob's inbox on B
+// surfaces it with a reply-addressable sender.
+func TestFederationRoundTrip(t *testing.T) {
+	// Relay B — receiver. Its label for A is "relaya".
+	relayB := newFedRelay(t, []config.FederationPeer{
+		{Label: "relaya", URL: "http://unused", Token: "pair-tok", Project: "default"},
+	})
+	if _, _, err := relayB.DB.RegisterAgent("default", "bob", "dev", "", nil, nil, false, nil, "[]", 0, db.RegisterOptions{}); err != nil {
+		t.Fatalf("register bob: %v", err)
+	}
+	bServer := httptest.NewServer(http.HandlerFunc(relayB.ServeAPI))
+	defer bServer.Close()
+
+	// Relay A — sender. Its peer "relayb" points at B's server.
+	relayA := newFedRelay(t, []config.FederationPeer{
+		{Label: "relayb", URL: bServer.URL, Token: "pair-tok", Project: "default"},
+	})
+	if _, _, err := relayA.DB.RegisterAgent("default", "alice", "dev", "", nil, nil, false, nil, "[]", 0, db.RegisterOptions{}); err != nil {
+		t.Fatalf("register alice: %v", err)
+	}
+
+	res, err := relayA.Handlers.HandleSendMessage(context.Background(), call(map[string]any{
+		"project": "default",
+		"as":      "alice",
+		"to":      "bob@relayb",
+		"subject": "ping",
+		"content": "hi from alice",
+	}))
+	if err != nil {
+		t.Fatalf("send: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("federated send errored: %s", expectError(t, res))
+	}
+
+	inbox, err := relayB.DB.GetInboxViaDeliveries("default", "bob", false, 10)
+	if err != nil {
+		t.Fatalf("read bob inbox: %v", err)
+	}
+	if len(inbox) != 1 {
+		t.Fatalf("bob should have 1 federated message, got %d", len(inbox))
+	}
+	if inbox[0].From != "alice@relaya" {
+		t.Errorf("from = %q, want alice@relaya (reply-addressable)", inbox[0].From)
+	}
+	if inbox[0].Content != "hi from alice" {
+		t.Errorf("content = %q", inbox[0].Content)
+	}
+
+	// Reply routes back symmetrically: bob → "alice@relaya" lands on relay A.
+	// Point B's peer "relaya" at A's server so the reverse hop resolves.
+	aServer := httptest.NewServer(http.HandlerFunc(relayA.ServeAPI))
+	defer aServer.Close()
+	relayB.Federation.peersByLabel["relaya"] = config.FederationPeer{Label: "relaya", URL: aServer.URL, Token: "pair-tok", Project: "default"}
+	for i := range relayB.Federation.peers {
+		if relayB.Federation.peers[i].Label == "relaya" {
+			relayB.Federation.peers[i].URL = aServer.URL
+		}
+	}
+
+	res, err = relayB.Handlers.HandleSendMessage(context.Background(), call(map[string]any{
+		"project": "default",
+		"as":      "bob",
+		"to":      "alice@relaya",
+		"content": "pong",
+	}))
+	if err != nil || res.IsError {
+		t.Fatalf("reply send failed: err=%v result=%+v", err, res)
+	}
+	aInbox, err := relayA.DB.GetInboxViaDeliveries("default", "alice", false, 10)
+	if err != nil {
+		t.Fatalf("read alice inbox: %v", err)
+	}
+	if len(aInbox) != 1 || aInbox[0].From != "bob@relayb" || aInbox[0].Content != "pong" {
+		t.Fatalf("reply not delivered symmetrically: %+v", aInbox)
+	}
+}
+
+// jsonMarshalable guards that fedMessage round-trips cleanly (schema sanity).
+func TestFedMessageJSON(t *testing.T) {
+	fm := fedMessage{From: "a", To: "b", Project: "p", Type: "task", Subject: "s", Content: "c", Priority: "P0", TTL: 60, ReplyTo: "r"}
+	b, err := json.Marshal(fm)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var back fedMessage
+	if err := json.Unmarshal(b, &back); err != nil {
+		t.Fatal(err)
+	}
+	if back != fm {
+		t.Errorf("round-trip mismatch: %+v vs %+v", back, fm)
+	}
+}

--- a/internal/relay/handlers.go
+++ b/internal/relay/handlers.go
@@ -27,6 +27,10 @@ type Handlers struct {
 	connMu    sync.RWMutex
 	connector connector.TaskConnector
 
+	// federation forwards direct messages to/from trusted peer relays. Nil-safe:
+	// a disabled Federation (no peers) makes the send path behave as before.
+	federation *Federation
+
 	// budgetAlerted dedupes the per-agent budget-exceeded alert to once an hour
 	// (TSU-53 slice-C), so a runaway agent pings once, not every flush.
 	budgetMu      sync.Mutex

--- a/internal/relay/handlers_messaging.go
+++ b/internal/relay/handlers_messaging.go
@@ -34,6 +34,17 @@ func (h *Handlers) HandleSendMessage(ctx context.Context, req mcp.CallToolReques
 		return mcp.NewToolResultError(qErr), nil
 	}
 
+	// Federated DM: recipient addressed as "name@peerlabel" routes to a peer
+	// relay. Checked before local resolution so a peer address is never mistaken
+	// for a local agent. Direct DMs only (splitPeerAddr already excludes team:/
+	// conversation:/broadcast). No-op when federation is disabled or "to" has no
+	// "@peer" suffix.
+	if h.federation.Enabled() {
+		if name, peerLabel, ok := splitPeerAddr(to); ok {
+			return h.sendFederated(ctx, project, from, peerLabel, name, msgType, subject, content, priority, ttlSeconds, replyTo)
+		}
+	}
+
 	// Cross-project DM: delivered to a peer executive in a different project.
 	// MVP scope: direct messages only (no broadcast, no team, no conversation).
 	// Both sender and recipient must be registered with is_executive=true.

--- a/internal/relay/middleware.go
+++ b/internal/relay/middleware.go
@@ -33,6 +33,14 @@ func authMiddleware(apiKey string, next http.Handler) http.Handler {
 	trustLoopback := os.Getenv("RELAY_TRUST_LOOPBACK") != "0"
 	expected := []byte(apiKey)
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Federation inbound is exempt from the global API key: it carries its own
+		// per-peer token (X-Relay-Federation-Token), verified constant-time in the
+		// handler. This keeps peer relays from ever needing the admin key, and the
+		// handler 404s when federation is disabled / 401s on a bad token.
+		if r.URL.Path == "/api/federation/inbound" {
+			next.ServeHTTP(w, r)
+			return
+		}
 		if trustLoopback && isLoopbackRemote(r.RemoteAddr) {
 			next.ServeHTTP(w, r)
 			return

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -29,6 +29,9 @@ type Relay struct {
 	Events    *EventBus
 	Handlers  *Handlers
 	Notifier  *Notifier
+	// Federation forwards direct messages between this relay and trusted peers.
+	// Shared with Handlers; disabled (no peers) unless RELAY_FEDERATION_PEERS set.
+	Federation *Federation
 	// Linear connector runtime — swapped at runtime by ReconfigureLinear()
 	// (settings-driven, no restart). Read through LinearConnector()/TaskConn().
 	linearMu   sync.RWMutex
@@ -68,6 +71,11 @@ func New(database *db.DB, ingester *ingest.Ingester, cfg config.Config) *Relay {
 	registry := NewSessionRegistry(mcpSrv)
 	handlers := NewHandlers(database, registry, ingester, events)
 	handlers.requireRegistered = cfg.RequireRegistered
+
+	// Federation registry — shared between the send path (Handlers) and the
+	// inbound REST route (Relay). Empty peer list => disabled, no behavior change.
+	federation := NewFederation(cfg.FederationPeers)
+	handlers.federation = federation
 
 	// Register every tool from the registry (single source of truth in
 	// toolset.go), plus the discovery pair used by ?tools=discovery
@@ -109,6 +117,7 @@ func New(database *db.DB, ingester *ingest.Ingester, cfg config.Config) *Relay {
 		Events:         events,
 		Handlers:       handlers,
 		Notifier:       notifier,
+		Federation:     federation,
 		taskConn:       connector.Noop{},
 		Config:         cfg,
 		StartedAt:      time.Now().UTC(),


### PR DESCRIPTION
## Goal
Let two independent relay instances communicate — **my relay ↔ Jérôme's relay** — on the same subnet or remote. (Network reachability itself is the operator's concern; this ships the protocol.)

## What
A local agent addresses a remote recipient as **`name@peerlabel`**. The sending relay forwards the DM over HTTP to the peer's `/api/federation/inbound`, which inserts it through the normal durable path so it surfaces in the recipient's existing inbox. **Delivery is pull-based → no cross-relay push needed.**

Design mirrors the existing same-instance `sendCrossProject` pattern, extended across the network.

## Surface
- **Config** — `RELAY_FEDERATION_PEERS` (JSON array of `{label,url,token,project}`). Empty ⇒ disabled, byte-identical to today. Malformed ⇒ skipped, never fatal.
- **Outbound** — `HandleSendMessage` detects `name@peer` (direct DMs only; `team:` / `conversation:` / broadcast excluded) and POSTs with a **per-peer token**.
- **Inbound** — new `POST /api/federation/inbound`, authed by the peer's own token (constant-time). **Exempt from the global `RELAY_API_KEY`** so peers never hold the admin key. `404` when disabled, `401` bad token, `404` if recipient absent locally (no phantom-agent spray).
- **Reply routing** — receiver stamps sender as `<from>@<its label for us>`; a plain reply routes straight back. Symmetric by each side's own config.
- **Security** — origin derived from the token, never trusted from the body (no spoofing). Body already capped by the 1 MiB BodyLimit middleware.

## Wiring (per peer, both sides)
```
# Loïc's relay
RELAY_FEDERATION_PEERS='[{"label":"jerome","url":"http://<jerome-host>:8090","token":"<shared>","project":"default"}]'
# Jérôme's relay
RELAY_FEDERATION_PEERS='[{"label":"loic","url":"http://<loic-host>:8090","token":"<shared>","project":"default"}]'
```
Then: `send_message to:"bob@jerome" content:"…"` → lands in bob's inbox on Jérôme's relay as `from: alice@loic`.

## Tests
`internal/relay/federation_test.go` — split/lookup units, inbound auth+delivery (401/404/happy), a **real two-relay HTTP round-trip with symmetric reply**, wire-schema round-trip. All green.

## Gate
`go build/vet/test` green with `-tags fts5`. gofmt-clean (formatted with the go.mod-pinned 1.25.5 toolchain to match CI). No schema change, no new per-request hot-path write, feature fully inert unless `RELAY_FEDERATION_PEERS` is set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)