### PR TITLE
feat(relay): structured logging via slog + RELAY_LOG_LEVEL

### DIFF
--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -1,0 +1,67 @@
+// Package logging configures the process-wide structured logger (slog) from the
+// environment and bridges the stdlib log package onto it, so existing log.Printf
+// call sites keep working — same handler, same format, filtered by the same
+// level — without being rewritten.
+package logging
+
+import (
+	"context"
+	"log"
+	"log/slog"
+	"os"
+	"strings"
+)
+
+// Setup installs slog as the default logger and points the stdlib log package at
+// it. Call once, as early as possible in each entrypoint.
+//
+//	RELAY_LOG_LEVEL   debug | info | warn | error   (default info)
+//	RELAY_LOG_FORMAT  text | json                   (default text)
+//
+// Output always goes to stderr: on the stdio MCP transport stdout carries the
+// JSON-RPC stream and must never be polluted by a log line.
+func Setup() {
+	level := ParseLevel(os.Getenv("RELAY_LOG_LEVEL"))
+	opts := &slog.HandlerOptions{Level: level}
+
+	var h slog.Handler
+	if strings.EqualFold(strings.TrimSpace(os.Getenv("RELAY_LOG_FORMAT")), "json") {
+		h = slog.NewJSONHandler(os.Stderr, opts)
+	} else {
+		h = slog.NewTextHandler(os.Stderr, opts)
+	}
+	slog.SetDefault(slog.New(h))
+
+	// Bridge the stdlib global logger onto slog. Drop its flags — slog stamps
+	// time and level itself, so leaving them on would double the timestamp — and
+	// route each line through slog at INFO. A plain log.Printf therefore still
+	// appears, formatted like everything else and hidden when the level is raised
+	// above INFO. Startup fatals that must survive a raised level use slog.Error
+	// directly (see main), so nothing load-bearing is lost when INFO is filtered.
+	log.SetFlags(0)
+	log.SetOutput(bridgeWriter{})
+}
+
+// ParseLevel maps a RELAY_LOG_LEVEL string to a slog.Level, defaulting to INFO
+// for empty or unrecognized input.
+func ParseLevel(s string) slog.Level {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "debug":
+		return slog.LevelDebug
+	case "warn", "warning":
+		return slog.LevelWarn
+	case "error":
+		return slog.LevelError
+	default:
+		return slog.LevelInfo
+	}
+}
+
+// bridgeWriter turns each stdlib log line into an slog record at INFO.
+type bridgeWriter struct{}
+
+func (bridgeWriter) Write(p []byte) (int, error) {
+	msg := strings.TrimRight(string(p), "\n")
+	slog.Default().LogAttrs(context.Background(), slog.LevelInfo, msg)
+	return len(p), nil
+}

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"log/slog"
 	"net"
 	"net/http"
 	"os"
