### PR TITLE
fix(relay): wake-count counts only new deliveries; mark_read acks conversations (WRAITH-2)

### DIFF
--- a/internal/db/deliveries.go
+++ b/internal/db/deliveries.go
@@ -239,6 +239,23 @@ func (d *DB) AcknowledgeDeliveryByMessage(messageID, agentName, project string) 
 	return err
 }
 
+// AcknowledgeConversationDeliveries acks every still-open delivery to an agent
+// for messages in a conversation. mark_read(conversation_id) writes
+// conversation_reads but historically never touched deliveries, so a
+// conversation's messages stayed queued/surfaced and kept re-surfacing until an
+// explicit ack_delivery (WRAITH-2). Acking here makes mark_read a real clear for
+// conversation messages, matching what the message_ids branch already does.
+func (d *DB) AcknowledgeConversationDeliveries(conversationID, agentName, project string) error {
+	now := time.Now().UTC().Format("2006-01-02T15:04:05.000000Z")
+	_, err := d.conn.Exec(
+		`UPDATE deliveries SET state = 'acknowledged', acknowledged_at = ?
+		 WHERE to_agent = ? AND project = ? AND state IN ('queued', 'surfaced')
+		   AND message_id IN (SELECT id FROM messages WHERE conversation_id = ?)`,
+		now, agentName, project, conversationID,
+	)
+	return err
+}
+
 // ExpireDeliveries marks deliveries for expired messages.
 func (d *DB) ExpireDeliveries() (int, error) {
 	now := time.Now().UTC().Format("2006-01-02T15:04:05.000000Z")

--- a/internal/db/messages.go
+++ b/internal/db/messages.go
@@ -123,19 +123,28 @@ func (d *DB) GetInbox(project, agentName string, unreadOnly bool, limit int, fil
 	return d.getInboxLegacy(project, agentName, unreadOnly, limit, f)
 }
 
-// UnreadCountForAgent returns how many unread messages an agent has, without
-// mutating delivery state (unlike GetInbox, which marks queued deliveries
-// surfaced). This backs the HTTP unread-count endpoint (issue #17) so a poller
-// can cheaply check for new mail without draining the inbox.
+// UnreadCountForAgent returns how many NEW (unseen) messages an agent has —
+// deliveries still 'queued', i.e. never surfaced by get_inbox. It is the wake
+// signal behind the HTTP unread-count endpoint (issue #17): a poller checks it
+// to decide whether to wake the agent. It is non-mutating (unlike GetInbox,
+// which marks queued deliveries surfaced) and deliberately excludes 'surfaced'
+// deliveries so an already-seen message never re-wakes the agent (WRAITH-2).
 func (d *DB) UnreadCountForAgent(project, agentName string) (int, error) {
 	if d.HasDeliveries() {
 		var n int
+		// Count only 'queued' — deliveries the agent has NOT yet been shown. Once
+		// a delivery is 'surfaced' (returned by get_inbox at least once) the agent
+		// has seen it, so it must not keep re-triggering a wake-up on every poll;
+		// it stays visible in the inbox's unread view until an explicit ack. This
+		// is the wake signal, deliberately narrower than the get_inbox unread view
+		// (queued+surfaced), and is what stops a pile of long-surfaced broadcasts
+		// from waking the whole fleet forever (WRAITH-2).
 		err := d.ro().QueryRow(`
 			SELECT COUNT(*)
 			FROM deliveries d
 			JOIN messages m ON d.message_id = m.id
 			WHERE d.project = ? AND d.to_agent = ?
-			  AND d.state IN ('queued', 'surfaced')
+			  AND d.state = 'queued'
 			  AND m.expired_at IS NULL
 			  AND (m.ttl_seconds = 0 OR datetime(m.created_at, '+' || m.ttl_seconds || ' seconds') > datetime('now'))
 		`, project, agentName).Scan(&n)

--- a/internal/db/wraith2_test.go
+++ b/internal/db/wraith2_test.go
@@ -1,0 +1,74 @@
+package db
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// WRAITH-2: the wake signal (UnreadCountForAgent) counts only NEW ('queued')
+// deliveries. Once a delivery is surfaced (shown by get_inbox), it must stop
+// waking the agent — but stay visible in the inbox's unread view until acked.
+func TestUnreadCountExcludesSurfaced(t *testing.T) {
+	d, err := NewTestDB(filepath.Join(t.TempDir(), "t.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := d.RegisterAgent("p", "bob", "dev", "", nil, nil, false, nil, "[]", 0, RegisterOptions{}); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	if _, err := d.InsertMessageWithDeliveries("p", "alice", "bob", "note", "hi", "body", "", "P2", 0, nil, nil, []string{"bob"}); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	// New delivery is 'queued' → wakes.
+	if n, _ := d.UnreadCountForAgent("p", "bob"); n != 1 {
+		t.Fatalf("queued delivery: want wake-count 1, got %d", n)
+	}
+
+	// get_inbox surfaces the delivery (marks queued → surfaced).
+	msgs, err := d.GetInbox("p", "bob", true, 10)
+	if err != nil || len(msgs) != 1 {
+		t.Fatalf("get_inbox: got %d msgs, err %v", len(msgs), err)
+	}
+
+	// Surfaced → no longer wakes.
+	if n, _ := d.UnreadCountForAgent("p", "bob"); n != 0 {
+		t.Errorf("surfaced delivery must not wake: want 0, got %d", n)
+	}
+	// ...but is still in the unread VIEW until an explicit ack (non-destructive peek).
+	stillMsgs, _ := d.GetInbox("p", "bob", true, 10)
+	if len(stillMsgs) != 1 {
+		t.Errorf("surfaced message must stay in unread view, got %d", len(stillMsgs))
+	}
+}
+
+// WRAITH-2: mark_read(conversation_id) must acknowledge the conversation's
+// deliveries, not just write conversation_reads — otherwise they resurface.
+func TestAcknowledgeConversationDeliveries(t *testing.T) {
+	d, err := NewTestDB(filepath.Join(t.TempDir(), "t.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := d.RegisterAgent("p", "bob", "dev", "", nil, nil, false, nil, "[]", 0, RegisterOptions{}); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	cid := "conv-1"
+	if _, err := d.InsertMessageWithDeliveries("p", "alice", "", "note", "s", "c", "", "P2", 0, nil, &cid, []string{"bob"}); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	if n, _ := d.UnreadCountForAgent("p", "bob"); n != 1 {
+		t.Fatalf("pre-ack wake-count: want 1, got %d", n)
+	}
+
+	if err := d.AcknowledgeConversationDeliveries(cid, "bob", "p"); err != nil {
+		t.Fatalf("ack conversation: %v", err)
+	}
+
+	// Acknowledged → gone from the wake count AND the unread view.
+	if n, _ := d.UnreadCountForAgent("p", "bob"); n != 0 {
+		t.Errorf("acked conversation delivery must not wake: got %d", n)
+	}
+	if msgs, _ := d.GetInbox("p", "bob", true, 10); len(msgs) != 0 {
+		t.Errorf("acked conversation message must leave unread view, got %d", len(msgs))
+	}
+}

--- a/internal/relay/handlers_messaging.go
+++ b/internal/relay/handlers_messaging.go
@@ -428,6 +428,10 @@ func (h *Handlers) HandleMarkRead(ctx context.Context, req mcp.CallToolRequest) 
 		if err := h.db.MarkConversationRead(convID, agent); err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("failed to mark conversation read: %v", err)), nil
 		}
+		// Also acknowledge the deliveries for this conversation's messages —
+		// otherwise they stay queued/surfaced and keep re-surfacing (and, before
+		// WRAITH-2, re-waking) until an explicit ack_delivery. Best-effort.
+		_ = h.db.AcknowledgeConversationDeliveries(convID, agent, project)
 		return h.resultJSONTracked(project, agent, "mark_read", map[string]any{
 			"conversation_id": convID,
 			"marked_read":     true,


### PR DESCRIPTION
Fixes **WRAITH-2**: a processed message re-wakes the agent on every poll until `ack_delivery`; `mark_read` doesn't stop it. Each false wake = a wasted context turn, fleet-wide.

## Diagnosed against the live production relay DB (read-only)
- **0** cases of "marked read (message_reads) but delivery unacked" — the `message_ids` branch of `mark_read` already acks (TSU-73). So the reported cause was slightly off.
- **2423 / 2542** open deliveries were **surfaced broadcasts** (`to='*'`), 2192 of them **7–30 days old**, never acknowledged.
- `UnreadCountForAgent` (the wake signal behind `GET /api/inbox/unread-count`, #17) counted `queued` **and** `surfaced` → every poll saw unread>0 → a wake-up burned on messages the agent had already seen, forever.

## Fix
1. **Wake-count = `queued` only.** `UnreadCountForAgent` now counts only never-surfaced deliveries — the wake signal fires on genuinely *new* mail. `surfaced` deliveries stay in the `get_inbox` unread view (still `queued`+`surfaced`) until an explicit ack, so the **non-destructive peek is unchanged**; they just stop re-waking. On deploy the entire standing broadcast backlog is already surfaced → wake-count drops to 0.
2. **`mark_read(conversation_id)` now acks the conversation's deliveries** (`AcknowledgeConversationDeliveries`), matching the `message_ids` branch. It previously wrote only `conversation_reads`, so conversation messages resurfaced until `ack_delivery`.

## Why this over the alternatives
- *Auto-ack on get_inbox* would make reads destructive and break the P0-full-on-first-surface guard (TSU-73).
- *GC old surfaced deliveries* is unnecessary once the wake-count ignores surfaced.
- The `surfaced` state already means "the agent has seen this," so excluding it from the wake signal is the semantically correct narrowing.

## Verified
- `go build/vet/test -tags fts5` all green (**375** passed).
- New tests: surfaced delivery → wake-count 0 but still in unread view; `AcknowledgeConversationDeliveries` clears both wake-count and unread view.

---

## review-wraith verdict: SHIP
Scope: internal/db/messages.go (UnreadCountForAgent), internal/db/deliveries.go (AcknowledgeConversationDeliveries), internal/relay/handlers_messaging.go (mark_read conv branch), tests
Gate: build -tags fts5 OK / vet OK / gofmt OK / test -tags fts5 OK (375)

BLOCKERS: none

Invariants verified:
- Non-destructive peek intact: get_inbox unread view still queued+surfaced (FetchInboxDeliveries/GetInboxViaDeliveries untouched); only the wake COUNT narrows to queued.
- No P0/first-surface regression: surfacing logic + full-body-on-first-surface (handlers_messaging) unchanged; TSU-73 message_ids ack path unchanged.
- Reads via d.ro(); the two acks are guarded conditional UPDATEs (state IN queued,surfaced) — no double-write, no per-request hot-path write added.
- UnreadCountForAgent is only consumed by the #17 wake endpoint (new this release), so narrowing its meaning has no other caller to break.

NITS (non-blocking):
- Standing surfaced backlog stays in the unread VIEW until agents ack/expire it; it just no longer wakes. A one-off GC of >30d surfaced deliveries could tidy the view but is out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
