### PR TITLE
fix(serve): fresh-host ENOENT misread as second writer; systemd-less installs die post-binary

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -545,6 +545,15 @@ EOF
 }
 
 install_systemd_service() {
+  # Containers / minimal hosts have no systemd: an unguarded systemctl under
+  # `set -e` killed the whole install AFTER the binary landed (and its
+  # half-start left users chasing a phantom relay). Auto-start is a nicety —
+  # skip it, never die on it.
+  if ! command -v systemctl &>/dev/null; then
+    warn "systemd not available — skipping auto-start service (run '${BINARY_NAME} serve' yourself, e.g. under nohup/supervisor)"
+    return 0
+  fi
+
   local unit_dir="$HOME/.config/systemd/user"
   local unit_path="${unit_dir}/${BINARY_NAME}.service"
   local bin_path="${BIN_DIR}/${BINARY_NAME}"
@@ -567,7 +576,12 @@ Environment=PORT=${PORT}
 WantedBy=default.target
 EOF
 
-  systemctl --user daemon-reload
+  # A user bus may be missing even where systemctl exists (ssh session
+  # without lingering, chroot) — degrade to a warning, never die (set -e).
+  if ! systemctl --user daemon-reload 2>/dev/null; then
+    warn "systemd user bus unavailable — skipping auto-start service (run '${BINARY_NAME} serve' yourself)"
+    return 0
+  fi
   systemctl --user enable "$BINARY_NAME" 2>/dev/null || true
   systemctl --user restart "$BINARY_NAME" 2>/dev/null || true
 

--- a/main.go
+++ b/main.go
@@ -127,7 +127,13 @@ func startServer() {
 	// teams when a stray launchd relay came up on the same database).
 	if dbPath, perr := db.DBPath(); perr == nil {
 		if release, lerr := acquireServeLock(dbPath + ".lock"); lerr != nil {
-			log.Fatalf("another agent-relay is already serving %s — refusing to start a second writer (it corrupts the DB). Stop the other instance first.", dbPath)
+			if errors.Is(lerr, errLockHeld) {
+				log.Fatalf("another agent-relay is already serving %s — refusing to start a second writer (it corrupts the DB). Stop the other instance first.", dbPath)
+			}
+			// Environment problem (missing dir, permissions) — say what it
+			// is; a phantom "second writer" here sent fresh installs hunting
+			// for a relay that never existed.
+			log.Fatalf("cannot take the serve lock %s.lock: %v", dbPath, lerr)
 		} else {
 			defer release()
 		}

--- a/serve_lock_unix.go
+++ b/serve_lock_unix.go
@@ -3,24 +3,41 @@
 package main
 
 import (
+	"errors"
 	"os"
+	"path/filepath"
 	"syscall"
 )
+
+// errLockHeld marks "another live relay holds the serve lock" — the ONLY
+// case the caller should report as a second-writer refusal. Every other
+// error (missing state dir, permissions) is an environment problem and
+// must surface as itself, not as a phantom second relay.
+var errLockHeld = errors.New("serve lock held by another process")
 
 // acquireServeLock takes an exclusive, non-blocking advisory lock on a lockfile
 // next to the DB so two relay processes can NEVER serve the same database at
 // once — the failure that wiped agents+teams when a second (launchd) relay came
-// up on the same SQLite file. Returns a release func, or an error if another
+// up on the same SQLite file. Returns a release func, or errLockHeld if another
 // live relay already holds it (caller should refuse to start). The lock is held
 // for the process lifetime and released by the OS if the process dies.
 func acquireServeLock(path string) (func(), error) {
+	// Fresh host: the state dir may not exist yet (serve locks before db.New
+	// creates it). Creating it here must not read as "another relay is
+	// serving" — found live: every brand-new install died on the ENOENT.
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return nil, err
+	}
 	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o644)
 	if err != nil {
 		return nil, err
 	}
 	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
 		_ = f.Close()
-		return nil, err // EWOULDBLOCK → another relay holds it
+		if errors.Is(err, syscall.EWOULDBLOCK) || errors.Is(err, syscall.EAGAIN) {
+			return nil, errLockHeld
+		}
+		return nil, err
 	}
 	return func() {
 		_ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN)

--- a/serve_lock_windows.go
+++ b/serve_lock_windows.go
@@ -2,6 +2,12 @@
 
 package main
 
+import "errors"
+
+// errLockHeld mirrors the unix declaration so main.go's errors.Is check
+// compiles on Windows too (never returned here).
+var errLockHeld = errors.New("serve lock held by another process")
+
 // acquireServeLock is a no-op on Windows (flock is unix-only). Windows isn't a
 // relay host in this deployment; revisit with LockFileEx if that changes.
 func acquireServeLock(_ string) (func(), error) {


### PR DESCRIPTION
## What

Two fresh-host installability bugs found by niwa's clean-container onboarding e2e:

1. **serve-lock ENOENT → phantom second writer.** `acquireServeLock` opened `<db>.lock` without creating `~/.agent-relay/`, and `main` reported EVERY lock error as "another agent-relay is already serving". On any brand-new host, `serve` died on a relay that never existed. Fix: `MkdirAll` the lock's parent; sentinel `errLockHeld` returned only on EWOULDBLOCK/EAGAIN; other errors surface as themselves. Windows stub mirrors the sentinel.
2. **Installer dies on systemd-less hosts.** `install_systemd_service` ran unguarded `systemctl` under `set -e` — containers/minimal hosts crashed AFTER the binary landed, leaving a half-start. Now: warn + skip when `systemctl` is absent or the user bus is down.

## Verified

- Fresh-HOME `serve` boots and answers `/api/health`; lock file created in the auto-created dir.
- Second writer on the same DB still refused (flock path intact).
- `go build -tags fts5 ./...` + `go test -tags fts5 ./...` — 315 green.
- `bash -n install.sh` clean.

## review-wraith verdict

```
verdict: GO
lane: wraith-dev (serve lifecycle + installer)
fts5/CGO build bar: go build/test -tags fts5 all green (315)
single-writer discipline: flock semantics unchanged — only the error taxonomy is split
  (errLockHeld vs environment); double-writer refusal re-verified live
restart-safety: no schema/db changes, no handler changes, no ingest changes
installer: degradation-only change (warn+skip), no new deps, uninstall path untouched
risk: low — serve start path + installer nicety
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)