@@ -18,6 +19,7 @@ import (
 	"agent-relay/internal/config"
 	"agent-relay/internal/db"
 	"agent-relay/internal/ingest"
+	"agent-relay/internal/logging"
 	"agent-relay/internal/relay"
 
 	"github.com/mark3labs/mcp-go/server"
@@ -75,15 +77,15 @@ func main() {
 // MCP registry). Exposes the same tools as the HTTP server; logs go to stderr so
 // they never corrupt the JSON-RPC stream on stdout. Blocks until the client closes.
 func startStdioMCP() {
-	log.SetFlags(0)
-	log.SetOutput(os.Stderr)
+	logging.Setup()
 
 	cfg := config.Load()
 	cfg.Version = Version
 
 	database, err := db.New()
 	if err != nil {
-		log.Fatalf("failed to init database: %v", err)
+		slog.Error("failed to init database", "err", err)
+		os.Exit(1)
 	}
 	defer func() { _ = database.Close() }()
 
@@ -104,7 +106,8 @@ func startStdioMCP() {
 		},
 	})
 	if err != nil {
-		log.Fatalf("failed to init ingester: %v", err)
+		slog.Error("failed to init ingester", "err", err)
+		os.Exit(1)
 	}
 	defer ingester.Stop()
 
@@ -112,12 +115,13 @@ func startStdioMCP() {
 	r.Version = Version
 
 	if err := server.ServeStdio(r.MCPServer); err != nil {
-		log.Fatalf("stdio MCP server error: %v", err)
+		slog.Error("stdio MCP server error", "err", err)
+		os.Exit(1)
 	}
 }
 
 func startServer() {
-	log.SetFlags(log.LstdFlags | log.Lshortfile)
+	logging.Setup()
 
 	cfg := config.Load()
 	cfg.Version = Version
@@ -127,7 +131,9 @@ func startServer() {
 	// teams when a stray launchd relay came up on the same database).
 	if dbPath, perr := db.DBPath(); perr == nil {
 		if release, lerr := acquireServeLock(dbPath + ".lock"); lerr != nil {
-			log.Fatalf("another agent-relay is already serving %s — refusing to start a second writer (it corrupts the DB). Stop the other instance first.", dbPath)
+			slog.Error("another agent-relay is already serving this DB — refusing to start a second writer (it corrupts the DB); stop the other instance first",
+				"db", dbPath, "err", lerr)
+			os.Exit(1)
 		} else {
 			defer release()
 		}
@@ -135,7 +141,8 @@ func startServer() {
 
 	database, err := db.New()
 	if err != nil {
-		log.Fatalf("failed to init database: %v", err)
+		slog.Error("failed to init database", "err", err)
+		os.Exit(1)
 	}
 	defer func() { _ = database.Close() }()
 
@@ -156,7 +163,8 @@ func startServer() {
 		},
 	})
 	if err != nil {
-		log.Fatalf("failed to init ingester: %v", err)
+		slog.Error("failed to init ingester", "err", err)
+		os.Exit(1)
 	}
 	defer ingester.Stop()
 
@@ -178,7 +186,9 @@ func startServer() {
 	// Refuse to expose a non-loopback bind without authentication — otherwise the
 	// entire API/MCP surface is open to everything on the network.
 	if !isLoopbackHost(host) && cfg.APIKey == "" {
-		log.Fatalf("refusing to bind %s without auth: set RELAY_API_KEY to expose on a non-loopback address, or unset RELAY_BIND to bind 127.0.0.1", addr)
+		slog.Error("refusing to bind without auth: set RELAY_API_KEY to expose on a non-loopback address, or unset RELAY_BIND to bind 127.0.0.1",
+			"addr", addr)
+		os.Exit(1)
 	}
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
@@ -244,10 +254,12 @@ func startServer() {
 	select {
 	case err := <-serveErr:
 		if isAddrInUse(err) {
-			log.Fatalf("cannot bind %s: address already in use — another agent-relay is still running. "+
-				"Stop it first: lsof -ti tcp:%s | xargs kill -9", addr, port)
+			slog.Error("cannot bind: address already in use — another agent-relay is still running; stop it first: lsof -ti tcp:<port> | xargs kill -9",
+				"addr", addr, "port", port)
+			os.Exit(1)
 		}
-		log.Fatalf("server failed: %v", err)
+		slog.Error("server failed", "err", err)
+		os.Exit(1)
 	case <-ctx.Done():
 	}
 	close(cleanupDone)


### PR DESCRIPTION
Replaces the plain stdlib `log` setup with **slog** and adds level + format control.

## What
- `RELAY_LOG_LEVEL` — `debug|info|warn|error` (default `info`) gates verbosity.
- `RELAY_LOG_FORMAT` — `text|json` (default `text`); `json` for Loki/Grafana ingest (the box already runs Grafana/Prometheus).
- `internal/logging.Setup()` installs slog as default and **bridges the stdlib `log` package onto it**, so the ~70 existing `log.Printf` sites emit through the same handler — consistent format, filtered by level — with zero rewrites.
- Kills the inconsistent per-entrypoint `SetFlags` (stdio had **no timestamp**; serve had `file:line`).
- Startup fatals in `main.go` become `slog.Error` + `os.Exit(1)` so a raised level (e.g. `error`) never swallows the reason the process refused to start: single-writer guard, auth refusal, bind-in-use, init failures.

Output stays on **stderr** (stdout carries the stdio MCP JSON-RPC stream — must stay clean).

## Verified
- `go build -tags fts5` / `go vet -tags fts5` / `gofmt` all clean; `go test -tags fts5` green (244 on relay+cli).
- Smoke: `RELAY_LOG_FORMAT=json` emits `{"time":...,"level":"INFO","msg":"notifier: seeded 5 default notification rules"}` from an existing `log.Printf` site; `RELAY_LOG_LEVEL=error` suppresses the INFO banner.

Progressive: existing sites keep working as-is; new code can call `slog` with levels/attrs directly.

---

## review-wraith verdict: SHIP
Scope: main.go (log setup + startup fatals), internal/logging/logging.go (new)
Gate: build -tags fts5 OK / vet -tags fts5 OK / gofmt OK / test -tags fts5 OK (244 relay+cli)

BLOCKERS (must fix before merge):
- none

Invariants verified:
- No DB/schema/messaging/dispatch change — cannot empty a result set or blind the fleet.
- stdio transport: logs stay on stderr; stdout JSON-RPC stream untouched.
- Single-writer guard, auth refusal, bind-in-use fatals now slog.Error (visible at ANY level) — a raised level cannot hide why startup aborted.
- Bridge writes at INFO; RELAY_LOG_LEVEL filters old log.Printf chatter as intended.

NITS (non-blocking):
- The two `fmt`-printed FTS5-availability warnings bypass slog (printed before/around Setup); left as-is (build-mode notice, not runtime logging).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
