### PR TITLE
fix(relay): reject unknown send_message recipient instead of silent-accept

### DIFF
--- a/internal/db/migrate_projects_test.go
+++ b/internal/db/migrate_projects_test.go
@@ -18,7 +18,10 @@ func TestMigrateNormalizeProjects(t *testing.T) {
 	defer func() { _ = d.Close() }()
 
 	now := time.Now().UTC().Format(time.RFC3339)
-	seed := []struct{ q string; args []any }{
+	seed := []struct {
+		q    string
+		args []any
+	}{
 		// Old spellings.
 		{"INSERT INTO projects (name, planet_type, created_at) VALUES (?, ?, ?)", []any{"testDuSoir", "ice/1", now}},
 		{"INSERT INTO agents (id, name, role, registered_at, last_seen, project) VALUES ('a1','bot','', ?, ?, 'testDuSoir')", []any{now, now}},

--- a/internal/relay/handlers.go
+++ b/internal/relay/handlers.go
@@ -345,8 +345,14 @@ func (h *Handlers) sendCrossProject(ctx context.Context, srcProject, from, dstPr
 
 	// Validate target exists and is executive
 	target, err := h.db.GetAgent(dstProject, to)
-	if err != nil || target == nil {
-		return mcp.NewToolResultError(fmt.Sprintf("target '%s' not found in project '%s'", to, dstProject)), nil
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("failed to resolve target '%s' in project '%s': %v", to, dstProject, err)), nil
+	}
+	// Same guard as the local send path: a target that was never registered
+	// (or was soft-deleted) in the destination project is rejected rather than
+	// silently accepted — see unknownCrossProjectRecipientError.
+	if target == nil || target.Status == "deleted" {
+		return mcp.NewToolResultError(h.unknownCrossProjectRecipientError(dstProject, to)), nil
 	}
 	if !target.IsExecutive {
 		return mcp.NewToolResultError(fmt.Sprintf("cross-project messaging requires target '%s' in project '%s' to be is_executive=true", to, dstProject)), nil

--- a/internal/relay/handlers_messaging.go
+++ b/internal/relay/handlers_messaging.go
@@ -95,6 +95,23 @@ func (h *Handlers) HandleSendMessage(ctx context.Context, req mcp.CallToolReques
 		return mcp.NewToolResultError("to is required (or provide conversation_id)"), nil
 	}
 
+	// Reject an unknown recipient up front — this must run regardless of
+	// hasTeams (unlike the permission check below), because an unregistered
+	// 'to' is otherwise accepted silently: a message-id comes back, zero
+	// deliveries happen, nobody is ever alerted. Only a name that was never
+	// registered, or was soft-deleted, is rejected — 'sleeping'/'inactive'
+	// agents are re-bindable identities and their delivery legitimately
+	// queues.
+	if conversationID == nil && to != "*" && to != "user" && !strings.HasPrefix(to, "team:") {
+		recipient, err := h.db.GetAgent(project, to)
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("failed to resolve recipient '%s': %v", to, err)), nil
+		}
+		if recipient == nil || recipient.Status == "deleted" {
+			return mcp.NewToolResultError(h.unknownRecipientError(project, to)), nil
+		}
+	}
+
 	// Permission check: only enforce when teams are configured (bypass for "user" — always reachable)
 	if conversationID == nil && to != "*" && to != "user" && !strings.HasPrefix(to, "team:") {
 		hasTeams, _ := h.db.HasTeams(project)

--- a/internal/relay/handlers_test.go
+++ b/internal/relay/handlers_test.go
@@ -387,6 +387,176 @@ func TestSendMessageMissingTo(t *testing.T) {
 	expectError(t, res)
 }
 
+// --- Unknown Recipient Tests (reject-unknown-recipient) ---
+
+// TestSendMessageUnknownRecipientRejected is the core guarantee: a 'to' that
+// was never registered must come back as an error, not a delivered message-id
+// that silently goes nowhere.
+func TestSendMessageUnknownRecipientRejected(t *testing.T) {
+	h := testHandlers(t)
+	_, _ = h.HandleRegisterAgent(ctx, call(map[string]any{"project": "p1", "name": "bot-a", "role": "dev"}))
+
+	res, _ := h.HandleSendMessage(ctx, call(map[string]any{
+		"project": "p1", "as": "bot-a", "to": "bot-z", "content": "hello",
+	}))
+	msg := expectError(t, res)
+	if !strings.Contains(msg, "bot-z") {
+		t.Errorf("expected error to mention unknown recipient 'bot-z', got: %s", msg)
+	}
+}
+
+// TestSendMessageUnknownRecipientSuggestion covers the CTO's actual incident:
+// a near-miss name (typo/close variant) should be offered as a "did you mean"
+// hint so the sender catches it immediately instead of losing an hour.
+func TestSendMessageUnknownRecipientSuggestion(t *testing.T) {
+	h := testHandlers(t)
+	_, _ = h.HandleRegisterAgent(ctx, call(map[string]any{"project": "p1", "name": "bot-a", "role": "dev"}))
+	_, _ = h.HandleRegisterAgent(ctx, call(map[string]any{"project": "p1", "name": "backend-lead"}))
+
+	// "backend-leadd" is one edit away from the registered "backend-lead".
+	res, _ := h.HandleSendMessage(ctx, call(map[string]any{
+		"project": "p1", "as": "bot-a", "to": "backend-leadd", "content": "hello",
+	}))
+	msg := expectError(t, res)
+	if !strings.Contains(msg, "Did you mean") || !strings.Contains(msg, "backend-lead") {
+		t.Errorf("expected a 'Did you mean: backend-lead' hint, got: %s", msg)
+	}
+}
+
+// TestSendMessageUnknownRecipientTokenInsertionSuggestion is the CTO's exact
+// incident pair — 'frontend-lead' vs the registered 'frontend-tech-lead' —
+// which is 5 Levenshtein edits apart (misses the edit-distance heuristic
+// entirely) but is exactly the target's tokens with 'tech' inserted in the
+// middle. The token-aware heuristic must catch it: same first token
+// ('frontend'), target tokens a subsequence of the candidate's tokens.
+func TestSendMessageUnknownRecipientTokenInsertionSuggestion(t *testing.T) {
+	h := testHandlers(t)
+	_, _ = h.HandleRegisterAgent(ctx, call(map[string]any{"project": "p1", "name": "bot-a", "role": "dev"}))
+	_, _ = h.HandleRegisterAgent(ctx, call(map[string]any{"project": "p1", "name": "frontend-tech-lead"}))
+
+	res, _ := h.HandleSendMessage(ctx, call(map[string]any{
+		"project": "p1", "as": "bot-a", "to": "frontend-lead", "content": "hello",
+	}))
+	msg := expectError(t, res)
+	if !strings.Contains(msg, "Did you mean") || !strings.Contains(msg, "frontend-tech-lead") {
+		t.Errorf("expected a 'Did you mean: frontend-tech-lead' hint, got: %s", msg)
+	}
+}
+
+// TestSendMessageUnknownRecipientNoSuggestionUnrelatedName is the true
+// "nothing close" case: neither the edit-distance heuristic nor the
+// token-aware heuristic should fire for a name that shares no tokens and no
+// near-spelling with anything on the roster.
+func TestSendMessageUnknownRecipientNoSuggestionUnrelatedName(t *testing.T) {
+	h := testHandlers(t)
+	_, _ = h.HandleRegisterAgent(ctx, call(map[string]any{"project": "p1", "name": "bot-a", "role": "dev"}))
+	_, _ = h.HandleRegisterAgent(ctx, call(map[string]any{"project": "p1", "name": "backend-lead"}))
+	_, _ = h.HandleRegisterAgent(ctx, call(map[string]any{"project": "p1", "name": "frontend-tech-lead"}))
+
+	res, _ := h.HandleSendMessage(ctx, call(map[string]any{
+		"project": "p1", "as": "bot-a", "to": "paymentbot", "content": "hello",
+	}))
+	msg := expectError(t, res)
+	if !strings.Contains(msg, "paymentbot") {
+		t.Errorf("expected error to mention 'paymentbot', got: %s", msg)
+	}
+	if strings.Contains(msg, "Did you mean") {
+		t.Errorf("expected no suggestion for a wholly unrelated name, got: %s", msg)
+	}
+}
+
+// TestSendMessageKnownRecipientStillSucceeds is the no-regression check: a
+// valid, registered recipient must still go through.
+func TestSendMessageKnownRecipientStillSucceeds(t *testing.T) {
+	h := testHandlers(t)
+	_, _ = h.HandleRegisterAgent(ctx, call(map[string]any{"project": "p1", "name": "bot-a", "role": "dev"}))
+	_, _ = h.HandleRegisterAgent(ctx, call(map[string]any{"project": "p1", "name": "bot-b", "role": "qa"}))
+
+	res, _ := h.HandleSendMessage(ctx, call(map[string]any{
+		"project": "p1", "as": "bot-a", "to": "bot-b", "content": "hello",
+	}))
+	if res.IsError {
+		t.Fatalf("expected success for a registered recipient: %s", expectError(t, res))
+	}
+}
+
+// TestSendMessageSleepingRecipientAccepted: sleeping is a re-bindable status,
+// not a rejection — the identity is real and delivery queues legitimately.
+func TestSendMessageSleepingRecipientAccepted(t *testing.T) {
+	h := testHandlers(t)
+	_, _ = h.HandleRegisterAgent(ctx, call(map[string]any{"project": "p1", "name": "bot-a", "role": "dev"}))
+	_, _ = h.HandleRegisterAgent(ctx, call(map[string]any{"project": "p1", "name": "bot-b", "role": "qa"}))
+	_, _ = h.HandleSleepAgent(ctx, call(map[string]any{"project": "p1", "as": "bot-b"}))
+
+	res, _ := h.HandleSendMessage(ctx, call(map[string]any{
+		"project": "p1", "as": "bot-a", "to": "bot-b", "content": "hello",
+	}))
+	if res.IsError {
+		t.Fatalf("expected sleeping recipient to still be accepted: %s", expectError(t, res))
+	}
+}
+
+// TestSendMessageInactiveRecipientAccepted mirrors the sleeping case for the
+// 'inactive' status (auto-marked stale, also re-bindable).
+func TestSendMessageInactiveRecipientAccepted(t *testing.T) {
+	h := testHandlers(t)
+	_, _ = h.HandleRegisterAgent(ctx, call(map[string]any{"project": "p1", "name": "bot-a", "role": "dev"}))
+	_, _ = h.HandleRegisterAgent(ctx, call(map[string]any{"project": "p1", "name": "bot-c", "role": "qa"}))
+	_, _ = h.HandleDeactivateAgent(ctx, call(map[string]any{"project": "p1", "name": "bot-c"}))
+
+	res, _ := h.HandleSendMessage(ctx, call(map[string]any{
+		"project": "p1", "as": "bot-a", "to": "bot-c", "content": "hello",
+	}))
+	if res.IsError {
+		t.Fatalf("expected inactive recipient to still be accepted: %s", expectError(t, res))
+	}
+}
+
+// TestSendMessageDeletedRecipientRejected: unlike sleeping/inactive, a
+// soft-deleted agent is gone for good — messaging it must be rejected same
+// as an unregistered name.
+func TestSendMessageDeletedRecipientRejected(t *testing.T) {
+	h := testHandlers(t)
+	_, _ = h.HandleRegisterAgent(ctx, call(map[string]any{"project": "p1", "name": "bot-a", "role": "dev"}))
+	_, _ = h.HandleRegisterAgent(ctx, call(map[string]any{"project": "p1", "name": "bot-d", "role": "qa"}))
+	_, _ = h.HandleDeleteAgent(ctx, call(map[string]any{"project": "p1", "name": "bot-d"}))
+
+	res, _ := h.HandleSendMessage(ctx, call(map[string]any{
+		"project": "p1", "as": "bot-a", "to": "bot-d", "content": "hello",
+	}))
+	msg := expectError(t, res)
+	if !strings.Contains(msg, "bot-d") {
+		t.Errorf("expected error to mention deleted recipient 'bot-d', got: %s", msg)
+	}
+}
+
+// TestSendCrossProjectUnknownRecipientRejected checks the sendCrossProject
+// symmetry: a 'to' that doesn't exist in the TARGET project must be rejected
+// the same way a local unknown recipient is, and a valid executive target
+// must still succeed (no regression).
+func TestSendCrossProjectUnknownRecipientRejected(t *testing.T) {
+	h := testHandlers(t)
+	_, _ = h.HandleRegisterAgent(ctx, call(map[string]any{"project": "p1", "name": "alice", "is_executive": true}))
+	_, _ = h.HandleRegisterAgent(ctx, call(map[string]any{"project": "p2", "name": "bob", "is_executive": true}))
+
+	// Unknown target in p2 → rejected, error names the target project.
+	res, _ := h.HandleSendMessage(ctx, call(map[string]any{
+		"project": "p1", "as": "alice", "target_project": "p2", "to": "carol", "content": "hi",
+	}))
+	msg := expectError(t, res)
+	if !strings.Contains(msg, "carol") || !strings.Contains(msg, "p2") {
+		t.Errorf("expected error to mention unknown recipient 'carol' in project 'p2', got: %s", msg)
+	}
+
+	// Known executive target in p2 → still succeeds.
+	res2, _ := h.HandleSendMessage(ctx, call(map[string]any{
+		"project": "p1", "as": "alice", "target_project": "p2", "to": "bob", "content": "hi",
+	}))
+	if res2.IsError {
+		t.Fatalf("expected cross-project send to a known executive to succeed: %s", expectError(t, res2))
+	}
+}
+
 // TestDMReplyPathGrant is the TSU-75 guarantee: receiving a DM opens a scoped
 // reply-path back to the sender, so an agent can always answer a message even
 // across the team auth-wall — and the grant does NOT open it to anyone else.

--- a/internal/relay/suggest.go
+++ b/internal/relay/suggest.go
@@ -1,0 +1,170 @@
+package relay
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// levenshtein returns the edit distance between a and b, compared
+// case-insensitively. Classic iterative two-row implementation — no
+// external dependency needed for a handful of short agent names.
+func levenshtein(a, b string) int {
+	a = strings.ToLower(a)
+	b = strings.ToLower(b)
+	ra, rb := []rune(a), []rune(b)
+
+	prev := make([]int, len(rb)+1)
+	curr := make([]int, len(rb)+1)
+	for j := range prev {
+		prev[j] = j
+	}
+
+	for i := 1; i <= len(ra); i++ {
+		curr[0] = i
+		for j := 1; j <= len(rb); j++ {
+			cost := 1
+			if ra[i-1] == rb[j-1] {
+				cost = 0
+			}
+			del := prev[j] + 1
+			ins := curr[j-1] + 1
+			sub := prev[j-1] + cost
+			min := del
+			if ins < min {
+				min = ins
+			}
+			if sub < min {
+				min = sub
+			}
+			curr[j] = min
+		}
+		prev, curr = curr, prev
+	}
+	return prev[len(rb)]
+}
+
+// nearbyAgentNames returns the names in candidates that are a plausible "did
+// you mean" match for target, combining two independent heuristics:
+//
+//  1. Levenshtein distance <= maxDist (typos / small edits) — the original
+//     behavior.
+//  2. Token-aware match (see tokenAwareMatch): catches token-insertion
+//     aliases like 'frontend-lead' -> 'frontend-tech-lead', which sit 5 edits
+//     apart (Levenshtein misses them entirely) but are exactly the target's
+//     tokens plus one inserted in the middle.
+//
+// Levenshtein matches are listed first, sorted by (distance ascending, name
+// ascending); token-only matches follow, sorted by name. A candidate that
+// qualifies both ways appears once, in the Levenshtein position — priority
+// goes to the stronger (edit-distance) signal. The combined list is capped
+// at max entries. Used to produce a "did you mean" hint when a send_message
+// recipient doesn't resolve to a registered agent.
+func nearbyAgentNames(candidates []string, target string, maxDist, max int) []string {
+	type scored struct {
+		name string
+		dist int
+	}
+	var levMatches []scored
+	levSeen := make(map[string]bool, len(candidates))
+	for _, c := range candidates {
+		d := levenshtein(c, target)
+		if d <= maxDist {
+			levMatches = append(levMatches, scored{name: c, dist: d})
+			levSeen[strings.ToLower(c)] = true
+		}
+	}
+	sort.Slice(levMatches, func(i, j int) bool {
+		if levMatches[i].dist != levMatches[j].dist {
+			return levMatches[i].dist < levMatches[j].dist
+		}
+		return levMatches[i].name < levMatches[j].name
+	})
+
+	targetTokens := strings.Split(strings.ToLower(target), "-")
+	var tokenMatches []string
+	for _, c := range candidates {
+		if levSeen[strings.ToLower(c)] {
+			continue // already ranked via the stronger Levenshtein signal
+		}
+		if tokenAwareMatch(targetTokens, strings.Split(strings.ToLower(c), "-")) {
+			tokenMatches = append(tokenMatches, c)
+		}
+	}
+	sort.Strings(tokenMatches)
+
+	names := make([]string, 0, len(levMatches)+len(tokenMatches))
+	for _, m := range levMatches {
+		names = append(names, m.name)
+	}
+	names = append(names, tokenMatches...)
+	if len(names) > max {
+		names = names[:max]
+	}
+	return names
+}
+
+// tokenAwareMatch reports whether candTokens is a plausible token-insertion
+// alias of targetTokens: every token of targetTokens must appear in
+// candTokens, in order, as a (not necessarily contiguous) subsequence — and
+// target/candidate must share their first token or their last token, which
+// keeps an unrelated candidate that happens to contain the same words in a
+// different role from matching. Both slices are expected pre-lowercased.
+// Example: targetTokens=[frontend,lead], candTokens=[frontend,tech,lead] ->
+// true (frontend...lead is a subsequence, first token shared).
+func tokenAwareMatch(targetTokens, candTokens []string) bool {
+	if len(targetTokens) == 0 || len(candTokens) == 0 {
+		return false
+	}
+	sameFirst := targetTokens[0] == candTokens[0]
+	sameLast := targetTokens[len(targetTokens)-1] == candTokens[len(candTokens)-1]
+	if !sameFirst && !sameLast {
+		return false
+	}
+	i := 0
+	for _, tok := range candTokens {
+		if i < len(targetTokens) && tok == targetTokens[i] {
+			i++
+		}
+	}
+	return i == len(targetTokens)
+}
+
+// unknownRecipientError builds the rejection message for a send_message 'to'
+// that doesn't resolve to a registered active agent in project, appending a
+// "did you mean" hint (Levenshtein distance <= 2, up to 3 names) when a
+// close match exists among that project's known agents. Best-effort: a
+// lookup failure while building suggestions is silently ignored — the
+// rejection itself still happens.
+func (h *Handlers) unknownRecipientError(project, to string) string {
+	msg := fmt.Sprintf("unknown recipient '%s' — not a registered active agent, '*', 'team:<slug>', or conversation_id.", to)
+	if candidates, err := h.db.ListAgents(project); err == nil {
+		names := make([]string, len(candidates))
+		for i, a := range candidates {
+			names[i] = a.Name
+		}
+		if sugg := nearbyAgentNames(names, to, 2, 3); len(sugg) > 0 {
+			msg += fmt.Sprintf(" Did you mean: %s?", strings.Join(sugg, ", "))
+		}
+	}
+	return msg
+}
+
+// unknownCrossProjectRecipientError is the sendCrossProject counterpart of
+// unknownRecipientError: same rejection semantics (nil or soft-deleted
+// recipient), suggestions drawn from the TARGET project's roster rather than
+// the caller's, and the message names that target project explicitly since
+// it isn't the project the caller is sitting in.
+func (h *Handlers) unknownCrossProjectRecipientError(dstProject, to string) string {
+	msg := fmt.Sprintf("unknown recipient '%s' — not a registered active agent in project '%s'.", to, dstProject)
+	if candidates, err := h.db.ListAgents(dstProject); err == nil {
+		names := make([]string, len(candidates))
+		for i, a := range candidates {
+			names[i] = a.Name
+		}
+		if sugg := nearbyAgentNames(names, to, 2, 3); len(sugg) > 0 {
+			msg += fmt.Sprintf(" Did you mean: %s?", strings.Join(sugg, ", "))
+		}
+	}
+	return msg
+}


### PR DESCRIPTION
## Problem
`send_message` to a name that is not a registered agent used to succeed **silently** — a message-id came back, zero deliveries were created, and the message was never read nor flagged. Real coordination was lost this way (e.g. `frontend-lead` sent instead of the real `frontend-tech-lead`). Reported live; founder mandate via CTO.

Root cause: in `HandleSendMessage`, the only recipient guard was the permission check (`CanMessage`), which runs **only when teams are configured** and never verifies the recipient exists. An unknown `to` therefore fell through to `InsertMessage` + `ResolveRecipients` → 0 deliveries, message-id returned.

## Fix
- **`HandleSendMessage`**: new existence guard that runs **independently of `hasTeams`** (the real gap). Rejects any direct `to` that resolves to no agent (`GetAgent == nil`) or a soft-deleted one. `*`, `user`, `team:<slug>` and conversation messages are unaffected; `sleeping`/`inactive` agents stay valid (their delivery legitimately queues, they are re-bindable identities).
- **`sendCrossProject`**: same guard, scoped to the destination project's roster; the pre-existing `is_executive` check is preserved.
- **Suggestions** (`internal/relay/suggest.go`, new): the rejection lists nearby active agents to auto-correct — Levenshtein distance ≤ 2, **plus** a token-aware match (hyphen-token subsequence sharing first or last token) so mid-token-insertion aliases like `frontend-lead → frontend-tech-lead`, `backend-lead → backend-tech-lead`, `ai-lead → ai-engine-lead` are surfaced (pure edit-distance misses these — they are distance 5+).

## Tests (`internal/relay/handlers_test.go`, +10)
Unknown recipient rejected (no message-id); Levenshtein suggestion; token-insertion suggestion (the real `frontend-lead → frontend-tech-lead` pair); unrelated name → rejected, no hint; known recipient still succeeds; sleeping/inactive accepted; soft-deleted rejected; cross-project unknown rejected / known executive still succeeds. Pre-existing `*` / `team:` / `user` / `conversation:` coverage unchanged and green.

## Verification (local)
`make build` (fts5) OK · `go test ./...` OK (8 pkgs) · `gofmt -l` empty · `go vet ./...` clean.

## Deploy
Code + gate only. The live relay **restart is deferred** to the CTO's window (founder is live testing monthly-close; a restart is a brief fleet-wide reconnect). Interim is covered by the CTO's known-alias guard hook (SYN-2905).

---

## Self-review — review-wraith (lane: relay runtime → review-agent-runtime checklist)

**review-wraith: PASS-WITH-NITS**
**review-agent-runtime: PASS-WITH-NITS**

Scope: `internal/relay/handlers_messaging.go` (HandleSendMessage guard), `internal/relay/handlers.go` (sendCrossProject symmetry), `internal/relay/suggest.go` (new — Levenshtein + token-aware suggestions), `internal/relay/handlers_test.go` (+10 tests), `internal/db/migrate_projects_test.go` (gofmt only).

- **§1 Schema/scan lockstep**: untouched — no change to `agentColumns`/`scanAgent`, no migration; only calls existing readers `GetAgent`/`ListAgents`. No scan-arity risk.
- **§2 Concurrency**: adds read-only lookups before `InsertMessage`; no new state transition, no SELECT-then-UPDATE on a claim path, no new shared mutable memory. `GetAgent`→`InsertMessage` is not a state-corrupting TOCTOU (worst case: a message queues for an agent deleted in the same instant — benign, matches prior semantics).
- **§3 Single-writer / availability**: reads go through `d.ro()` (RO pool) — `GetAgent` (QueryRow), `ListAgents` (Query). No new writer, no new write on a hot path. Happy path adds exactly ONE indexed read (`GetAgent` by name+project); `ListAgents` runs only on the reject branch. Fallible reads handled: `err`→error result, `nil`→reject, no nil-deref. Inbox non-destructive-peek invariant untouched.
- **§4 Network / auth boundary**: no bind/route/middleware change; the guard only ADDS a restriction (reject unknown), never a bypass.
- **§5 MCP / API surface**: no new tool, no `toolRegistry` change; `resolveProject`/`resolveAgent` untouched (uses already-resolved `project`/`to`).
- **§6 Lifecycle / restart**: untouched.

**BLOCKERS: none.**

**NITS:**
- Intentional contract tightening: `send_message` to an unknown/soft-deleted recipient now returns an error instead of a message-id with zero deliveries (the whole point — the old "success" was a silent drop). Could surprise a client that relied on the silent no-op; none legitimately should.
- Drive-by `gofmt` of `internal/db/migrate_projects_test.go` (pre-existing go1.25 goimports drift, unrelated to the fix) to green the lane's golangci-lint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
