### PR TITLE
feat(relay): federation config via settings + dashboard UI panel

### DIFF
--- a/internal/relay/api.go
+++ b/internal/relay/api.go
@@ -365,6 +365,7 @@ func (r *Relay) apiGetSettings(w http.ResponseWriter) {
 			"interval":       interval.String(),
 			"source":         source,
 		},
+		"federation": r.federationStatus(),
 	})
 }
 
@@ -372,13 +373,14 @@ func (r *Relay) apiGetSettings(w http.ResponseWriter) {
 // it, an (unauthenticated by default) caller could set arbitrary key→value pairs
 // — including swapping linear_api_key or repointing the connector.
 var writableSettings = map[string]bool{
-	"sun_type":        true,
-	setLinearEnabled:  true,
-	setLinearAPIKey:   true,
-	setLinearTeamKey:  true,
-	setLinearProject:  true,
-	setLinearInterval: true,
-	setLinearRouting:  true,
+	"sun_type":         true,
+	setLinearEnabled:   true,
+	setLinearAPIKey:    true,
+	setLinearTeamKey:   true,
+	setLinearProject:   true,
+	setLinearInterval:  true,
+	setLinearRouting:   true,
+	setFederationPeers: true,
 }
 
 func (r *Relay) apiPutSetting(w http.ResponseWriter, req *http.Request) {
@@ -395,15 +397,27 @@ func (r *Relay) apiPutSetting(w http.ResponseWriter, req *http.Request) {
 		}
 	}
 	linearChanged := false
+	federationChanged := false
 	for k, v := range body {
+		if k == setFederationPeers {
+			// Preserve stored tokens for peers the UI submitted with an empty
+			// token (it only ever holds masked values).
+			v = r.mergeFederationPeersJSON(v)
+		}
 		r.DB.SetSetting(k, v)
 		if strings.HasPrefix(k, "linear_") {
 			linearChanged = true
+		}
+		if strings.HasPrefix(k, "federation_") {
+			federationChanged = true
 		}
 	}
 	if linearChanged {
 		// Hot-reload the connector — no restart needed.
 		r.ReconfigureLinear()
+	}
+	if federationChanged {
+		r.ReconfigureFederation()
 	}
 	writeJSON(w, map[string]string{"ok": "true"})
 }

--- a/internal/relay/federation.go
+++ b/internal/relay/federation.go
@@ -6,14 +6,22 @@ import (
 	"crypto/subtle"
 	"encoding/json"
 	"fmt"
+	"log"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"agent-relay/internal/config"
 
 	"github.com/mark3labs/mcp-go/mcp"
 )
+
+// setFederationPeers is the settings-table key holding the runtime (UI-driven)
+// peer list as a JSON array of {label,url,token,project}. When the env var
+// RELAY_FEDERATION_PEERS is set it wins (env = ops override); otherwise this
+// settings value drives the connector and is hot-reloaded on change.
+const setFederationPeers = "federation_peers"
 
 // Federation forwards direct messages between two independent relay instances.
 //
