### PR TITLE
feat(relay): get_message tool — full untruncated body by id (WRAITH-3)

### DIFF
--- a/internal/relay/handlers_get_message_test.go
+++ b/internal/relay/handlers_get_message_test.go
@@ -1,0 +1,46 @@
+package relay
+
+import (
+	"strings"
+	"testing"
+)
+
+// WRAITH-3: get_message returns the FULL untruncated body that get_inbox /
+// get_thread / get_session_context preview-truncate at ~300 chars.
+func TestGetMessageReturnsFullContent(t *testing.T) {
+	h := testHandlers(t)
+	_, _ = h.HandleRegisterAgent(ctx, call(map[string]any{"project": "p1", "name": "a", "role": "dev"}))
+	_, _ = h.HandleRegisterAgent(ctx, call(map[string]any{"project": "p1", "name": "b", "role": "dev"}))
+
+	long := strings.Repeat("x", 1200)
+	sendRes, _ := h.HandleSendMessage(ctx, call(map[string]any{
+		"project": "p1", "as": "a", "to": "b", "subject": "steer", "content": long,
+	}))
+	sent := parseJSON(t, sendRes)
+	id, _ := sent["id"].(string)
+	if id == "" {
+		t.Fatalf("no message id in send result: %v", sent)
+	}
+
+	// Full ID.
+	res, _ := h.HandleGetMessage(ctx, call(map[string]any{"project": "p1", "as": "b", "id": id}))
+	got := parseJSON(t, res)
+	if c, _ := got["content"].(string); c != long {
+		t.Fatalf("expected full %d-char body, got %d chars", len(long), len(c))
+	}
+
+	// Unambiguous prefix resolves.
+	res2, _ := h.HandleGetMessage(ctx, call(map[string]any{"project": "p1", "as": "b", "id": id[:8]}))
+	if c, _ := parseJSON(t, res2)["content"].(string); c != long {
+		t.Errorf("prefix lookup did not return full body")
+	}
+
+	// Missing id → error.
+	if r, _ := h.HandleGetMessage(ctx, call(map[string]any{"project": "p1", "as": "b"})); !r.IsError {
+		t.Error("expected error when id omitted")
+	}
+	// Unknown id → error, not a panic.
+	if r, _ := h.HandleGetMessage(ctx, call(map[string]any{"project": "p1", "as": "b", "id": "nope-nope"})); !r.IsError {
+		t.Error("expected error for unknown id")
+	}
+}

--- a/internal/relay/handlers_messaging.go
+++ b/internal/relay/handlers_messaging.go
@@ -418,6 +418,54 @@ func (h *Handlers) HandleGetThread(ctx context.Context, req mcp.CallToolRequest)
 	})
 }
 
+// HandleGetMessage returns one message by ID with its full, untruncated content
+// — the escape hatch for the ~300-char previews in get_inbox / get_thread /
+// get_session_context (WRAITH-3). Read-only, non-mutating: it never surfaces or
+// acks a delivery, so fetching a full body cannot alter the unread view.
+func (h *Handlers) HandleGetMessage(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	project := h.resolveProject(ctx, req)
+	id := req.GetString("id", "")
+	if id == "" {
+		return mcp.NewToolResultError("id is required"), nil
+	}
+
+	msg, err := h.db.GetMessage(id)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("failed to get message: %v", err)), nil
+	}
+	if msg == nil {
+		// Not a full ID — try to resolve an unambiguous prefix.
+		full, ferr := h.db.FindMessageByPrefix(id)
+		if ferr != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("no message with id %q: %v", id, ferr)), nil
+		}
+		if msg, err = h.db.GetMessage(full); err != nil || msg == nil {
+			return mcp.NewToolResultError(fmt.Sprintf("no message with id %q", id)), nil
+		}
+	}
+
+	entry := map[string]any{
+		"id":         msg.ID,
+		"from":       msg.From,
+		"to":         msg.To,
+		"type":       msg.Type,
+		"subject":    msg.Subject,
+		"content":    msg.Content, // full, untruncated — the whole point of this tool
+		"created_at": msg.CreatedAt,
+		"priority":   msg.Priority,
+	}
+	if msg.ReplyTo != nil {
+		entry["reply_to"] = *msg.ReplyTo
+	}
+	if msg.ConversationID != nil {
+		entry["conversation_id"] = *msg.ConversationID
+	}
+	if msg.Metadata != "" && msg.Metadata != "{}" {
+		entry["metadata"] = msg.Metadata
+	}
+	return h.resultJSONTracked(project, "", "get_message", entry)
+}
+
 func (h *Handlers) HandleMarkRead(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	project := h.resolveProject(ctx, req)
 	agent := resolveAgent(ctx, req)

--- a/internal/relay/tools.go
+++ b/internal/relay/tools.go
@@ -102,6 +102,17 @@ func getThreadTool() mcp.Tool {
 	)
 }
 
