### PR TITLE
feat(relay): kill anonymous/default fallbacks + identity binding (v2)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,12 +22,10 @@ type Config struct {
 	MaxBody     int64    // RELAY_MAX_BODY: max request body in bytes (default 1 MiB; 0 disables)
 	RateLimit   int      // RELAY_RATE_LIMIT: requests/minute per IP (opt-in; 0 = off)
 
-	// RequireRegistered (RELAY_REQUIRE_REGISTERED) rejects mutating tool calls
-	// whose acting agent is "anonymous" or not registered in the project. Opt-in
-	// (default off) — the loopback trust model still treats the declared `as`/
-	// ?agent= identity as authoritative; this only stops silent anonymous and
-	// typo'd writes from polluting the bus. Reads and register_agent stay open.
-	RequireRegistered bool // RELAY_REQUIRE_REGISTERED
+	// Identity enforcement is no longer opt-in: every mutating tool call must
+	// resolve a real agent registered in a real project (guardIdentity), and the
+	// former RELAY_REQUIRE_REGISTERED env var is retired along with the
+	// anonymous/default fallbacks it used to guard against.
 
 	// LinearMode toggles Linear-SSOT mirror mode. Default false = degraded/native
 	// mode (tasks live in the relay DB, kanban is writable). Surfaced via
@@ -108,10 +106,6 @@ func Load() Config {
 
 	if v := strings.ToLower(strings.TrimSpace(os.Getenv("RELAY_LINEAR_MODE"))); v == "1" || v == "true" || v == "yes" {
 		cfg.LinearMode = true
-	}
-
-	if v := strings.ToLower(strings.TrimSpace(os.Getenv("RELAY_REQUIRE_REGISTERED"))); v == "1" || v == "true" || v == "yes" {
-		cfg.RequireRegistered = true
 	}
 
 	// Federation peers: JSON array in RELAY_FEDERATION_PEERS. A malformed value or

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -30,23 +30,6 @@ func TestMaxBodyNegativeIgnored(t *testing.T) {
 	}
 }
 
-func TestRequireRegisteredOptIn(t *testing.T) {
-	t.Setenv("RELAY_REQUIRE_REGISTERED", "")
-	if Load().RequireRegistered {
-		t.Error("RequireRegistered should default to false")
-	}
-	for _, v := range []string{"1", "true", "yes", "TRUE"} {
-		t.Setenv("RELAY_REQUIRE_REGISTERED", v)
-		if !Load().RequireRegistered {
-			t.Errorf("RequireRegistered should be true for %q", v)
-		}
-	}
-	t.Setenv("RELAY_REQUIRE_REGISTERED", "0")
-	if Load().RequireRegistered {
-		t.Error("RequireRegistered should be false for \"0\"")
-	}
-}
-
 func TestRateLimitOptIn(t *testing.T) {
 	t.Setenv("RELAY_RATE_LIMIT", "")
 	if got := Load().RateLimit; got != 0 {

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -943,10 +943,19 @@ func migrate(conn *sql.DB) error {
 	// NormalizeProject) so an upgrade doesn't split existing namespaces.
 	migrateNormalizeProjects(conn)
 
-	// Purge the retired 'default' catch-all project and its data. Runs after
-	// normalization so any 'Default'/'DEFAULT' spellings have already folded to
-	// 'default'. Idempotent: once purged the deletes match nothing.
-	migratePurgeDefaultProject(conn)
+	// Purge the retired 'default' catch-all project and its data — ONE-SHOT,
+	// guarded by a settings marker. Must NOT run on every boot: 'default' is not
+	// a reserved storage key, and REST/DB paths that have not yet been migrated
+	// off their own = "default" fallback can still write rows there at runtime;
+	// an every-boot purge would silently delete such live data on the next
+	// restart. Runs once on upgrade (after normalization folds any 'Default'
+	// spellings), cleaning the legacy catch-all, then never again.
+	var purgedDefault string
+	_ = conn.QueryRow("SELECT value FROM settings WHERE key = 'purge_default_project'").Scan(&purgedDefault)
+	if purgedDefault == "" {
+		migratePurgeDefaultProject(conn)
+		_, _ = conn.Exec("INSERT INTO settings (key, value) VALUES ('purge_default_project', 'done') ON CONFLICT(key) DO UPDATE SET value = 'done'")
+	}
 
 	return nil
 }

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -293,11 +293,10 @@ func migrate(conn *sql.DB) error {
 	// Backfill projects from existing agents
 	backfillProjects(conn)
 
-	// Ensure the 'default' project row always exists — CLI and MCP tools accept
-	// project="default" implicitly but never created the row, so the UI hid
-	// activity that happened in the implicit default scope.
+	// The implicit 'default' project is gone: every call must resolve a real
+	// project or be rejected (guardIdentity). The row is no longer auto-created,
+	// and migratePurgeDefaultProject removes any legacy 'default' data on boot.
 	nowStr := time.Now().UTC().Format("2006-01-02T15:04:05Z")
-	_, _ = conn.Exec("INSERT OR IGNORE INTO projects (name, planet_type, created_at) VALUES ('default', 'forest/1', ?)", nowStr)
 
 	// Typed-ticket enforcement flag (V-lifecycle). Per-project opt-in: the relay
 	// serves many projects, so a hard "no goal/AC/dod → refuse" default would
@@ -943,6 +942,11 @@ func migrate(conn *sql.DB) error {
 	// Canonicalize project names everywhere (lockstep with the handlers'
 	// NormalizeProject) so an upgrade doesn't split existing namespaces.
 	migrateNormalizeProjects(conn)
+
+	// Purge the retired 'default' catch-all project and its data. Runs after
+	// normalization so any 'Default'/'DEFAULT' spellings have already folded to
+	// 'default'. Idempotent: once purged the deletes match nothing.
+	migratePurgeDefaultProject(conn)
 
 	return nil
 }

--- a/internal/db/migrate_default.go
+++ b/internal/db/migrate_default.go
@@ -48,6 +48,14 @@ func migratePurgeDefaultProject(conn *sql.DB) {
 	}
 	_ = rows.Close()
 
+	// Tables where 'default' is NOT the retired catch-all but a load-bearing
+	// sentinel with its own meaning — never purge these. In notification_rules a
+	// rule with project='default' is the GLOBAL rule (the evaluator fires it for
+	// every project, see relay/notifications.go), not a rule that landed in the
+	// catch-all. Deleting them would silently disable the global/autonomy
+	// notification rules.
+	skip := map[string]bool{"notification_rules": true}
+
 	total := int64(0)
 	del := func(table, col string) bool {
 		res, err := tx.Exec("DELETE FROM " + table + " WHERE " + col + " = 'default'") //nolint:gosec // table/col are internal identifiers, never user input
@@ -62,6 +70,9 @@ func migratePurgeDefaultProject(conn *sql.DB) {
 	}
 
 	for _, t := range tables {
+		if skip[t] {
+			continue
+		}
 		if !del(t, "project") {
 			return
 		}

--- a/internal/db/migrate_default.go
+++ b/internal/db/migrate_default.go
@@ -14,8 +14,14 @@ import (
 //
 // Tables are discovered live from sqlite_master (any table carrying a `project`
 // column), so future tables are covered without editing this migration. The
-// projects registry itself keys on `name`. Runs on every boot; idempotent —
-// once purged the WHERE clauses match nothing.
+// projects registry itself keys on `name`.
+//
+// Called ONCE, gated by the 'purge_default_project' settings marker in migrate()
+// — deliberately NOT on every boot: until every non-MCP path (REST, connectors)
+// is migrated off its own = "default" fallback, a row can still be written to
+// 'default' at runtime, and an every-boot purge would silently delete it on the
+// next restart. The function itself is idempotent (a re-run matches nothing), so
+// it is also safe to call directly in tests.
 //
 // Internal pseudo-projects (names starting with '_', e.g. the vault's '_relay')
 // are never touched. This only ever targets the literal 'default'.

--- a/internal/db/migrate_default.go
+++ b/internal/db/migrate_default.go
@@ -1,0 +1,74 @@
+package db
+
+import (
+	"database/sql"
+	"log"
+)
+
+// migratePurgeDefaultProject deletes the retired 'default' catch-all project and
+// every row attributed to it. The implicit 'default' project was where any call
+// that named no project silently landed; it collapsed unrelated teams into one
+// shared namespace. The handlers now reject an unresolved project outright
+// (guardIdentity), so the leftover 'default' data is unreachable noise — this
+// removes it.
+//
+// Tables are discovered live from sqlite_master (any table carrying a `project`
+// column), so future tables are covered without editing this migration. The
+// projects registry itself keys on `name`. Runs on every boot; idempotent —
+// once purged the WHERE clauses match nothing.
+//
+// Internal pseudo-projects (names starting with '_', e.g. the vault's '_relay')
+// are never touched. This only ever targets the literal 'default'.
+func migratePurgeDefaultProject(conn *sql.DB) {
+	tx, err := conn.Begin()
+	if err != nil {
+		return
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	rows, err := tx.Query(`
+		SELECT m.name FROM sqlite_master m
+		WHERE m.type = 'table' AND m.name NOT LIKE 'sqlite_%'
+		  AND EXISTS (SELECT 1 FROM pragma_table_info(m.name) c WHERE c.name = 'project')`)
+	if err != nil {
+		return
+	}
+	var tables []string
+	for rows.Next() {
+		var t string
+		if rows.Scan(&t) == nil {
+			tables = append(tables, t)
+		}
+	}
+	_ = rows.Close()
+
+	total := int64(0)
+	del := func(table, col string) bool {
+		res, err := tx.Exec("DELETE FROM " + table + " WHERE " + col + " = 'default'") //nolint:gosec // table/col are internal identifiers, never user input
+		if err != nil {
+			log.Printf("purge default: %s delete failed: %v", table, err)
+			return false
+		}
+		if n, _ := res.RowsAffected(); n > 0 {
+			total += n
+		}
+		return true
+	}
+
+	for _, t := range tables {
+		if !del(t, "project") {
+			return
+		}
+	}
+	// The projects registry keys the project on `name`, not `project`.
+	if !del("projects", "name") {
+		return
+	}
+
+	if err := tx.Commit(); err != nil {
+		return
+	}
+	if total > 0 {
+		log.Printf("purge default: removed %d row(s) belonging to the retired 'default' project", total)
+	}
+}

--- a/internal/db/migrate_default_test.go
+++ b/internal/db/migrate_default_test.go
@@ -1,0 +1,63 @@
+package db
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestMigratePurgeDefaultProject verifies the retired 'default' catch-all and
+// all rows attributed to it are removed, real projects survive untouched, and a
+// second pass is a no-op.
+func TestMigratePurgeDefaultProject(t *testing.T) {
+	d, err := NewTestDB(filepath.Join(t.TempDir(), "d.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = d.Close() }()
+
+	now := time.Now().UTC().Format(time.RFC3339)
+	seed := []struct {
+		q    string
+		args []any
+	}{
+		// 'default' project + its data — must all be purged.
+		{"INSERT INTO projects (name, planet_type, created_at) VALUES ('default','forest/1',?)", []any{now}},
+		{"INSERT INTO agents (id, name, role, registered_at, last_seen, project) VALUES ('a1','bot','',?,?,'default')", []any{now, now}},
+		{"INSERT INTO messages (id, from_agent, to_agent, type, subject, content, created_at, project) VALUES ('m1','bot','user','notification','','x',?,'default')", []any{now}},
+		// A real project + its data — must survive.
+		{"INSERT INTO projects (name, planet_type, created_at) VALUES ('trovex-growth','forest/1',?)", []any{now}},
+		{"INSERT INTO agents (id, name, role, registered_at, last_seen, project) VALUES ('a2','cmo','',?,?,'trovex-growth')", []any{now, now}},
+		{"INSERT INTO messages (id, from_agent, to_agent, type, subject, content, created_at, project) VALUES ('m2','cmo','user','notification','','y',?,'trovex-growth')", []any{now}},
+	}
+	for _, s := range seed {
+		if _, err := d.conn.Exec(s.q, s.args...); err != nil {
+			t.Fatalf("seed %q: %v", s.q, err)
+		}
+	}
+
+	migratePurgeDefaultProject(d.conn)
+
+	assertOne := func(q string, want int) {
+		t.Helper()
+		var n int
+		if err := d.conn.QueryRow(q).Scan(&n); err != nil {
+			t.Fatalf("%s: %v", q, err)
+		}
+		if n != want {
+			t.Errorf("%s = %d, want %d", q, n, want)
+		}
+	}
+	// default gone everywhere.
+	assertOne("SELECT COUNT(*) FROM projects WHERE name = 'default'", 0)
+	assertOne("SELECT COUNT(*) FROM agents WHERE project = 'default'", 0)
+	assertOne("SELECT COUNT(*) FROM messages WHERE project = 'default'", 0)
+	// real project intact.
+	assertOne("SELECT COUNT(*) FROM projects WHERE name = 'trovex-growth'", 1)
+	assertOne("SELECT COUNT(*) FROM agents WHERE project = 'trovex-growth'", 1)
+	assertOne("SELECT COUNT(*) FROM messages WHERE project = 'trovex-growth'", 1)
+
+	// Idempotent: a second pass changes nothing and does not error.
+	migratePurgeDefaultProject(d.conn)
+	assertOne("SELECT COUNT(*) FROM projects WHERE name = 'trovex-growth'", 1)
+}

--- a/internal/db/migrate_default_test.go
+++ b/internal/db/migrate_default_test.go
@@ -29,6 +29,9 @@ func TestMigratePurgeDefaultProject(t *testing.T) {
 		{"INSERT INTO projects (name, planet_type, created_at) VALUES ('trovex-growth','forest/1',?)", []any{now}},
 		{"INSERT INTO agents (id, name, role, registered_at, last_seen, project) VALUES ('a2','cmo','',?,?,'trovex-growth')", []any{now, now}},
 		{"INSERT INTO messages (id, from_agent, to_agent, type, subject, content, created_at, project) VALUES ('m2','cmo','user','notification','','y',?,'trovex-growth')", []any{now}},
+		// A GLOBAL notification rule (project='default' = wildcard, not catch-all)
+		// — must survive: purging it would silently disable global notifications.
+		{"INSERT INTO notification_rules (id, project, name, event, action, created_at, updated_at) VALUES ('r1','default','global-rule','task.dispatched','log',?,?)", []any{now, now}},
 	}
 	for _, s := range seed {
 		if _, err := d.conn.Exec(s.q, s.args...); err != nil {
@@ -56,6 +59,8 @@ func TestMigratePurgeDefaultProject(t *testing.T) {
 	assertOne("SELECT COUNT(*) FROM projects WHERE name = 'trovex-growth'", 1)
 	assertOne("SELECT COUNT(*) FROM agents WHERE project = 'trovex-growth'", 1)
 	assertOne("SELECT COUNT(*) FROM messages WHERE project = 'trovex-growth'", 1)
+	// global notification rule survives — 'default' there is the wildcard, not the catch-all.
+	assertOne("SELECT COUNT(*) FROM notification_rules WHERE project = 'default'", 1)
 
 	// Idempotent: a second pass changes nothing and does not error.
 	migratePurgeDefaultProject(d.conn)

--- a/internal/db/migrate_projects_test.go
+++ b/internal/db/migrate_projects_test.go
@@ -18,7 +18,10 @@ func TestMigrateNormalizeProjects(t *testing.T) {
 	defer func() { _ = d.Close() }()
 
 	now := time.Now().UTC().Format(time.RFC3339)
-	seed := []struct{ q string; args []any }{
+	seed := []struct {
+		q    string
+		args []any
+	}{
 		// Old spellings.
 		{"INSERT INTO projects (name, planet_type, created_at) VALUES (?, ?, ?)", []any{"testDuSoir", "ice/1", now}},
 		{"INSERT INTO agents (id, name, role, registered_at, last_seen, project) VALUES ('a1','bot','', ?, ?, 'testDuSoir')", []any{now, now}},

--- a/internal/relay/context.go
+++ b/internal/relay/context.go
@@ -3,6 +3,7 @@ package relay
 import (
 	"context"
 	"net/http"
+	"strings"
 )
 
 type contextKey string
@@ -27,14 +28,12 @@ const (
 // in either mode (see toolsModeFilter), so clients that invoke tools directly
 // keep working under the default.
 func HTTPContextFunc(ctx context.Context, r *http.Request) context.Context {
-	agent := r.URL.Query().Get("agent")
-	if agent == "" {
-		agent = "anonymous"
-	}
+	// No silent fallbacks: an unset agent/project stays empty and is rejected
+	// at the write boundary (guardIdentity). The legacy "anonymous" agent and
+	// "default" project catch-alls were removed — they let unidentified calls
+	// and untargeted writes collapse into shared namespaces nobody owned.
+	agent := strings.ToLower(strings.TrimSpace(r.URL.Query().Get("agent")))
 	project := NormalizeProject(r.URL.Query().Get("project"))
-	if project == "" {
-		project = "default"
-	}
 	if r.URL.Query().Get("tools") == ToolsModeFull {
 		ctx = context.WithValue(ctx, toolsModeKey, ToolsModeFull)
 	}
@@ -42,20 +41,24 @@ func HTTPContextFunc(ctx context.Context, r *http.Request) context.Context {
 	return context.WithValue(ctx, projectKey, project)
 }
 
-// AgentFromContext retrieves the agent name from the context.
+// AgentFromContext retrieves the agent name from the context, or "" when the
+// connection carried no ?agent= identity. Callers that mutate state must reject
+// an empty identity rather than substitute a placeholder.
 func AgentFromContext(ctx context.Context) string {
 	if v, ok := ctx.Value(agentNameKey).(string); ok {
 		return v
 	}
-	return "anonymous"
+	return ""
 }
 
-// ProjectFromContext retrieves the project name from the context.
+// ProjectFromContext retrieves the project name from the context, or "" when
+// the connection carried no ?project=. An empty project is unresolved, not a
+// catch-all — resolveProject / guardIdentity turn it into an error on writes.
 func ProjectFromContext(ctx context.Context) string {
 	if v, ok := ctx.Value(projectKey).(string); ok {
 		return v
 	}
-	return "default"
+	return ""
 }
 
 // ToolsModeFromContext retrieves the tool exposure mode from the context.

--- a/internal/relay/guard_test.go
+++ b/internal/relay/guard_test.go
@@ -12,27 +12,36 @@ func ctxWith(agent, project string) context.Context {
 	return context.WithValue(ctx, projectKey, project)
 }
 
-// TestGuardRegistered verifies the RELAY_REQUIRE_REGISTERED gate: anonymous and
-// unregistered identities are rejected before the wrapped handler runs, while a
-// registered agent passes through.
-func TestGuardRegistered(t *testing.T) {
+// TestGuardIdentity verifies the always-on identity gate: a call with no
+// resolvable project or agent, or an agent not registered in the project, is
+// rejected before the wrapped handler runs; a registered agent passes through.
+func TestGuardIdentity(t *testing.T) {
 	h := testHandlers(t)
-	h.requireRegistered = true
 
 	ran := false
 	next := func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		ran = true
 		return mcp.NewToolResultText("ok"), nil
 	}
-	guarded := h.guardRegistered(next)
+	guarded := h.guardIdentity(next)
 
-	// anonymous → rejected, next never runs
-	res, _ := guarded(ctxWith("anonymous", "p1"), call(nil))
+	// no project resolvable → rejected, next never runs
+	res, _ := guarded(ctxWith("", ""), call(nil))
 	if !res.IsError {
-		t.Fatal("anonymous identity should be rejected")
+		t.Fatal("call with no project should be rejected")
 	}
 	if ran {
-		t.Fatal("wrapped handler must not run for anonymous")
+		t.Fatal("wrapped handler must not run without a project")
+	}
+
+	// project present but no agent identity → rejected
+	ran = false
+	res, _ = guarded(ctxWith("", "p1"), call(nil))
+	if !res.IsError {
+		t.Fatal("call with no agent identity should be rejected")
+	}
+	if ran {
+		t.Fatal("wrapped handler must not run without an identity")
 	}
 
 	// unregistered name → rejected
@@ -66,15 +75,28 @@ func TestGuardRegistered(t *testing.T) {
 	}
 }
 
-// TestGuardDisabledByDefault confirms toolRegistry leaves handlers unwrapped
-// when the flag is off (no identity enforcement).
-func TestToolRegistryNoWrapByDefault(t *testing.T) {
+// TestGuardInstalledOnMutatingTools confirms toolRegistry now wraps every
+// mutating tool with the identity gate (no opt-in flag): an unidentified
+// send_message is rejected, while a bootstrap tool like create_project is not
+// wrapped and stays reachable.
+func TestGuardInstalledOnMutatingTools(t *testing.T) {
 	h := testHandlers(t)
-	// requireRegistered defaults false
+	var sendGuarded, createProjectWrapped bool
 	for _, rt := range h.toolRegistry() {
-		_ = rt // handlers are the bare h.HandleX; nothing to assert beyond no panic
+		switch rt.Tool.Name {
+		case "send_message":
+			// An unidentified call must be rejected by the wrapper.
+			res, _ := rt.Handler(ctxWith("", ""), call(map[string]any{"to": "x", "content": "y"}))
+			sendGuarded = res != nil && res.IsError
+		case "create_project":
+			createProjectWrapped = true // presence in mutatingTools would wrap it; asserted below
+		}
 	}
-	if h.requireRegistered {
-		t.Fatal("requireRegistered should default to false")
+	if !sendGuarded {
+		t.Fatal("send_message should be identity-guarded in the registry")
 	}
+	if mutatingTools["create_project"] {
+		t.Fatal("create_project must stay a bootstrap tool (unguarded)")
+	}
+	_ = createProjectWrapped
 }

--- a/internal/relay/guard_test.go
+++ b/internal/relay/guard_test.go
@@ -75,6 +75,64 @@ func TestGuardIdentity(t *testing.T) {
 	}
 }
 
+type fakeSession string
+
+func (f fakeSession) SessionID() string { return string(f) }
+
+func ctxWithSession(agent, project, sessionID string) context.Context {
+	return context.WithValue(ctxWith(agent, project), sessionKey, fakeSession(sessionID))
+}
+
+// TestGuardIdentityBinding verifies the Option-A binding: a connection whose
+// session is provably bound to one agent cannot act as another; an unknown
+// session fails open (the write proceeds) so legitimate traffic is never dropped.
+func TestGuardIdentityBinding(t *testing.T) {
+	h := testHandlers(t)
+	// Register alice on session sA and bob on session sB, both in p1. Registering
+	// with a session in context populates the reverse session→agent binding.
+	if r, _ := h.HandleRegisterAgent(ctxWithSession("", "p1", "sA"), call(map[string]any{"name": "alice", "role": "dev"})); r.IsError {
+		t.Fatalf("register alice: %s", expectError(t, r))
+	}
+	if r, _ := h.HandleRegisterAgent(ctxWithSession("", "p1", "sB"), call(map[string]any{"name": "bob", "role": "dev"})); r.IsError {
+		t.Fatalf("register bob: %s", expectError(t, r))
+	}
+
+	ran := false
+	next := func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		ran = true
+		return mcp.NewToolResultText("ok"), nil
+	}
+	guarded := h.guardIdentity(next)
+
+	// alice acting as herself from her own session → passes
+	ran = false
+	if res, _ := guarded(ctxWithSession("", "p1", "sA"), call(map[string]any{"as": "alice"})); res != nil && res.IsError {
+		t.Fatalf("alice on her own session should pass: %s", res.Content[0].(mcp.TextContent).Text)
+	}
+	if !ran {
+		t.Fatal("legit self-identified write should run")
+	}
+
+	// alice's session claiming as:bob → impersonation, rejected
+	ran = false
+	res, _ := guarded(ctxWithSession("", "p1", "sA"), call(map[string]any{"as": "bob"}))
+	if !res.IsError {
+		t.Fatal("session bound to alice must not act as bob")
+	}
+	if ran {
+		t.Fatal("impersonating write must not run")
+	}
+
+	// unknown session claiming as:alice → fail open, passes (alice is registered)
+	ran = false
+	if res, _ := guarded(ctxWithSession("", "p1", "sX"), call(map[string]any{"as": "alice"})); res != nil && res.IsError {
+		t.Fatalf("unknown session should fail open: %s", res.Content[0].(mcp.TextContent).Text)
+	}
+	if !ran {
+		t.Fatal("write from an unbound session should proceed (fail-open)")
+	}
+}
+
 // TestGuardInstalledOnMutatingTools confirms toolRegistry now wraps every
 // mutating tool with the identity gate (no opt-in flag): an unidentified
 // send_message is rejected, while a bootstrap tool like create_project is not

--- a/internal/relay/handlers.go
+++ b/internal/relay/handlers.go
@@ -92,6 +92,13 @@ func validProjectName(name string) bool {
 	if len(name) == 0 || len(name) > 64 {
 		return false
 	}
+	// "default" is a retired reserved word — the former silent catch-all. Names
+	// are normalized (lowercased) before they reach here, so a case-insensitive
+	// literal check suffices to stop anyone re-creating the catch-all as a real
+	// project through the front door.
+	if strings.ToLower(name) == "default" {
+		return false
+	}
 	seenAt := false
 	for i, r := range name {
 		isAlnum := (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9')

--- a/internal/relay/handlers.go
+++ b/internal/relay/handlers.go
@@ -37,10 +37,6 @@ type Handlers struct {
 	budgetMu      sync.Mutex
 	budgetAlerted map[string]time.Time
 
-	// requireRegistered gates mutating tools behind a registered acting agent
-	// (RELAY_REQUIRE_REGISTERED). Set from config in relay.New before dispatch.
-	requireRegistered bool
-
 	// registerLimiters throttles register_agent per (project, name) identity so a
 	// runaway client loop (e.g. a headless job re-registering on every tick) can't
 	// flood the agents table. Keyed lazily, swept on a timer like the HTTP-layer

--- a/internal/relay/handlers_test.go
+++ b/internal/relay/handlers_test.go
@@ -142,6 +142,14 @@ func TestRegisterAgentRejectsInvalidProjectName(t *testing.T) {
 			t.Errorf("%q must be invalid", bad)
 		}
 	}
+
+	// "default" is a retired reserved word — the former silent catch-all — and
+	// must never be re-creatable as a real project through registration.
+	for _, reserved := range []string{"default", "Default", "DEFAULT"} {
+		if validProjectName(reserved) {
+			t.Errorf("reserved project name %q must be invalid", reserved)
+		}
+	}
 }
 
 // TestRegisterAgentRateLimit reproduces the runaway classify-loop incident: the

--- a/internal/relay/handlers_test.go
+++ b/internal/relay/handlers_test.go
@@ -1350,20 +1350,25 @@ func TestTaskSubtaskCompletion(t *testing.T) {
 
 // --- Validation Tests (cross-cutting) ---
 
-func TestResolveProjectDefault(t *testing.T) {
+// TestResolveProjectUnresolved: with no project param, no ?project= context, and
+// no single-project registration, the project is unresolved ("") — there is no
+// "default" catch-all. The write boundary rejects it.
+func TestResolveProjectUnresolved(t *testing.T) {
 	h := testHandlers(t)
 	ctx := context.Background()
 	req := call(map[string]any{})
-	if p := h.resolveProject(ctx, req); p != "default" {
-		t.Errorf("expected 'default', got %s", p)
+	if p := h.resolveProject(ctx, req); p != "" {
+		t.Errorf("expected \"\" (unresolved), got %s", p)
 	}
 }
 
-func TestResolveAgentDefault(t *testing.T) {
+// TestResolveAgentUnidentified: with no `as` param and no ?agent= context, the
+// agent is unidentified ("") — the "anonymous" fallback was removed.
+func TestResolveAgentUnidentified(t *testing.T) {
 	ctx := context.Background()
 	req := call(map[string]any{})
-	if a := resolveAgent(ctx, req); a != "anonymous" {
-		t.Errorf("expected 'anonymous', got %s", a)
+	if a := resolveAgent(ctx, req); a != "" {
+		t.Errorf("expected \"\" (unidentified), got %s", a)
 	}
 }
 

--- a/internal/relay/notify.go
+++ b/internal/relay/notify.go
@@ -53,6 +53,41 @@ func (r *SessionRegistry) Unregister(agentName, sessionID string) {
 	}
 }
 
+// AgentForSession reverse-looks-up which agent a connection's session is bound
+// to within a project, for the identity-binding check in guardIdentity. Returns
+// (name, true) ONLY when the session is bound to exactly one agent in that
+// project — the caller's provable identity. Returns ("", false) when the session
+// is unknown (e.g. the in-memory registry was cleared by a relay restart and the
+// agent has not re-registered yet) or bound to more than one agent, so the guard
+// fails open and never drops a legitimate write on incomplete knowledge.
+func (r *SessionRegistry) AgentForSession(project, sessionID string) (string, bool) {
+	if sessionID == "" {
+		return "", false
+	}
+	prefix := project + ":"
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	found := ""
+	for key, ids := range r.sessions {
+		if !strings.HasPrefix(key, prefix) {
+			continue
+		}
+		for _, id := range ids {
+			if id == sessionID {
+				if found != "" && found != key[len(prefix):] {
+					return "", false // session bound to >1 agent — ambiguous, fail open
+				}
+				found = key[len(prefix):]
+				break
+			}
+		}
+	}
+	if found == "" {
+		return "", false
+	}
+	return found, true
+}
+
 // Notify sends a notification to all sessions of the given agent in a project.
 func (r *SessionRegistry) Notify(project, agentName, from, subject, messageID string) {
 	key := registryKey(project, agentName)

--- a/internal/relay/project_ns.go
+++ b/internal/relay/project_ns.go
@@ -21,29 +21,27 @@ func NormalizeProject(p string) string {
 // resolveProject returns the project for a tool call, most explicit first:
 //
 //  1. the `project` tool parameter;
-//  2. the HTTP session default (?project= URL param);
+//  2. the HTTP session project (?project= URL param);
 //  3. the calling agent's own registration, when it names exactly ONE
-//     project — an agent whose MCP connection carries no project used to
-//     fall into the "default" catch-all here, and its messages (e.g. a
-//     CTO reporting to its founder) landed in a namespace nobody reads;
-//  4. "default", only when nothing above resolves.
+//     project — an agent whose MCP connection carries no project would
+//     otherwise be unresolved even though it belongs to exactly one.
 //
-// A context project of "default" is treated as unset for step 3: it is the
-// compiled fallback of ProjectFromContext, not something a caller chose.
+// Returns "" when nothing resolves. There is no "default" catch-all: an
+// unresolved project is an error at the write boundary (guardIdentity), not a
+// shared bucket that silently collects untargeted writes.
 func (h *Handlers) resolveProject(ctx context.Context, req mcp.CallToolRequest) string {
 	if p := req.GetString("project", ""); p != "" {
 		return NormalizeProject(p)
 	}
-	ctxProject := ProjectFromContext(ctx)
-	if ctxProject != "" && ctxProject != "default" {
+	if ctxProject := ProjectFromContext(ctx); ctxProject != "" {
 		return NormalizeProject(ctxProject)
 	}
-	if agent := resolveAgent(ctx, req); agent != "" && agent != "anonymous" {
+	if agent := resolveAgent(ctx, req); agent != "" {
 		if projects, err := h.db.ProjectsOfAgent(agent); err == nil && len(projects) == 1 {
 			return NormalizeProject(projects[0])
 		}
 	}
-	return "default"
+	return ""
 }
 
 // suggestProject returns the closest existing project name to `miss`

--- a/internal/relay/project_ns_test.go
+++ b/internal/relay/project_ns_test.go
@@ -59,9 +59,10 @@ func TestResolveProjectBindsToRegistration(t *testing.T) {
 	}
 }
 
-// TestResolveProjectAmbiguousStaysDefault: a name registered in two projects
-// must not be guessed — better the visible default than a silent misroute.
-func TestResolveProjectAmbiguousStaysDefault(t *testing.T) {
+// TestResolveProjectAmbiguousStaysUnresolved: a name registered in two projects
+// must not be guessed — it resolves to "" (unresolved), and the write boundary
+// then rejects it, rather than silently misrouting into a shared bucket.
+func TestResolveProjectAmbiguousStaysUnresolved(t *testing.T) {
 	h := testHandlers(t)
 	for _, p := range []string{"proj-a", "proj-b"} {
 		if _, err := h.HandleRegisterAgent(context.Background(), call(map[string]any{
@@ -70,8 +71,8 @@ func TestResolveProjectAmbiguousStaysDefault(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	if got := h.resolveProject(context.Background(), call(map[string]any{"as": "cto"})); got != "default" {
-		t.Errorf("ambiguous binding = %q, want default", got)
+	if got := h.resolveProject(context.Background(), call(map[string]any{"as": "cto"})); got != "" {
+		t.Errorf("ambiguous binding = %q, want \"\" (unresolved)", got)
 	}
 }
 

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -70,7 +70,6 @@ func New(database *db.DB, ingester *ingest.Ingester, cfg config.Config) *Relay {
 	events := NewEventBus()
 	registry := NewSessionRegistry(mcpSrv)
 	handlers := NewHandlers(database, registry, ingester, events)
-	handlers.requireRegistered = cfg.RequireRegistered
 
 	// Federation registry — shared between the send path (Handlers) and the
 	// inbound REST route (Relay). Empty peer list => disabled, no behavior change.

--- a/internal/relay/toolset.go
+++ b/internal/relay/toolset.go
@@ -115,15 +115,16 @@ func (h *Handlers) toolRegistry() []registeredTool {
 		{server.ServerTool{Tool: createProjectTool(), Handler: h.HandleCreateProject}, "projects"},
 		{server.ServerTool{Tool: deleteProjectTool(), Handler: h.HandleDeleteProject}, "projects"},
 	}
-	// When RELAY_REQUIRE_REGISTERED is on, wrap the actor-attributed write tools
-	// so an unregistered/anonymous identity is rejected before the write. Reads
-	// and the bootstrap tools (register_agent, whoami, get_session_context …)
-	// are never wrapped, so an agent can always register and orient first.
-	if h.requireRegistered {
-		for i := range tools {
-			if mutatingTools[tools[i].Tool.Name] {
-				tools[i].Handler = h.guardRegistered(tools[i].Handler)
-			}
+	// Identity is mandatory on every actor-attributed write: a call with no
+	// resolvable agent or project is rejected before the write. Reads and the
+	// bootstrap tools (register_agent, create_project, whoami,
+	// get_session_context …) are never wrapped, so an agent can always create
+	// its project, register, and orient first. This replaces the opt-in
+	// RELAY_REQUIRE_REGISTERED gate — there is no longer an anonymous/default
+	// path to fall back to.
+	for i := range tools {
+		if mutatingTools[tools[i].Tool.Name] {
+			tools[i].Handler = h.guardIdentity(tools[i].Handler)
 		}
 	}
 	return tools
@@ -148,25 +149,35 @@ var mutatingTools = map[string]bool{
 	"remove_team_member": true, "add_notify_channel": true,
 	"create_conversation": true, "invite_to_conversation": true,
 	"leave_conversation": true, "archive_conversation": true,
-	"create_project": true, "delete_project": true,
+	// create_project is intentionally absent: it is a bootstrap tool. Requiring a
+	// registered identity in a project that does not exist yet is a chicken-and-egg
+	// lock (you cannot register under a project before creating it).
+	"delete_project": true,
 }
 
-// guardRegistered wraps a tool handler to reject calls whose acting agent is
-// anonymous or not registered in the project. Only installed when
-// RELAY_REQUIRE_REGISTERED is on (see toolRegistry).
-func (h *Handlers) guardRegistered(next server.ToolHandlerFunc) server.ToolHandlerFunc {
+// guardIdentity wraps a mutating tool handler to reject any write that cannot
+// be attributed to a real agent in a real project. It enforces three things,
+// in order: a resolvable project, a resolvable agent identity, and that the
+// agent is actually registered in that project. Installed on every mutating
+// tool (see toolRegistry) — there is no anonymous/default path to fall through
+// to, so an untargeted or unidentified write fails loudly instead of silently
+// landing in a shared bucket.
+func (h *Handlers) guardIdentity(next server.ToolHandlerFunc) server.ToolHandlerFunc {
 	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		project := h.resolveProject(ctx, req)
+		if project == "" {
+			return mcp.NewToolResultError("no project resolved: pass project=<name> (or connect with ?project=<name>) — the 'default' catch-all was removed."), nil
+		}
 		from := strings.ToLower(resolveAgent(ctx, req))
-		project := ProjectFromContext(ctx)
-		if from == "" || from == "anonymous" {
-			return mcp.NewToolResultError("RELAY_REQUIRE_REGISTERED is on: no agent identity. Set ?agent=<name> on the MCP URL (or pass `as`) after calling register_agent."), nil
+		if from == "" {
+			return mcp.NewToolResultError("no agent identity: pass `as`=<name> (or connect with ?agent=<name>) after register_agent — the 'anonymous' fallback was removed."), nil
 		}
 		agent, err := h.db.GetAgent(project, from)
 		if err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("identity check failed: %v", err)), nil
 		}
 		if agent == nil {
-			return mcp.NewToolResultError(fmt.Sprintf("RELAY_REQUIRE_REGISTERED is on: agent %q is not registered in project %q — call register_agent first.", from, project)), nil
+			return mcp.NewToolResultError(fmt.Sprintf("agent %q is not registered in project %q — call register_agent first.", from, project)), nil
 		}
 		return next(ctx, req)
 	}

--- a/internal/relay/toolset.go
+++ b/internal/relay/toolset.go
@@ -179,6 +179,18 @@ func (h *Handlers) guardIdentity(next server.ToolHandlerFunc) server.ToolHandler
 		if agent == nil {
 			return mcp.NewToolResultError(fmt.Sprintf("agent %q is not registered in project %q — call register_agent first.", from, project)), nil
 		}
+		// Identity binding (best-effort, fail-open): if this MCP connection's
+		// session is provably bound to a DIFFERENT agent in the project, the
+		// caller is acting under a name that is not theirs — reject. When the
+		// session is unknown (unbound, or the in-memory registry was cleared by a
+		// restart), we cannot prove impersonation, so the write proceeds — the
+		// relay is the fleet's SSOT and must never drop a legitimate write on a
+		// guess. Bulletproof anti-theft would need a per-agent secret token.
+		if sess := sessionFromContext(ctx); sess != nil {
+			if owner, ok := h.registry.AgentForSession(project, sess.SessionID()); ok && owner != from {
+				return mcp.NewToolResultError(fmt.Sprintf("identity mismatch: this connection is registered as %q in project %q and cannot act as %q — use your own identity (or register_agent as %q).", owner, project, from, from)), nil
+			}
+		}
 		return next(ctx, req)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -226,13 +226,9 @@ func startServer() {
 	if cfg.MaxBody > 0 {
 		bodyStatus = fmt.Sprintf("%dKB", cfg.MaxBody/1024)
 	}
-	requireReg := "off"
-	if cfg.RequireRegistered {
-		requireReg = "on"
-	}
 	log.Printf("agent-relay starting on %s", addr)
-	log.Printf("  auth: %s | cors: %s | max body: %s | rate limit: %s | require-registered: %s",
-		authStatus, corsStatus, bodyStatus, rateLimitStatus, requireReg)
+	log.Printf("  auth: %s | cors: %s | max body: %s | rate limit: %s | identity: enforced (no anonymous/default)",
+		authStatus, corsStatus, bodyStatus, rateLimitStatus)
 
 	// serveErr surfaces a bind/listen failure (e.g. EADDRINUSE when a stale
 	// relay still holds the port after sleep/wake) so we exit non-zero instead


### PR DESCRIPTION
## What

v2 identity hardening — **zero silent fallbacks + connection-bound identity**. Every mutating call must resolve a **real agent** in a **real project**, and a connection can only act as **its own** agent.

## 1 · Kill the catch-alls
- **`anonymous`** — a connection with no `?agent=` used to become the literal `anonymous`.
- **`default`** — a call with no project landed in an implicit `default` project mixing unrelated teams.

Changes: `context.go` / `resolveProject` / `resolveAgent` return `""` when unresolved. `guardIdentity` (always-on) replaces the opt-in `RELAY_REQUIRE_REGISTERED` gate and rejects any write with no resolvable project, no identity, or an agent not registered in that project. Reads + bootstrap tools (`register_agent`, `create_project`, `whoami`, `get_session_context`) stay open. `RELAY_REQUIRE_REGISTERED` env + `Config.RequireRegistered` removed.

**Migration `migratePurgeDefaultProject`** (boot, idempotent, tables discovered live): removes the retired `default` project + all its rows; no longer auto-created. Applies automatically on auto-update restart.

## 2 · Identity binding (anti-impersonation, Option A)
`guardIdentity` also rejects a call whose `as` names an agent that is **not** the one this MCP connection's session is bound to (`SessionRegistry` → `AgentForSession`). **Fail-open**: unknown session, ambiguous binding, or post-restart empty registry → the write proceeds. Rejects **only** on a provable mismatch, so a legitimate write is never dropped. Bulletproof token-based binding deliberately deferred (would break every agent + hook).

## Breaking (intentional — owner-chosen hard reject)
After auto-update, a client sending no project / no identity / registering without a project is **rejected** instead of falling back. Every fleet agent already connects with explicit `project` + `as`. Prod `default` footprint purged (19 agents + 13 msgs).

## Gate
`build -tags fts5` OK · `vet` OK · `gofmt` OK · `test -tags fts5` **363 pass**
New tests: `TestMigratePurgeDefaultProject`, `TestGuardIdentity`, `TestGuardIdentityBinding`, `TestGuardInstalledOnMutatingTools`, `TestResolveProjectUnresolved` / `TestResolveAgentUnidentified` / `TestResolveProjectAmbiguousStaysUnresolved`.

## Follow-ups (separate PRs, same epic)
1. Non-MCP paths (REST `api_messages`, `webhook_github`, `linear`) still carry their own `= "default"` fallback — reject/skip at those boundaries.
2. Audit `mutatingTools` completeness — any actor-attributed write tool outside the set now resolves `project=""`.
3. `projects` string-FK → integer id + `ON DELETE CASCADE` (root of the "delete → clean / mauvais waterfall" item).

## review-wraith verdict: SHIP-WITH-NITS
Scope: relay identity resolution + guard + session binding + db default purge migration + config. Gate: build/vet/gofmt/test -tags fts5 all green (363 pass). Touches a DB migration → **not self-merge**, routed for review.
BLOCKERS: none.
NITS: follow-ups 1–2 above (non-MCP default fallbacks; mutatingTools completeness audit) — tracked, out of this PR's MCP-path scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)