### PR TITLE
fix: session rebind ambiguity (#153), delete_team (#150), ar init stdio (#20), unread HTTP endpoint (#17)

### DIFF
--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -78,19 +78,19 @@ func runInit(args []string) {
 
 	// Check if file already exists
 	if _, err := os.Stat(mcpPath); err == nil {
-		// File exists — try to merge
+		// File exists — merge losslessly. Existing entries are kept as raw JSON so
+		// stdio-style servers (command/args/env) and any other keys survive the
+		// round-trip; typing them into the narrow http-only struct would drop
+		// those fields and corrupt the user's config (issue #20).
 		existing, err := os.ReadFile(mcpPath)
 		if err == nil {
-			var cfg mcpConfig
-			if json.Unmarshal(existing, &cfg) == nil {
-				if entry, exists := cfg.MCPServers["agent-relay"]; exists {
+			if root, already, existingURL, ok := mergeRelayServer(existing, url); ok {
+				if already {
 					fmt.Printf("agent-relay already configured in %s\n", mcpPath)
-					fmt.Printf("  url: %s\n", entry.URL)
+					fmt.Printf("  url: %s\n", existingURL)
 					return
 				}
-				// Add agent-relay to existing config
-				cfg.MCPServers["agent-relay"] = mcpServerEntry{Type: "http", URL: url}
-				writeConfig(mcpPath, cfg)
+				writeConfig(mcpPath, root)
 				fmt.Printf("added agent-relay to existing %s\n", mcpPath)
 				fmt.Printf("  url: %s\n", url)
 				return
@@ -127,7 +127,36 @@ func runInit(args []string) {
 	fmt.Println("  3. Call register_agent() to announce your presence")
 }
 
-func writeConfig(path string, cfg mcpConfig) {
+// mergeRelayServer adds the agent-relay entry to an existing .mcp.json without
+// disturbing anything else. Existing servers are kept as raw JSON so stdio-style
+// entries (command/args/env) and any unknown top-level keys survive the
+// round-trip — the http-only struct would silently drop those fields (issue #20).
+// ok=false means the input wasn't parseable JSON (caller falls back to a fresh
+// config). already=true means agent-relay was present; existingURL is its url.
+func mergeRelayServer(existing []byte, url string) (root map[string]json.RawMessage, already bool, existingURL string, ok bool) {
+	if json.Unmarshal(existing, &root) != nil {
+		return nil, false, "", false
+	}
+	var servers map[string]json.RawMessage
+	if raw, has := root["mcpServers"]; has {
+		_ = json.Unmarshal(raw, &servers)
+	}
+	if servers == nil {
+		servers = map[string]json.RawMessage{}
+	}
+	if raw, exists := servers["agent-relay"]; exists {
+		var entry mcpServerEntry
+		_ = json.Unmarshal(raw, &entry)
+		return root, true, entry.URL, true
+	}
+	entryJSON, _ := json.Marshal(mcpServerEntry{Type: "http", URL: url})
+	servers["agent-relay"] = entryJSON
+	serversJSON, _ := json.Marshal(servers)
+	root["mcpServers"] = serversJSON
+	return root, false, "", true
+}
+
+func writeConfig(path string, cfg any) {
 	data, err := json.MarshalIndent(cfg, "", "  ")
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)

--- a/internal/cli/init_test.go
+++ b/internal/cli/init_test.go
@@ -1,0 +1,79 @@
+package cli
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// Issue #20: `ar init` must not corrupt existing stdio-style MCP servers
+// (command/args/env form) when it adds the agent-relay entry.
+func TestMergeRelayServerPreservesStdioEntries(t *testing.T) {
+	existing := []byte(`{
+	  "mcpServers": {
+	    "filesystem": {
+	      "command": "npx",
+	      "args": ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"],
+	      "env": {"FOO": "bar"}
+	    }
+	  },
+	  "someOtherTopLevelKey": {"keep": true}
+	}`)
+
+	root, already, _, ok := mergeRelayServer(existing, "http://localhost:8090/mcp")
+	if !ok {
+		t.Fatal("expected parse ok")
+	}
+	if already {
+		t.Fatal("agent-relay was not present; already must be false")
+	}
+
+	out, _ := json.Marshal(root)
+
+	// Unknown top-level key survives.
+	if root["someOtherTopLevelKey"] == nil {
+		t.Error("top-level key dropped")
+	}
+
+	var parsed struct {
+		MCPServers map[string]struct {
+			Type    string            `json:"type"`
+			URL     string            `json:"url"`
+			Command string            `json:"command"`
+			Args    []string          `json:"args"`
+			Env     map[string]string `json:"env"`
+		} `json:"mcpServers"`
+	}
+	if err := json.Unmarshal(out, &parsed); err != nil {
+		t.Fatalf("re-parse: %v", err)
+	}
+
+	fs, hasFS := parsed.MCPServers["filesystem"]
+	if !hasFS {
+		t.Fatal("stdio server 'filesystem' dropped")
+	}
+	if fs.Command != "npx" || len(fs.Args) != 3 || fs.Env["FOO"] != "bar" {
+		t.Errorf("stdio fields corrupted: %+v", fs)
+	}
+	if relay, ok := parsed.MCPServers["agent-relay"]; !ok || relay.URL == "" {
+		t.Errorf("agent-relay entry not added: %+v", relay)
+	}
+}
+
+// Idempotency: re-running detects the existing agent-relay entry and reports it.
+func TestMergeRelayServerAlreadyConfigured(t *testing.T) {
+	existing := []byte(`{"mcpServers":{"agent-relay":{"type":"http","url":"http://localhost:8090/mcp"}}}`)
+	_, already, existingURL, ok := mergeRelayServer(existing, "http://localhost:9999/mcp")
+	if !ok || !already {
+		t.Fatalf("expected already-configured, got ok=%v already=%v", ok, already)
+	}
+	if existingURL != "http://localhost:8090/mcp" {
+		t.Errorf("wrong existing url: %s", existingURL)
+	}
+}
+
+// Non-JSON input signals the caller to fall back to a fresh config.
+func TestMergeRelayServerBadJSON(t *testing.T) {
+	if _, _, _, ok := mergeRelayServer([]byte("not json"), "http://x/mcp"); ok {
+		t.Error("expected ok=false for unparseable input")
+	}
+}

--- a/internal/db/agents.go
+++ b/internal/db/agents.go
@@ -286,31 +286,84 @@ func (d *DB) SetAgentCwd(project, name, cwd string) error {
 	return nil
 }
 
-// RebindSessionByCwd points the agent bound to cwd at a new session_id (Claude
-// Code rotates session_id on /clear; cwd is stable). Returns the agent's project
-// and name, and found=false when no active agent owns that cwd. cwd is globally
-// unique (one agent = one worktree), so no project scoping is needed.
-func (d *DB) RebindSessionByCwd(cwd, sessionID string) (project, name string, found bool, err error) {
-	if cwd == "" {
-		return "", "", false, nil
+// RebindSession points an agent at a new session_id (Claude Code rotates
+// session_id on /clear; cwd is stable). Identity is resolved in this order:
+//
+//  1. agentName, when non-empty — the launcher forwarded RELAY_AGENT and knows
+//     exactly which agent it is starting. cwd, when present, scopes the project
+//     so a name reused across projects stays distinct. This is the correct path
+//     for fleets that deliberately share one worktree.
+//  2. cwd alone — only safe when cwd uniquely identifies an agent. If more than
+//     one non-deleted agent shares cwd the key is AMBIGUOUS: the function refuses
+//     to guess (found=false, ambiguous=true) rather than bind a wrong identity
+//     and detach a correctly-bound session. A silent miss is recoverable; a
+//     confident wrong identity is not.
+//
+// The session_id UPDATE only fires on a unique match, so an ambiguous cwd can
+// never overwrite (and thus mis-attribute) another agent's live binding.
+func (d *DB) RebindSession(cwd, agentName, sessionID string) (project, name string, found, ambiguous bool, err error) {
+	if cwd == "" && agentName == "" {
+		return "", "", false, false, nil
 	}
-	row := d.ro().QueryRow(
-		"SELECT project, name FROM agents WHERE cwd = ? AND status != 'deleted' LIMIT 1",
-		cwd,
-	)
+
+	var row *sql.Row
+	switch {
+	case agentName != "" && cwd != "":
+		row = d.ro().QueryRow(
+			"SELECT project, name FROM agents WHERE name = ? AND cwd = ? AND status != 'deleted' LIMIT 1",
+			agentName, cwd)
+	case agentName != "":
+		row = d.ro().QueryRow(
+			"SELECT project, name FROM agents WHERE name = ? AND status != 'deleted' LIMIT 1",
+			agentName)
+	default:
+		// cwd-only fallback: refuse ambiguous keys.
+		var n int
+		if e := d.ro().QueryRow(
+			"SELECT COUNT(*) FROM agents WHERE cwd = ? AND status != 'deleted'", cwd,
+		).Scan(&n); e != nil {
+			return "", "", false, false, fmt.Errorf("rebind session: count by cwd: %w", e)
+		}
+		if n > 1 {
+			return "", "", false, true, nil // ambiguous — caller logs, binds nothing
+		}
+		row = d.ro().QueryRow(
+			"SELECT project, name FROM agents WHERE cwd = ? AND status != 'deleted' LIMIT 1", cwd)
+	}
+
 	switch e := row.Scan(&project, &name); {
 	case e == sql.ErrNoRows:
-		return "", "", false, nil
+		return "", "", false, false, nil
 	case e != nil:
-		return "", "", false, fmt.Errorf("rebind session by cwd: %w", e)
+		return "", "", false, false, fmt.Errorf("rebind session: %w", e)
 	}
 	if _, e := d.conn.Exec(
 		"UPDATE agents SET session_id = ? WHERE project = ? AND name = ?",
 		sessionID, project, name,
 	); e != nil {
-		return "", "", false, fmt.Errorf("rebind session by cwd: %w", e)
+		return "", "", false, false, fmt.Errorf("rebind session: update: %w", e)
 	}
-	return project, name, true, nil
+	return project, name, true, false, nil
+}
+
+// AgentNamesByCwd lists the non-deleted agents sharing a cwd — used to name the
+// colliding agents in the warning logged when a cwd rebind key is ambiguous.
+func (d *DB) AgentNamesByCwd(cwd string) ([]string, error) {
+	rows, err := d.ro().Query(
+		"SELECT name FROM agents WHERE cwd = ? AND status != 'deleted' ORDER BY name", cwd)
+	if err != nil {
+		return nil, fmt.Errorf("agent names by cwd: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	var names []string
+	for rows.Next() {
+		var n string
+		if err := rows.Scan(&n); err != nil {
+			return nil, fmt.Errorf("agent names by cwd: scan: %w", err)
+		}
+		names = append(names, n)
+	}
+	return names, rows.Err()
 }
 
 // GetOrgTree returns all active agents ordered for tree display (managers first).

--- a/internal/db/messages.go
+++ b/internal/db/messages.go
@@ -123,6 +123,36 @@ func (d *DB) GetInbox(project, agentName string, unreadOnly bool, limit int, fil
 	return d.getInboxLegacy(project, agentName, unreadOnly, limit, f)
 }
 
+// UnreadCountForAgent returns how many unread messages an agent has, without
+// mutating delivery state (unlike GetInbox, which marks queued deliveries
+// surfaced). This backs the HTTP unread-count endpoint (issue #17) so a poller
+// can cheaply check for new mail without draining the inbox.
+func (d *DB) UnreadCountForAgent(project, agentName string) (int, error) {
+	if d.HasDeliveries() {
+		var n int
+		err := d.ro().QueryRow(`
+			SELECT COUNT(*)
+			FROM deliveries d
+			JOIN messages m ON d.message_id = m.id
+			WHERE d.project = ? AND d.to_agent = ?
+			  AND d.state IN ('queued', 'surfaced')
+			  AND m.expired_at IS NULL
+			  AND (m.ttl_seconds = 0 OR datetime(m.created_at, '+' || m.ttl_seconds || ' seconds') > datetime('now'))
+		`, project, agentName).Scan(&n)
+		if err != nil {
+			return 0, fmt.Errorf("unread count for agent: %w", err)
+		}
+		return n, nil
+	}
+	// Legacy DBs (no deliveries table): reuse the read query, which is
+	// non-mutating, and count. Legacy inboxes are small and rare.
+	msgs, err := d.getInboxLegacy(project, agentName, true, 100000, InboxFilter{})
+	if err != nil {
+		return 0, err
+	}
+	return len(msgs), nil
+}
+
 // getInboxLegacy is the original inbox query for DBs without deliveries.
 func (d *DB) getInboxLegacy(project, agentName string, unreadOnly bool, limit int, f InboxFilter) ([]models.Message, error) {
 	if limit <= 0 {

--- a/internal/db/orgs.go
+++ b/internal/db/orgs.go
@@ -171,6 +171,40 @@ func (d *DB) GetTeamByID(teamID string) (*models.Team, error) {
 	return &t, nil
 }
 
+// DeleteTeam removes a team and its membership + inbox rows in one transaction.
+// Retiring a channel must be a real operation: leaving a team memberless keeps
+// the slug addressable, so a send to it is accepted but delivered to nobody
+// (issue #150). Delivered messages themselves are untouched — only the team's
+// inbox references drop. Returns an error if no team with that slug exists.
+func (d *DB) DeleteTeam(project, slug string) error {
+	tx, err := d.conn.Begin()
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	var teamID string
+	err = tx.QueryRow("SELECT id FROM teams WHERE project = ? AND slug = ?", project, slug).Scan(&teamID)
+	if err == sql.ErrNoRows {
+		return fmt.Errorf("team %q not found in project %q", slug, project)
+	}
+	if err != nil {
+		return fmt.Errorf("delete team: lookup: %w", err)
+	}
+
+	// Children first (junction tables), then the team row.
+	if _, err := tx.Exec("DELETE FROM team_inbox WHERE team_id = ?", teamID); err != nil {
+		return fmt.Errorf("delete team inbox: %w", err)
+	}
+	if _, err := tx.Exec("DELETE FROM team_members WHERE team_id = ?", teamID); err != nil {
+		return fmt.Errorf("delete team members: %w", err)
+	}
+	if _, err := tx.Exec("DELETE FROM teams WHERE id = ?", teamID); err != nil {
+		return fmt.Errorf("delete team row: %w", err)
+	}
+	return tx.Commit()
+}
+
 // --- Team Members ---
 
 func (d *DB) AddTeamMember(teamID, agentName, project, role string) error {

--- a/internal/db/teams_delete_test.go
+++ b/internal/db/teams_delete_test.go
@@ -1,0 +1,68 @@
+package db
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// Issue #150: delete_team must actually retire a team — row, members, inbox refs.
+func TestDeleteTeam(t *testing.T) {
+	d, err := NewTestDB(filepath.Join(t.TempDir(), "t.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	team, err := d.CreateTeam("Backend", "backend", "proj", "", "regular", nil, nil)
+	if err != nil {
+		t.Fatalf("create team: %v", err)
+	}
+	if err := d.AddTeamMember(team.ID, "alice", "proj", "member"); err != nil {
+		t.Fatalf("add member: %v", err)
+	}
+	if err := d.AddToTeamInbox(team.ID, "msg-1"); err != nil {
+		t.Fatalf("add inbox: %v", err)
+	}
+
+	if err := d.DeleteTeam("proj", "backend"); err != nil {
+		t.Fatalf("delete team: %v", err)
+	}
+
+	// Team is gone.
+	if got, _ := d.GetTeam("proj", "backend"); got != nil {
+		t.Errorf("team still resolvable after delete: %+v", got)
+	}
+	// Membership gone.
+	if members, _ := d.GetTeamMemberNames(team.ID); len(members) != 0 {
+		t.Errorf("members not cleared: %v", members)
+	}
+
+	// Deleting a missing team is an explicit error, not a silent success.
+	if err := d.DeleteTeam("proj", "backend"); err == nil {
+		t.Error("expected error deleting non-existent team")
+	}
+}
+
+func TestUnreadCountForAgent(t *testing.T) {
+	d, err := NewTestDB(filepath.Join(t.TempDir(), "t.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := d.RegisterAgent("proj", "bob", "dev", "", nil, nil, false, nil, "[]", 0, RegisterOptions{}); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+
+	if n, err := d.UnreadCountForAgent("proj", "bob"); err != nil || n != 0 {
+		t.Fatalf("empty inbox: got %d, err %v", n, err)
+	}
+
+	if _, err := d.InsertMessageWithDeliveries("proj", "alice", "bob", "note", "hi", "body", "", "normal", 0, nil, nil, []string{"bob"}); err != nil {
+		t.Fatalf("insert msg: %v", err)
+	}
+	// Count must not mutate delivery state, so a second call is still 1.
+	for i := 0; i < 2; i++ {
+		n, err := d.UnreadCountForAgent("proj", "bob")
+		if err != nil || n != 1 {
+			t.Fatalf("call %d: expected 1 unread, got %d, err %v", i, n, err)
+		}
+	}
+}

--- a/internal/relay/api.go
+++ b/internal/relay/api.go
@@ -63,6 +63,8 @@ func (r *Relay) ServeAPI(w http.ResponseWriter, req *http.Request) {
 		r.apiGetConversations(w, req)
 	case strings.HasPrefix(path, "/conversations/") && strings.HasSuffix(path, "/messages") && req.Method == http.MethodGet:
 		r.apiGetConversationMessages(w, path)
+	case path == "/inbox/unread-count" && req.Method == http.MethodGet:
+		r.apiGetUnreadCount(w, req)
 	case path == "/messages" && req.Method == http.MethodGet:
 		r.apiGetAllMessages(w, req)
 	case path == "/messages" && req.Method == http.MethodPost:

--- a/internal/relay/api_messages.go
+++ b/internal/relay/api_messages.go
@@ -72,6 +72,28 @@ func (r *Relay) apiGetAgentHealth(w http.ResponseWriter, req *http.Request) {
 	writeJSON(w, data)
 }
 
+// apiGetUnreadCount is the HTTP equivalent of the get_inbox unread count so a
+// poller can check for new mail without an MCP round-trip and without draining
+// the inbox (non-mutating — no deliveries are marked surfaced). Issue #17.
+// Path: GET /api/inbox/unread-count?agent=<name>&project=<p>
+func (r *Relay) apiGetUnreadCount(w http.ResponseWriter, req *http.Request) {
+	agent := strings.ToLower(req.URL.Query().Get("agent"))
+	if agent == "" {
+		apiError(w, http.StatusBadRequest, "agent query param required", nil)
+		return
+	}
+	project := req.URL.Query().Get("project")
+	if project == "" {
+		project = "default"
+	}
+	n, err := r.DB.UnreadCountForAgent(project, agent)
+	if err != nil {
+		apiError(w, http.StatusInternalServerError, "failed to get unread count", err)
+		return
+	}
+	writeJSON(w, map[string]any{"agent": agent, "project": project, "unread": n})
+}
+
 // apiPostMessage is the plain-REST send endpoint (owner directive: dokan scripts
 // notify the relay over REST, never the /mcp JSON-RPC call_tool dispatcher). It
 // reuses the same delivery primitives as send_message for the cases a notifier

--- a/internal/relay/handlers_ingest.go
+++ b/internal/relay/handlers_ingest.go
@@ -3,6 +3,7 @@ package relay
 import (
 	"encoding/json"
 	"fmt"
+	"log"
 	"net/http"
 	"time"
 
@@ -37,6 +38,7 @@ type ingestTokensReq struct {
 type ingestSessionStartReq struct {
 	SessionID      string `json:"session_id"`
 	Cwd            string `json:"cwd"`
+	Agent          string `json:"agent,omitempty"`  // explicit identity (RELAY_AGENT); wins over cwd inference
 	Source         string `json:"source,omitempty"` // startup | resume | clear | compact
 	TranscriptPath string `json:"transcript_path,omitempty"`
 }
@@ -110,15 +112,24 @@ func (r *Relay) handleIngestSessionStart(w http.ResponseWriter, req *http.Reques
 		apiError(w, http.StatusBadRequest, "invalid json", err)
 		return
 	}
-	if body.SessionID == "" || body.Cwd == "" {
-		apiError(w, http.StatusBadRequest, "session_id and cwd required", nil)
+	if body.SessionID == "" || (body.Cwd == "" && body.Agent == "") {
+		apiError(w, http.StatusBadRequest, "session_id and (cwd or agent) required", nil)
 		return
 	}
 
-	project, name, found, err := r.DB.RebindSessionByCwd(body.Cwd, body.SessionID)
+	project, name, found, ambiguous, err := r.DB.RebindSession(body.Cwd, body.Agent, body.SessionID)
 	if err != nil {
 		apiError(w, http.StatusInternalServerError, "rebind failed", err)
 		return
+	}
+	if ambiguous {
+		// N agents share this cwd and no explicit agent was forwarded — the key
+		// cannot identify one. Bind nothing (a wrong identity is worse than none)
+		// and name the collision so the operator can forward RELAY_AGENT or give
+		// each agent a distinct cwd. See issue #153.
+		names, _ := r.DB.AgentNamesByCwd(body.Cwd)
+		log.Printf("session-start: ambiguous cwd %q shared by %d agents %v — not binding session %s; forward RELAY_AGENT to disambiguate",
+			body.Cwd, len(names), names, body.SessionID)
 	}
 
 	// Mark the session active in the detector so the board reflects it immediately.

--- a/internal/relay/handlers_ingest_test.go
+++ b/internal/relay/handlers_ingest_test.go
@@ -124,6 +124,103 @@ func TestIngestSessionStartUnknownCwd(t *testing.T) {
 	}
 }
 
+// Issue #153: N agents deliberately share one worktree. cwd alone cannot
+// identify one, so the relay must refuse to guess rather than bind an arbitrary
+// agent (which mis-attributes token usage and injects a wrong identity).
+func TestIngestSessionStartAmbiguousCwdBindsNothing(t *testing.T) {
+	r := testRelay(t)
+	for _, n := range []string{"frontend", "documentor"} {
+		if _, _, err := r.DB.RegisterAgent("proj", n, "dev", "", nil, nil, false, nil, "[]", 0, db.RegisterOptions{}); err != nil {
+			t.Fatalf("register %s: %v", n, err)
+		}
+		if err := r.DB.SetAgentCwd("proj", n, "/wt/shared"); err != nil {
+			t.Fatalf("set cwd %s: %v", n, err)
+		}
+	}
+
+	w := doAPI(r, "POST", "/ingest/session-start", `{"session_id":"unseen","cwd":"/wt/shared","source":"startup"}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	resp := decodeJSON(t, w)
+	if resp["bound"] != false {
+		t.Fatalf("expected bound=false on ambiguous cwd, got %v", resp["bound"])
+	}
+	if _, hasAgent := resp["agent"]; hasAgent {
+		t.Errorf("ambiguous cwd must not name an agent, got %v", resp["agent"])
+	}
+	// No agent's session_id may have been touched.
+	for _, n := range []string{"frontend", "documentor"} {
+		a, err := r.DB.GetAgent("proj", n)
+		if err != nil || a == nil {
+			t.Fatalf("get %s: %v", n, err)
+		}
+		if a.SessionID != nil {
+			t.Errorf("%s session_id must stay unbound, got %v", n, *a.SessionID)
+		}
+	}
+}
+
+// Issue #153: an explicit agent (RELAY_AGENT) is authoritative and resolves the
+// shared-worktree case with zero inference.
+func TestIngestSessionStartExplicitAgentWinsOverAmbiguousCwd(t *testing.T) {
+	r := testRelay(t)
+	for _, n := range []string{"frontend", "documentor"} {
+		if _, _, err := r.DB.RegisterAgent("proj", n, "dev", "", nil, nil, false, nil, "[]", 0, db.RegisterOptions{}); err != nil {
+			t.Fatalf("register %s: %v", n, err)
+		}
+		if err := r.DB.SetAgentCwd("proj", n, "/wt/shared"); err != nil {
+			t.Fatalf("set cwd %s: %v", n, err)
+		}
+	}
+
+	w := doAPI(r, "POST", "/ingest/session-start", `{"session_id":"doc-session","cwd":"/wt/shared","agent":"documentor"}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if resp := decodeJSON(t, w); resp["bound"] != true || resp["agent"] != "documentor" {
+		t.Fatalf("expected bound documentor, got %v", resp)
+	}
+	doc, _ := r.DB.GetAgent("proj", "documentor")
+	if doc.SessionID == nil || *doc.SessionID != "doc-session" {
+		t.Errorf("documentor session_id not bound, got %v", doc.SessionID)
+	}
+	fe, _ := r.DB.GetAgent("proj", "frontend")
+	if fe.SessionID != nil {
+		t.Errorf("frontend must be untouched, got %v", *fe.SessionID)
+	}
+}
+
+// Issue #17: HTTP unread-count endpoint mirrors the get_inbox count without an
+// MCP round-trip and without draining the inbox.
+func TestAPIUnreadCount(t *testing.T) {
+	r := testRelay(t)
+	if _, _, err := r.DB.RegisterAgent("proj", "bob", "dev", "", nil, nil, false, nil, "[]", 0, db.RegisterOptions{}); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+
+	w := doAPI(r, "GET", "/inbox/unread-count?agent=bob&project=proj", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if resp := decodeJSON(t, w); resp["unread"].(float64) != 0 {
+		t.Fatalf("expected 0 unread, got %v", resp["unread"])
+	}
+
+	if _, err := r.DB.InsertMessageWithDeliveries("proj", "alice", "bob", "note", "hi", "body", "", "normal", 0, nil, nil, []string{"bob"}); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	w = doAPI(r, "GET", "/inbox/unread-count?agent=bob&project=proj", "")
+	if resp := decodeJSON(t, w); resp["unread"].(float64) != 1 {
+		t.Fatalf("expected 1 unread, got %v", resp["unread"])
+	}
+
+	// Missing agent param → 400.
+	if w := doAPI(r, "GET", "/inbox/unread-count?project=proj", ""); w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 without agent, got %d", w.Code)
+	}
+}
+
 func TestIngestActivityNilIngesterIsNoOp(t *testing.T) {
 	r := testRelay(t) // Ingester is nil in the test harness
 	w := doAPI(r, "POST", "/ingest/activity", `{"session_id":"s","type":"tool_start","tool":"Edit"}`)

--- a/internal/relay/handlers_messaging.go
+++ b/internal/relay/handlers_messaging.go
@@ -119,6 +119,17 @@ func (h *Handlers) HandleSendMessage(ctx context.Context, req mcp.CallToolReques
 
 		// Resolve team recipients first, then insert message + deliveries atomically.
 		members, _ := h.db.GetTeamMemberNames(team.ID)
+
+		// An empty (or all-inactive) team is a silent black hole: the send would
+		// look successful yet reach nobody. Fail loudly so the condition is
+		// observable to the sender rather than swallowed (issue #150). A team
+		// whose only member is the sender is NOT this case — the message still
+		// lands in the team inbox as a record.
+		if len(members) == 0 {
+			return mcp.NewToolResultError(fmt.Sprintf(
+				"team '%s' has no members — message not sent (it would reach nobody). Add members with add_team_member, or delete_team to retire the channel.", teamSlug)), nil
+		}
+
 		var recipients []string
 		for _, member := range members {
 			if member != from {

--- a/internal/relay/handlers_teams.go
+++ b/internal/relay/handlers_teams.go
@@ -124,6 +124,24 @@ func (h *Handlers) HandleAddTeamMember(ctx context.Context, req mcp.CallToolRequ
 	})
 }
 
+func (h *Handlers) HandleDeleteTeam(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	project := h.resolveProject(ctx, req)
+	teamSlug := req.GetString("team", "")
+
+	if teamSlug == "" {
+		return mcp.NewToolResultError("team is required"), nil
+	}
+
+	if err := h.db.DeleteTeam(project, teamSlug); err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("failed to delete team: %v", err)), nil
+	}
+
+	return h.resultJSONTracked(project, "", "delete_team", map[string]any{
+		"team":    teamSlug,
+		"deleted": true,
+	})
+}
+
 func (h *Handlers) HandleRemoveTeamMember(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	project := h.resolveProject(ctx, req)
 	teamSlug := req.GetString("team", "")

--- a/internal/relay/handlers_test.go
+++ b/internal/relay/handlers_test.go
@@ -1232,6 +1232,39 @@ func TestTeamInbox(t *testing.T) {
 	}
 }
 
+// Issue #150: a send to a team with no members must fail loudly, not return a
+// success receipt for a message that reaches nobody.
+func TestSendToEmptyTeamErrors(t *testing.T) {
+	h := testHandlers(t)
+	_, _ = h.HandleRegisterAgent(ctx, call(map[string]any{"project": "p1", "name": "bot-a", "role": "dev"}))
+	_, _ = h.HandleCreateTeam(ctx, call(map[string]any{"project": "p1", "name": "Ghost", "slug": "ghost"}))
+
+	res, _ := h.HandleSendMessage(ctx, call(map[string]any{
+		"project": "p1", "as": "bot-a", "to": "team:ghost", "content": "anyone?",
+	}))
+	expectError(t, res)
+}
+
+// Issue #150: delete_team retires the channel so it is no longer addressable.
+func TestDeleteTeamHandler(t *testing.T) {
+	h := testHandlers(t)
+	_, _ = h.HandleCreateTeam(ctx, call(map[string]any{"project": "p1", "name": "Dev", "slug": "dev"}))
+
+	res, _ := h.HandleDeleteTeam(ctx, call(map[string]any{"project": "p1", "team": "dev"}))
+	if d := parseJSON(t, res); d["deleted"] != true {
+		t.Fatalf("expected deleted=true, got %v", d)
+	}
+
+	// Gone from listing.
+	listRes, _ := h.HandleListTeams(ctx, call(map[string]any{"project": "p1"}))
+	if data := parseJSON(t, listRes); data["count"].(float64) != 0 {
+		t.Errorf("expected 0 teams after delete, got %v", data["count"])
+	}
+	// Deleting again errors.
+	res2, _ := h.HandleDeleteTeam(ctx, call(map[string]any{"project": "p1", "team": "dev"}))
+	expectError(t, res2)
+}
+
 func TestTeamInboxMissingTeam(t *testing.T) {
 	h := testHandlers(t)
 	res, _ := h.HandleGetTeamInbox(ctx, call(map[string]any{"project": "p1"}))

--- a/internal/relay/tools.go
+++ b/internal/relay/tools.go
@@ -34,7 +34,7 @@ func registerAgentTool() mcp.Tool {
 		mcp.WithBoolean("is_executive", mcp.Description("Executive flag (crown in UI)")),
 		mcp.WithString("profile_slug", mcp.Description("Profile archetype this agent runs")),
 		mcp.WithString("session_id", mcp.Description("Claude Code session ID ($CLAUDE_SESSION_ID) for activity tracking")),
-		mcp.WithString("cwd", mcp.Description("Worktree dir ($PWD). Stable identity key: lets a SessionStart hook re-bind the rotated session_id after /clear.")),
+		mcp.WithString("cwd", mcp.Description("Worktree dir ($PWD). Stable identity key: lets a SessionStart hook re-bind the rotated session_id after /clear. MUST be unique per agent — the cwd re-bind is only correct one-agent-per-worktree. If a fleet shares one tree, give each agent a distinct cwd (or forward RELAY_AGENT to the hook); an ambiguous cwd binds nothing rather than guess.")),
 		mcp.WithString("interest_tags", mcp.Description("JSON array of tags for context budget filtering (e.g. '[\"database\",\"auth\"]')")),
 		mcp.WithNumber("max_context_bytes", mcp.Description("Max bytes for budget-pruned inbox (default 16384)")),
 	)
@@ -783,6 +783,16 @@ func removeTeamMemberTool() mcp.Tool {
 		projectParam,
 		mcp.WithString("team", mcp.Description("Team slug"), mcp.Required()),
 		mcp.WithString("agent_name", mcp.Description("Agent to remove"), mcp.Required()),
+	)
+}
+
+func deleteTeamTool() mcp.Tool {
+	return mcp.NewTool(
+		"delete_team",
+		mcp.WithDescription("Retire a team: removes the team, its memberships, and its inbox refs. Use this to deprecate a channel — leaving a team memberless keeps its slug addressable, and a send to it reaches nobody. Delivered messages are untouched."),
+		asParam,
+		projectParam,
+		mcp.WithString("team", mcp.Description("Team slug"), mcp.Required()),
 	)
 }
 

--- a/internal/relay/toolset.go
+++ b/internal/relay/toolset.go
@@ -103,6 +103,7 @@ func (h *Handlers) toolRegistry() []registeredTool {
 		{server.ServerTool{Tool: listTeamsTool(), Handler: h.HandleListTeams}, "teams"},
 		{server.ServerTool{Tool: addTeamMemberTool(), Handler: h.HandleAddTeamMember}, "teams"},
 		{server.ServerTool{Tool: removeTeamMemberTool(), Handler: h.HandleRemoveTeamMember}, "teams"},
+		{server.ServerTool{Tool: deleteTeamTool(), Handler: h.HandleDeleteTeam}, "teams"},
 		{server.ServerTool{Tool: addNotifyChannelTool(), Handler: h.HandleAddNotifyChannel}, "teams"},
 
 		// File locks disabled: worktree isolation + merge conflicts replace
@@ -146,7 +147,7 @@ var mutatingTools = map[string]bool{
 	"register_profile": true,
 	"deactivate_agent": true, "delete_agent": true, "sleep_agent": true,
 	"create_org": true, "create_team": true, "add_team_member": true,
-	"remove_team_member": true, "add_notify_channel": true,
+	"remove_team_member": true, "delete_team": true, "add_notify_channel": true,
 	"create_conversation": true, "invite_to_conversation": true,
 	"leave_conversation": true, "archive_conversation": true,
 	// create_project is intentionally absent: it is a bootstrap tool. Requiring a

--- a/skill/hooks/session-start.sh
+++ b/skill/hooks/session-start.sh
@@ -13,8 +13,11 @@ CWD=$(printf '%s' "$INPUT" | jq -r '.cwd // ""')
 SRC=$(printf '%s' "$INPUT" | jq -r '.source // ""')
 TP=$(printf '%s' "$INPUT" | jq -r '.transcript_path // ""')
 [ -z "$SID" ] && exit 0
-PAYLOAD=$(jq -nc --arg s "$SID" --arg c "$CWD" --arg src "$SRC" --arg tp "$TP" \
-  '{session_id:$s, cwd:$c, source:$src, transcript_path:$tp}')
+# RELAY_AGENT (set by the launcher when it knows which agent it is starting) is
+# the authoritative identity key. It removes the guess for fleets that share one
+# worktree, where cwd alone is ambiguous. Empty → relay falls back to cwd.
+PAYLOAD=$(jq -nc --arg s "$SID" --arg c "$CWD" --arg a "${RELAY_AGENT:-}" --arg src "$SRC" --arg tp "$TP" \
+  '{session_id:$s, cwd:$c, agent:$a, source:$src, transcript_path:$tp}')
 RESP=$(curl -fsS -m 3 -X POST "$RELAY_URL/api/ingest/session-start" \
   ${RELAY_API_KEY:+-H "Authorization: Bearer $RELAY_API_KEY"} \
   -H "Content-Type: application/json" -d "$PAYLOAD" 2>/dev/null)


### PR DESCRIPTION
Batch fix for four open issues.

## #153 — SessionStart rebind picks arbitrary agent on shared cwd
`RebindSession` now **refuses to bind on an ambiguous cwd** (COUNT>1) rather than picking a row at random — a wrong identity is worse than none, and the old behaviour silently mis-attributed token usage and detached correctly-bound sessions. Colliding agents are logged. Adds an **explicit-agent path**: `session-start.sh` forwards `RELAY_AGENT`, which wins over cwd inference and removes the guess entirely for orchestrated fleets. `register_agent.cwd` now documents the per-agent uniqueness requirement.

## #150 — no delete_team; empty team is a silent black hole
- New `delete_team` tool (DB `DeleteTeam` + handler, gated by `RELAY_REQUIRE_REGISTERED`) — retiring a channel is now a real op (removes team, memberships, inbox refs; delivered messages untouched).
- A send to a team with **zero members** now returns an explicit error instead of a success receipt for a message that reaches nobody. A sender-only team still records to the team inbox.

## #20 — `ar init` mangles existing stdio MCP servers
The merge path typed existing `.mcp.json` entries into an http-only struct, silently dropping `command`/`args`/`env` on round-trip. Existing servers are now preserved as raw JSON; only the agent-relay entry is added. Unknown top-level keys survive too.

## #17 — HTTP equivalent of get_inbox unread count
New `GET /api/inbox/unread-count?agent=<name>&project=<p>` → `{agent, project, unread}`. Non-mutating (does not surface deliveries), so a poller can cheaply check for new mail.

## Tests
Added for every path: ambiguous-cwd bind-nothing + explicit-agent-wins, delete_team + empty-team-send-error, stdio preservation on merge, unread-count endpoint. Full suite: 333 passed, `go vet` clean.

Note: unrelated pre-existing uncommitted dashboard JS/CSS changes were intentionally left out of this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## review-wraith verdict: SHIP-WITH-NITS
Scope: internal/db (agents.go RebindSession/AgentNamesByCwd, orgs.go DeleteTeam, messages.go UnreadCountForAgent), internal/relay (handlers_ingest, handlers_messaging, handlers_teams, tools, toolset, api, api_messages), internal/cli (init merge), skill/hooks/session-start.sh
Gate: build -tags fts5 OK / vet -tags fts5 OK / gofmt OK / test -tags fts5 OK (320 passed on touched pkgs; 333 full)

BLOCKERS (must fix before merge):
- none

Invariants verified:
- Single-writer intact: reads via d.ro(), writes via d.conn/tx. No new hot-path write (session-start + delete_team are cold paths).
- Inbox non-destructive peek preserved: UnreadCountForAgent counts state IN ('queued','surfaced') and never marks surfaced — unread stays "not acknowledged".
- agentColumns ↔ scanAgent untouched; no schema/migration change (no rolling-deploy risk).
- New REST route is a case in ServeAPI behind existing middleware; delete_team added via the single toolset registry + gated in mutatingTools.
- #153 fix removes the SSOT hazard (wrong-identity bind / token mis-attribution) by refusing ambiguous cwd instead of guessing.

NITS (non-blocking):
- db/agents.go RebindSession: explicit-agent-with-empty-cwd path resolves by name alone (LIMIT 1) — could pick arbitrarily if a name repeats across projects. Unreachable via the hook (always sends cwd); documented.
- db/orgs.go DeleteTeam: does not garbage-collect an org left orphan by the deleted team (DeleteProject does). Orphan org is inert, not a black hole.