+func getMessageTool() mcp.Tool {
+	return mcp.NewTool(
+		"get_message",
+		mcp.WithDescription("Fetch a single message by ID with its FULL, untruncated content — the escape hatch when a preview in get_inbox / get_thread / get_session_context cut off the body. Accepts a full ID or an unambiguous ID prefix."),
+		asParam,
+		projectParam,
+		mcp.WithString("id", mcp.Description("Message ID (full or an unambiguous prefix)"), mcp.Required()),
+		formatParam,
+	)
+}
+
 func listAgentsTool() mcp.Tool {
 	return mcp.NewTool(
 		"list_agents",

--- a/internal/relay/toolset.go
+++ b/internal/relay/toolset.go
@@ -21,7 +21,7 @@ type registeredTool struct {
 // for display; keep summaries to one line — they are the discovery-mode index.
 var toolCategories = []struct{ name, summary string }{
 	{"session", "identity + boot: whoami, register_agent, get_session_context, query_context"},
-	{"messaging", "send/receive: send_message, get_inbox, ack_delivery, get_thread, mark_read, get_team_inbox"},
+	{"messaging", "send/receive: send_message, get_inbox, get_message, ack_delivery, get_thread, mark_read, get_team_inbox"},
 	{"conversations", "multi-agent threads: create, list, get messages, invite, leave, archive"},
 	{"tasks", "task lifecycle: dispatch, claim, start, review, complete, block, resume, cancel, get, list, update, move, archive, batch ops"},
 	{"boards", "task boards: create, list, archive, delete"},
@@ -46,6 +46,7 @@ func (h *Handlers) toolRegistry() []registeredTool {
 		{server.ServerTool{Tool: getInboxTool(), Handler: h.HandleGetInbox}, "messaging"},
 		{server.ServerTool{Tool: ackDeliveryTool(), Handler: h.HandleAckDelivery}, "messaging"},
 		{server.ServerTool{Tool: getThreadTool(), Handler: h.HandleGetThread}, "messaging"},
+		{server.ServerTool{Tool: getMessageTool(), Handler: h.HandleGetMessage}, "messaging"},
 		{server.ServerTool{Tool: markReadTool(), Handler: h.HandleMarkRead}, "messaging"},
 		{server.ServerTool{Tool: getTeamInboxTool(), Handler: h.HandleGetTeamInbox}, "messaging"},
 

--- a/internal/relay/toolset_test.go
+++ b/internal/relay/toolset_test.go
@@ -23,8 +23,8 @@ func TestDiscoverTools(t *testing.T) {
 		t.Errorf("category = %v", data["category"])
 	}
 	tools := data["tools"].([]any)
-	if len(tools) != 6 {
-		t.Errorf("messaging tools = %d, want 6", len(tools))
+	if len(tools) != 7 {
+		t.Errorf("messaging tools = %d, want 7", len(tools))
 	}
 	first := tools[0].(map[string]any)
 	if first["name"] == "" || first["inputSchema"] == nil {


### PR DESCRIPTION
Fixes **WRAITH-3**: relay message content is preview-truncated to ~300 chars in `get_inbox` / `get_thread` / `get_session_context`, so agents shuttle real content out-of-band into a vault file — defeating the "discoverable via relay" premise.

## What
- New **`get_message(id)`** tool → returns one message with its **full, untruncated** content.
- Accepts a full ID or an **unambiguous prefix** (via the existing `FindMessageByPrefix`).
- Backs onto the DB's `GetMessage(id)`, which existed but had **zero callers**.
- Read-only: never surfaces or acks a delivery, so fetching a full body cannot perturb the unread view (respects the non-destructive-peek invariant).
- Registered under the `messaging` category + discovery summary.

## Why a new tool vs. raising the cap
`get_inbox`/`get_thread`/`get_team_inbox` already expose `full_content=true`, but `get_session_context` has no such flag, and there was no fetch-full-by-id path. Keeping the list preview short (cheap) + full-on-demand by id is the least-token design.

## Verified
- `go build -tags fts5` / `go vet -tags fts5` / `gofmt` clean; `go test -tags fts5` green (310 relay+db).
- New test: 1200-char body round-trips full via full ID and via 8-char prefix; missing/unknown id error cleanly (no panic).

---

## review-wraith verdict: SHIP
Scope: internal/relay/tools.go (getMessageTool), handlers_messaging.go (HandleGetMessage), toolset.go (register + category summary), tests
Gate: build -tags fts5 OK / vet -tags fts5 OK / gofmt OK / test -tags fts5 OK (310 relay+db)

BLOCKERS: none

Invariants verified:
- Non-destructive peek intact: get_message is pure read — no MarkDeliveriesSurfaced, no ack, no message_reads write.
- Reuses the single tool registry (toolset.go); stdio + HTTP /mcp expose it identically; progressive disclosure summary updated.
- Not added to mutatingTools (it is a read) — correct; no identity gate needed beyond existing resolveProject.

NITS (non-blocking):
- No per-caller authorization scoping (any fleet agent can fetch any message id by design — same trust model as get_thread).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