@@ -30,6 +38,7 @@ import (
 // Federation is off unless at least one valid peer is configured; when off the
 // send path and inbound route behave as if the feature did not exist.
 type Federation struct {
+	mu           sync.RWMutex // guards peersByLabel/peers (swapped by Reload)
 	peersByLabel map[string]config.FederationPeer
 	peers        []config.FederationPeer // preserves order for token matching
 	client       *http.Client
@@ -55,26 +64,57 @@ type fedMessage struct {
 // empty peer list yields a disabled Federation (Enabled() == false).
 func NewFederation(peers []config.FederationPeer) *Federation {
 	f := &Federation{
-		peersByLabel: make(map[string]config.FederationPeer, len(peers)),
+		peersByLabel: map[string]config.FederationPeer{},
 		client:       &http.Client{Timeout: 5 * time.Second},
 	}
+	f.Reload(peers)
+	return f
+}
+
+// Reload atomically swaps the peer set (called at boot and on every
+// federation_* settings change). Invalid entries (missing label/url/token) and
+// duplicate labels are dropped; first definition of a label wins.
+func (f *Federation) Reload(peers []config.FederationPeer) {
+	byLabel := make(map[string]config.FederationPeer, len(peers))
+	var ordered []config.FederationPeer
 	for _, p := range peers {
 		label := strings.ToLower(strings.TrimSpace(p.Label))
-		if label == "" || p.URL == "" || p.Token == "" {
+		if label == "" || strings.TrimSpace(p.URL) == "" || strings.TrimSpace(p.Token) == "" {
 			continue
 		}
-		if _, dup := f.peersByLabel[label]; dup {
-			continue // first definition wins; ignore duplicate labels
+		if _, dup := byLabel[label]; dup {
+			continue
 		}
-		f.peersByLabel[label] = p
-		f.peers = append(f.peers, p)
+		p.Label = label
+		byLabel[label] = p
+		ordered = append(ordered, p)
 	}
-	return f
+	f.mu.Lock()
+	f.peersByLabel = byLabel
+	f.peers = ordered
+	f.mu.Unlock()
 }
 
 // Enabled reports whether any peer is configured.
 func (f *Federation) Enabled() bool {
-	return f != nil && len(f.peersByLabel) > 0
+	if f == nil {
+		return false
+	}
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	return len(f.peersByLabel) > 0
+}
+
+// Peers returns a snapshot of the configured peers (for the settings API).
+func (f *Federation) Peers() []config.FederationPeer {
+	if f == nil {
+		return nil
+	}
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	out := make([]config.FederationPeer, len(f.peers))
+	copy(out, f.peers)
+	return out
 }
 
 // PeerByLabel resolves an outbound peer by its local alias.
@@ -82,6 +122,8 @@ func (f *Federation) PeerByLabel(label string) (config.FederationPeer, bool) {
 	if f == nil {
 		return config.FederationPeer{}, false
 	}
+	f.mu.RLock()
+	defer f.mu.RUnlock()
 	p, ok := f.peersByLabel[strings.ToLower(strings.TrimSpace(label))]
 	return p, ok
 }
@@ -93,6 +135,8 @@ func (f *Federation) PeerByToken(token string) (config.FederationPeer, bool) {
 	if f == nil || token == "" {
 		return config.FederationPeer{}, false
 	}
+	f.mu.RLock()
+	defer f.mu.RUnlock()
 	tok := []byte(token)
 	var match config.FederationPeer
 	found := false
@@ -130,6 +174,102 @@ func (f *Federation) Forward(ctx context.Context, peer config.FederationPeer, ms
 		return fmt.Errorf("peer %q returned %d", peer.Label, resp.StatusCode)
 	}
 	return nil
+}
+
+// effectiveFederationPeers resolves the peer list: the env var
+// RELAY_FEDERATION_PEERS wins (ops override), else the settings-table JSON
+// (UI-driven). Malformed settings JSON yields no peers (federation stays off)
+// rather than an error — a bad value must not break the running relay.
+func (r *Relay) effectiveFederationPeers() (peers []config.FederationPeer, source string) {
+	if len(r.Config.FederationPeers) > 0 {
+		return r.Config.FederationPeers, "env"
+	}
+	raw := strings.TrimSpace(r.DB.GetSetting(setFederationPeers))
+	if raw == "" {
+		return nil, "settings"
+	}
+	var parsed []config.FederationPeer
+	if err := json.Unmarshal([]byte(raw), &parsed); err != nil {
+		return nil, "settings"
+	}
+	return parsed, "settings"
+}
+
+// ReconfigureFederation (re)loads the peer registry from the effective config.
+// Called at boot and on every federation_* settings change — the shared
+// Federation is reloaded atomically, no restart needed.
+func (r *Relay) ReconfigureFederation() {
+	if r.Federation == nil {
+		return
+	}
+	peers, source := r.effectiveFederationPeers()
+	r.Federation.Reload(peers)
+	log.Printf("[federation] reloaded %d peer(s) (source=%s)", len(r.Federation.Peers()), source)
+}
+
+// mergeFederationPeersJSON preserves stored tokens across a settings write from
+// the UI, which only ever sees masked tokens. Any incoming peer whose token is
+// empty inherits the currently-stored token for the same label; that lets the
+// dashboard save label/url/project edits without the operator re-typing secrets.
+// On any parse error the input is returned unchanged (Reload re-validates).
+func (r *Relay) mergeFederationPeersJSON(incoming string) string {
+	var next []config.FederationPeer
+	if err := json.Unmarshal([]byte(incoming), &next); err != nil {
+		return incoming
+	}
+	existing := map[string]string{} // label -> token
+	if raw := strings.TrimSpace(r.DB.GetSetting(setFederationPeers)); raw != "" {
+		var prev []config.FederationPeer
+		if json.Unmarshal([]byte(raw), &prev) == nil {
+			for _, p := range prev {
+				existing[strings.ToLower(strings.TrimSpace(p.Label))] = p.Token
+			}
+		}
+	}
+	for i := range next {
+		if strings.TrimSpace(next[i].Token) == "" {
+			next[i].Token = existing[strings.ToLower(strings.TrimSpace(next[i].Label))]
+		}
+	}
+	out, err := json.Marshal(next)
+	if err != nil {
+		return incoming
+	}
+	return string(out)
+}
+
+// maskToken redacts a peer token for display, keeping only a short suffix so an
+// operator can tell two peers apart without exposing the secret.
+func maskToken(tok string) string {
+	if n := len(tok); n <= 4 {
+		return "…"
+	}
+	return "…" + tok[len(tok)-4:]
+}
+
+// federationStatus is the settings-API view of federation: enabled flag, config
+// source, and the peer list with tokens masked.
+func (r *Relay) federationStatus() map[string]any {
+	_, source := r.effectiveFederationPeers()
+	peers := r.Federation.Peers()
+	view := make([]map[string]any, 0, len(peers))
+	for _, p := range peers {
+		project := p.Project
+		if project == "" {
+			project = "default"
+		}
+		view = append(view, map[string]any{
+			"label":        p.Label,
+			"url":          p.URL,
+			"project":      project,
+			"token_masked": maskToken(p.Token),
+		})
+	}
+	return map[string]any{
+		"enabled": r.Federation.Enabled(),
+		"source":  source, // "env" (read-only, RELAY_FEDERATION_PEERS) or "settings"
+		"peers":   view,
+	}
 }
 
 // splitPeerAddr splits "name@peerlabel" into (name, label, true). It returns

--- a/internal/relay/federation_test.go
+++ b/internal/relay/federation_test.go
@@ -210,12 +210,9 @@ func TestFederationRoundTrip(t *testing.T) {
 	// Point B's peer "relaya" at A's server so the reverse hop resolves.
 	aServer := httptest.NewServer(http.HandlerFunc(relayA.ServeAPI))
 	defer aServer.Close()
-	relayB.Federation.peersByLabel["relaya"] = config.FederationPeer{Label: "relaya", URL: aServer.URL, Token: "pair-tok", Project: "default"}
-	for i := range relayB.Federation.peers {
-		if relayB.Federation.peers[i].Label == "relaya" {
-			relayB.Federation.peers[i].URL = aServer.URL
-		}
-	}
+	relayB.Federation.Reload([]config.FederationPeer{
+		{Label: "relaya", URL: aServer.URL, Token: "pair-tok", Project: "default"},
+	})
 
 	res, err = relayB.Handlers.HandleSendMessage(context.Background(), call(map[string]any{
 		"project": "default",

--- a/internal/web/static/v2/api.js
+++ b/internal/web/static/v2/api.js
@@ -28,6 +28,7 @@ export const api = {
   health: () => getJSON('/api/health'),
   projects: () => getJSON('/api/projects'),
   settings: () => getJSON('/api/settings'),
+  saveSettings: (body) => sendJSON('PUT', '/api/settings', body),
   board: (project, cycle = 'active') =>
     getJSON(`/api/tasks/board?${q({ project, cycle })}`),
   cycles: (project) => getJSON(`/api/cycles?${q({ project })}`),

--- a/internal/web/static/v2/federation.js
+++ b/internal/web/static/v2/federation.js
@@ -1,0 +1,102 @@
+// Federation settings page — manage trusted peer relays (relay-to-relay DMs).
+// Reads/writes /api/settings .federation. Tokens are shown masked; leaving a
+// peer's token blank on save keeps the stored secret (backend merge). Address a
+// remote agent as `name@label` to route a DM to that peer.
+import { api } from './api.js';
+
+export function initFederation(el, ctx) {
+  const esc = ctx.esc;
+  let source = 'settings';
+  let peers = []; // {label,url,project,token_masked}
+  let msg = null; // {kind:'ok'|'err', text}
+
+  async function load() {
+    try {
+      const s = await api.settings();
+      const f = (s && s.federation) || {};
+      source = f.source || 'settings';
+      peers = Array.isArray(f.peers) ? f.peers.slice() : [];
+    } catch (e) {
+      msg = { kind: 'err', text: `load failed: ${e.message}` };
+    }
+    render();
+  }
+
+  function rowHTML(p, i) {
+    const ro = source === 'env' ? 'disabled' : '';
+    return `
+      <tr data-i="${i}">
+        <td><input class="fd-in" data-k="label" value="${esc(p.label || '')}" placeholder="jerome" ${ro}></td>
+        <td><input class="fd-in fd-url" data-k="url" value="${esc(p.url || '')}" placeholder="http://192.168.1.42:8090" ${ro}></td>
+        <td><input class="fd-in fd-proj" data-k="project" value="${esc(p.project || 'default')}" ${ro}></td>
+        <td><input class="fd-in fd-tok" data-k="token" value="" placeholder="${p.token_masked ? esc(p.token_masked) + ' (unchanged)' : 'shared secret'}" ${ro}></td>
+        <td>${ro ? '' : `<button class="fd-del" data-i="${i}" title="remove" aria-label="remove peer">✕</button>`}</td>
+      </tr>`;
+  }
+
+  function render() {
+    const envLocked = source === 'env';
+    const banner = envLocked
+      ? `<div class="fd-note fd-note-warn">Configured via <code>RELAY_FEDERATION_PEERS</code> (env). Read-only here — unset the env var to manage peers from the dashboard.</div>`
+      : `<div class="fd-note">Add the peer relay's address + a shared token. Configure the <em>same token</em> on both relays. Then message an agent there as <code>name@label</code>.</div>`;
+    const banom = msg ? `<div class="fd-note ${msg.kind === 'err' ? 'fd-note-err' : 'fd-note-ok'}">${esc(msg.text)}</div>` : '';
+    el.innerHTML = `
+      <section class="fd-wrap">
+        <header class="fd-head">
+          <h2>Federation <span class="fd-state" data-on="${peers.length > 0}">${peers.length ? 'active' : 'off'}</span></h2>
+          <p class="fd-sub">Relay-to-relay direct messaging. Peers below can DM your agents and receive DMs addressed <code>name@label</code>.</p>
+        </header>
+        ${banner}
+        ${banom}
+        <table class="fd-table">
+          <thead><tr><th>Label</th><th>URL</th><th>Project</th><th>Token</th><th></th></tr></thead>
+          <tbody id="fdRows">${peers.map(rowHTML).join('') || `<tr class="fd-empty"><td colspan="5">No peers configured.</td></tr>`}</tbody>
+        </table>
+        ${envLocked ? '' : `
+        <div class="fd-actions">
+          <button class="fd-add" id="fdAdd">+ Add peer</button>
+          <button class="fd-save" id="fdSave">Save</button>
+        </div>`}
+      </section>`;
+    wire();
+  }
+
+  function collect() {
+    const out = [];
+    el.querySelectorAll('#fdRows tr[data-i]').forEach((tr) => {
+      const get = (k) => (tr.querySelector(`[data-k="${k}"]`)?.value || '').trim();
+      const label = get('label');
+      const url = get('url');
+      if (!label && !url) return; // skip fully-empty row
+      out.push({ label, url, project: get('project') || 'default', token: get('token') });
+    });
+    return out;
+  }
+
+  function wire() {
+    const add = el.querySelector('#fdAdd');
+    if (add) add.onclick = () => { peers = collect().concat({ label: '', url: '', project: 'default', token_masked: '' }); msg = null; render(); };
+    el.querySelectorAll('.fd-del').forEach((b) => {
+      b.onclick = () => { const cur = collect(); cur.splice(Number(b.dataset.i), 1); peers = cur.map((p) => ({ ...p, token_masked: '' })); msg = null; render(); };
+    });
+    const save = el.querySelector('#fdSave');
+    if (save) save.onclick = async () => {
+      const list = collect();
+      // A brand-new peer (no stored token to inherit) needs a token now.
+      for (const p of list) {
+        if (!p.label || !p.url) { msg = { kind: 'err', text: 'each peer needs a label and a URL' }; return render(); }
+      }
+      save.disabled = true;
+      try {
+        await api.saveSettings({ federation_peers: JSON.stringify(list) });
+        msg = { kind: 'ok', text: `saved — ${list.length} peer(s), hot-reloaded` };
+        await load();
+      } catch (e) {
+        msg = { kind: 'err', text: `save failed: ${e.message}` };
+        render();
+      }
+    };
+  }
+
+  return { activate() { msg = null; load(); } };
+}

--- a/internal/web/static/v2/index.html
+++ b/internal/web/static/v2/index.html
@@ -59,6 +59,7 @@
             <h1 class="home-title">mission control</h1>
             <p class="home-sub">direct the fleet — golden signals, live throughput, and the crews that need you, across every project.</p>
             <a class="fleet-comms-link" href="#/messages">fleet comms — message any agent, any project →</a>
+            <a class="fleet-comms-link" href="#/federation">federation — connect a peer relay →</a>
           </div>
         </div>
 
@@ -171,6 +172,9 @@
           </section>
         </div>
       </section>
+
+      <!-- ============ FEDERATION · PEER RELAYS ============ -->
+      <section class="page main page-federation" data-page="federation" hidden></section>
 
       <!-- ============ MEMORY · CURATE ============ -->
       <section class="page main page-memory" data-page="memory" hidden>

--- a/internal/web/static/v2/v2.css
+++ b/internal/web/static/v2/v2.css
@@ -1214,3 +1214,33 @@ button { font-family: inherit; }
 .cmt-msg { font-size: 11px; }
 .cmt-msg[data-kind="ok"] { color: var(--accent); }
 .cmt-msg[data-kind="err"] { color: var(--red); }
+
+/* ============ FEDERATION · peer relays ============ */
+.page-federation { padding: 24px 28px; }
+.fd-wrap { max-width: 900px; }
+.fd-head h2 { display: flex; align-items: center; gap: 10px; margin: 0 0 4px; }
+.fd-state { font-size: 11px; text-transform: uppercase; letter-spacing: .06em; padding: 2px 8px; border-radius: 999px; background: var(--surface-2, #1b1f26); color: var(--muted, #8a93a2); }
+.fd-state[data-on="true"] { background: rgba(52,199,120,.14); color: #34c778; }
+.fd-sub { color: var(--muted, #8a93a2); margin: 0 0 16px; font-size: 13px; }
+.fd-note { background: var(--surface-2, #1b1f26); border: 1px solid var(--border, #262b33); border-radius: 8px; padding: 10px 12px; font-size: 12.5px; color: var(--muted, #98a1b0); margin-bottom: 14px; }
+.fd-note code { background: rgba(255,255,255,.06); padding: 1px 5px; border-radius: 4px; }
+.fd-note-warn { border-color: #6b5a1e; color: #d9b64a; }
+.fd-note-err { border-color: #7a2b2b; color: #ea6a6a; }
+.fd-note-ok { border-color: #2e6b3e; color: #4fce7f; }
+.fd-table { width: 100%; border-collapse: collapse; margin-bottom: 14px; }
+.fd-table th { text-align: left; font-size: 11px; text-transform: uppercase; letter-spacing: .05em; color: var(--muted, #8a93a2); padding: 6px 8px; font-weight: 600; }
+.fd-table td { padding: 4px 8px; }
+.fd-empty td { color: var(--muted, #8a93a2); font-size: 13px; padding: 12px 8px; }
+.fd-in { width: 100%; background: var(--surface, #12151a); border: 1px solid var(--border, #262b33); border-radius: 6px; color: var(--text, #e6e9ef); padding: 7px 9px; font-size: 13px; font-family: inherit; }
+.fd-in:focus { outline: none; border-color: var(--accent, #34c778); }
+.fd-in:disabled { opacity: .55; }
+.fd-tok { font-family: ui-monospace, monospace; }
+.fd-del { background: none; border: none; color: var(--muted, #8a93a2); cursor: pointer; font-size: 14px; padding: 4px 6px; border-radius: 6px; }
+.fd-del:hover { color: #ea6a6a; background: rgba(234,106,106,.1); }
+.fd-actions { display: flex; gap: 10px; }
+.fd-add, .fd-save { border-radius: 7px; padding: 8px 16px; font-size: 13px; cursor: pointer; border: 1px solid var(--border, #262b33); font-family: inherit; }
+.fd-add { background: var(--surface-2, #1b1f26); color: var(--text, #e6e9ef); }
+.fd-add:hover { border-color: var(--muted, #8a93a2); }
+.fd-save { background: var(--accent, #34c778); color: #06231a; border-color: transparent; font-weight: 600; }
+.fd-save:hover { filter: brightness(1.06); }
+.fd-save:disabled { opacity: .6; cursor: default; }

--- a/internal/web/static/v2/v2.js
+++ b/internal/web/static/v2/v2.js
@@ -14,6 +14,7 @@ import { initTeam } from './team.js';
 import { initMessages } from './messages.js';
 import { initMemory } from './memory.js';
 import { initLinearStrip } from './linear.js';
+import { initFederation } from './federation.js';
 
 const $ = (id) => document.getElementById(id);
 const esc = (s) => String(s ?? '').replace(/[&<>"]/g, (c) => (
@@ -118,6 +119,7 @@ const PAGES = {
   overview: { init: () => overviewPage(ctx), instance: null },
   board: { init: (el) => initBoard(el, ctx), instance: null },
   messages: { init: (el) => initMessages(el, ctx), instance: null },
+  federation: { init: (el) => initFederation(el, ctx), instance: null },
   memory: { init: (el) => initMemory(el, ctx), instance: null },
   stats: { init: (el) => initStats(el, ctx), instance: null },
   notifications: { init: (el) => initNotifications(el, ctx), instance: null },
@@ -129,6 +131,7 @@ let linearStrip = null;
 function parseHash() {
   const h = location.hash.replace(/^#\/?/, '');
   if (h === 'messages') return { view: 'global', project: null, page: 'messages' };
+  if (h === 'federation') return { view: 'global', project: null, page: 'federation' };
   if (h.startsWith('p/')) {
     const rest = h.slice(2);
     const i = rest.indexOf('/');

--- a/main.go
+++ b/main.go
@@ -198,6 +198,10 @@ func startServer() {
 	// Inert when unconfigured; hot-reloaded on settings changes without restart.
 	r.ReconfigureLinear()
 
+	// Load federation peers from effective config (env RELAY_FEDERATION_PEERS wins,
+	// else the settings table). Inert when no peers; hot-reloaded via /api/settings.
+	r.ReconfigureFederation()
+
 	// Log ingested events (phase 1: log only, phase 2: TouchAgent + WS broadcast)
 	go func() {
 		for evt := range ingester.Events {


### PR DESCRIPTION
Follow-up to #143 (relay federation). Makes federation configurable from the **dashboard** + settings API instead of env-only, with **live hot-reload** (no restart).

## Backend
- New settings key `federation_peers` (JSON `[{label,url,token,project}]`). `RELAY_FEDERATION_PEERS` env still wins (ops override); else settings drives it — `effectiveFederationPeers()`.
- `ReconfigureFederation()` atomically reloads the shared `Federation` (now RWMutex-guarded, `Reload`/`Peers`) at boot + on every `federation_*` settings change — mirrors `ReconfigureLinear`.
- `GET /api/settings` → `federation` block (`enabled`, `source`, peers with **tokens masked**). `writableSettings` gains `federation_peers`.
- **Token preservation**: a peer saved with an empty token inherits the stored secret (`mergeFederationPeersJSON`) — the UI only ever holds masked tokens.

## UI (v2 dashboard)
- New **Federation** page `#/federation`: peer table + add/remove + save, hot-reload feedback, env-locked read-only banner. Linked from the home hero.
- `api.saveSettings()` (PUT /api/settings).

## Verified live
Two isolated binaries, **no env peers** — configured via the settings API, hot-reloaded, cross-relay DM delivered; token stayed masked and was preserved across an empty-token save.

## Gate
build/vet/test green `-tags fts5`, race-clean, gofmt via go.mod-pinned 1.25.5. Inert unless peers configured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)