### PR TITLE
fix(relay): cap unbounded session_context sections (WRAITH-1)

### DIFF
--- a/internal/db/memories.go
+++ b/internal/db/memories.go
@@ -579,7 +579,8 @@ func (d *DB) GetMemoriesByLayer(project, agentName, layer string) ([]models.Memo
 		 FROM memories
 		 WHERE archived_at IS NULL AND layer = ?
 		   AND (scope = 'global' OR (project = ? AND (scope = 'project' OR (scope = 'agent' AND agent_name = ?))))
-		 ORDER BY updated_at DESC`,
+		 ORDER BY updated_at DESC
+		 LIMIT 500`,
 		layer, project, agentName,
 	)
 }

--- a/internal/relay/handlers.go
+++ b/internal/relay/handlers.go
@@ -797,7 +797,9 @@ func (h *Handlers) buildSessionContext(project, agentName string, profileSlug *s
 	if profileSlug != nil && *profileSlug != "" {
 		profile, err := h.db.GetProfile(project, *profileSlug)
 		if err == nil && profile != nil {
-			result["profile"] = profile
+			// Skills is an unbounded raw JSON array; project it so a large profile
+			// can't dominate the boot payload (WRAITH-1).
+			result["profile"] = projectProfile(profile)
 		}
 	}
 
@@ -828,12 +830,17 @@ func (h *Handlers) buildSessionContext(project, agentName string, profileSlug *s
 		result["unread_omitted"] = len(unread) - len(projected)
 	}
 
-	// Active conversations
+	// Active conversations — capped in count and title bytes; v1.9.0 injected
+	// these raw (30 rows, no byte cap), a primary source of oversized payloads.
 	convs, err := h.db.ListConversations(project, agentName)
 	if err != nil || convs == nil {
 		convs = []models.ConversationSummary{}
 	}
-	result["active_conversations"] = convs
+	projectedConvs := projectConversations(convs, sessionConversationMax)
+	result["active_conversations"] = projectedConvs
+	if len(projectedConvs) < len(convs) {
+		result["active_conversations_omitted"] = len(convs) - len(projectedConvs)
+	}
 
 	// Relevant memories — cross-scope boot view (global + project + own
 	// agent-scope; plain ListMemories filters agent_name on all scopes and
@@ -873,6 +880,11 @@ func (h *Handlers) buildSessionContext(project, agentName string, profileSlug *s
 	}
 
 	// Vault/doc context is served externally (the doc-context host), not injected here.
+
+	// Last-resort ceiling: if a P0 flood bypassed the per-section budgets and the
+	// whole payload still exceeds the tool token cap, collapse conversations and
+	// flag it — the "boot in one call" tool must never blow the cap (WRAITH-1).
+	enforceSessionPayloadCeiling(result)
 
 	return result
 }

--- a/internal/relay/project.go
+++ b/internal/relay/project.go
@@ -51,6 +51,112 @@ const memValuePreview = 400
 // out of boot).
 const sessionMemoryBudget = 6000
 
+// Session-context caps for the sections v1.9.0 injected RAW — the primary
+// contributors to an oversized boot payload (WRAITH-1).
+const (
+	// sessionConversationMax caps active_conversations rows in boot; the rest
+	// are reported via active_conversations_omitted and fetched with
+	// list_conversations. (Previously LIMIT 30 rows, no byte cap, no truncation.)
+	sessionConversationMax = 12
+	// convTitlePreview caps a single conversation title's bytes.
+	convTitlePreview = 120
+	// profileSkillsBudget caps a profile's Skills JSON (an unbounded raw array
+	// injected verbatim) in boot, keeping whole skill entries.
+	profileSkillsBudget = 2000
+	// sessionPayloadCeiling is the hard byte ceiling on the whole session_context
+	// payload — a last-resort net above the per-section budgets, so the "boot in
+	// one call" tool can never exceed the MCP token cap (WRAITH-1).
+	sessionPayloadCeiling = 60000
+)
+
+// projectConversations bounds active_conversations: caps the row count and
+// truncates each title. The caller reports the remainder via
+// active_conversations_omitted.
+func projectConversations(convs []models.ConversationSummary, max int) []models.ConversationSummary {
+	if len(convs) > max {
+		convs = convs[:max]
+	}
+	out := make([]models.ConversationSummary, len(convs))
+	for i, c := range convs {
+		c.Title, _ = truncatePreview(c.Title, convTitlePreview)
+		out[i] = c
+	}
+	return out
+}
+
+// projectProfile renders a profile for boot with its Skills JSON bounded to
+// profileSkillsBudget bytes (whole entries kept). Skills is otherwise an
+// unbounded raw JSON array injected verbatim.
+func projectProfile(p *models.Profile) map[string]any {
+	m := map[string]any{
+		"id":         p.ID,
+		"slug":       p.Slug,
+		"name":       p.Name,
+		"role":       p.Role,
+		"project":    p.Project,
+		"created_at": p.CreatedAt,
+		"updated_at": p.UpdatedAt,
+	}
+	if p.OrgID != nil {
+		m["org_id"] = *p.OrgID
+	}
+	skills, capped := capJSONArray(p.Skills, profileSkillsBudget)
+	m["skills"] = json.RawMessage(skills)
+	if capped {
+		m["skills_capped"] = true
+	}
+	return m
+}
+
+// capJSONArray trims a JSON array string to at most maxBytes, keeping whole
+// elements. Returns the (possibly trimmed) array and whether trimming occurred.
+// On any parse error it returns "[]" so the payload stays valid JSON.
+func capJSONArray(arr string, maxBytes int) (string, bool) {
+	if len(arr) <= maxBytes {
+		return arr, false
+	}
+	var items []json.RawMessage
+	if err := json.Unmarshal([]byte(arr), &items); err != nil {
+		return "[]", true
+	}
+	kept := make([]json.RawMessage, 0, len(items))
+	size := 2 // the surrounding "[]"
+	for _, it := range items {
+		size += len(it) + 1 // element + comma
+		if size > maxBytes {
+			break
+		}
+		kept = append(kept, it)
+	}
+	out, err := json.Marshal(kept)
+	if err != nil {
+		return "[]", true
+	}
+	return string(out), len(kept) < len(items)
+}
+
+// enforceSessionPayloadCeiling is the last-resort guard: if the assembled
+// session_context still exceeds sessionPayloadCeiling bytes (e.g. a P0 flood
+// that legitimately bypasses the per-section soft budgets), collapse the softest
+// section — active_conversations — to a count and flag payload_capped. The
+// higher-priority sections (tasks, unread P0s, constraints, decisions) are left
+// intact; they are already hard-capped and must survive boot.
+func enforceSessionPayloadCeiling(result map[string]any) {
+	over := func() bool {
+		b, err := json.Marshal(result)
+		return err == nil && len(b) > sessionPayloadCeiling
+	}
+	if !over() {
+		return
+	}
+	if convs, ok := result["active_conversations"].([]models.ConversationSummary); ok && len(convs) > 0 {
+		prev, _ := result["active_conversations_omitted"].(int)
+		result["active_conversations_omitted"] = prev + len(convs)
+		result["active_conversations"] = []models.ConversationSummary{}
+	}
+	result["payload_capped"] = true
+}
+
 // truncatePreview cuts s to at most max bytes without splitting a UTF-8 rune
 // (byte slicing on French text can cut an accent mid-sequence and produce
 // invalid JSON payloads). Returns the cut string and whether truncation occurred.

--- a/internal/relay/project_wraith1_test.go
+++ b/internal/relay/project_wraith1_test.go
@@ -1,0 +1,94 @@
+package relay
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"agent-relay/internal/models"
+)
+
+// WRAITH-1: active_conversations must be count-capped and title-truncated.
+func TestProjectConversations(t *testing.T) {
+	convs := make([]models.ConversationSummary, 20)
+	for i := range convs {
+		convs[i] = models.ConversationSummary{ID: string(rune('a' + i)), Title: strings.Repeat("x", 500)}
+	}
+	got := projectConversations(convs, sessionConversationMax)
+	if len(got) != sessionConversationMax {
+		t.Fatalf("want %d convs, got %d", sessionConversationMax, len(got))
+	}
+	if len(got[0].Title) > convTitlePreview+3 { // +ellipsis
+		t.Errorf("title not truncated: %d bytes", len(got[0].Title))
+	}
+	// Under the cap: unchanged count.
+	if n := len(projectConversations(convs[:3], sessionConversationMax)); n != 3 {
+		t.Errorf("under-cap count changed: %d", n)
+	}
+}
+
+// WRAITH-1: a profile's unbounded Skills JSON is bounded, staying valid JSON.
+func TestCapJSONArrayAndProfile(t *testing.T) {
+	// Small array: untouched.
+	small := `[{"s":"go"},{"s":"rust"}]`
+	if out, capped := capJSONArray(small, profileSkillsBudget); capped || out != small {
+		t.Errorf("small array altered: %q capped=%v", out, capped)
+	}
+
+	// Big array: trimmed to whole elements, still valid JSON.
+	var items []map[string]string
+	for i := 0; i < 500; i++ {
+		items = append(items, map[string]string{"skill": strings.Repeat("y", 20)})
+	}
+	bigBytes, _ := json.Marshal(items)
+	out, capped := capJSONArray(string(bigBytes), profileSkillsBudget)
+	if !capped {
+		t.Fatal("big array should be capped")
+	}
+	if len(out) > profileSkillsBudget {
+		t.Errorf("capped array over budget: %d", len(out))
+	}
+	var reparsed []map[string]string
+	if err := json.Unmarshal([]byte(out), &reparsed); err != nil {
+		t.Fatalf("capped array is not valid JSON: %v", err)
+	}
+
+	// Malformed skills → empty array, never a corrupt payload.
+	if out, capped := capJSONArray(strings.Repeat("{", 3000), profileSkillsBudget); out != "[]" || !capped {
+		t.Errorf("malformed skills should collapse to []: %q", out)
+	}
+
+	p := &models.Profile{ID: "1", Slug: "backend", Skills: string(bigBytes)}
+	m := projectProfile(p)
+	if m["skills_capped"] != true {
+		t.Error("projectProfile should flag skills_capped for a big profile")
+	}
+}
+
+// WRAITH-1: the global ceiling collapses conversations and flags payload_capped
+// when the whole payload is still too big; leaves a small payload untouched.
+func TestEnforceSessionPayloadCeiling(t *testing.T) {
+	small := map[string]any{"active_conversations": []models.ConversationSummary{{ID: "a"}}}
+	enforceSessionPayloadCeiling(small)
+	if _, capped := small["payload_capped"]; capped {
+		t.Error("small payload wrongly capped")
+	}
+	if n := len(small["active_conversations"].([]models.ConversationSummary)); n != 1 {
+		t.Error("small payload conversations wrongly trimmed")
+	}
+
+	big := map[string]any{
+		"unread_messages":      strings.Repeat("z", sessionPayloadCeiling+1000),
+		"active_conversations": []models.ConversationSummary{{ID: "a"}, {ID: "b"}, {ID: "c"}},
+	}
+	enforceSessionPayloadCeiling(big)
+	if big["payload_capped"] != true {
+		t.Fatal("oversized payload not flagged")
+	}
+	if n := len(big["active_conversations"].([]models.ConversationSummary)); n != 0 {
+		t.Errorf("conversations not collapsed: %d", n)
+	}
+	if big["active_conversations_omitted"].(int) != 3 {
+		t.Errorf("omitted count wrong: %v", big["active_conversations_omitted"])
+	}
+}


### PR DESCRIPTION
Fixes **WRAITH-1**: `get_session_context` could return ~94KB and blow the MCP tool token cap — the "boot in one call" tool sabotaging itself once an agent has real context.

## v1.9.0 state (verified)
Already budgets tasks / unread_messages / relevant_memories / decisions via the Def. 7 projection (soft budgets, hard ceilings, `*_omitted` counters), and defaults the inbox to unread-only. **Not** an "all uncapped" problem. But three sections were injected raw and one DB read was unbounded — the actual sources of a 94KB payload.

## Fix (targeted)
- **active_conversations** — was injected verbatim (30 rows, no byte cap, no title truncation, no omitted counter). Now count-capped (12) + titles truncated to 120 bytes, with `active_conversations_omitted`.
- **profile** — was the full `Profile` incl. its raw `Skills` JSON array (unbounded). Now projected with `Skills` bounded to 2000 bytes keeping whole entries; `skills_capped` flagged. Malformed skills collapse to `[]` (never a corrupt payload).
- **decisions** — `GetMemoriesByLayer` had no DB `LIMIT` (saved only by the downstream 40-item / 6000-byte projection). Added `LIMIT 500` — far above the projection cap, so normal behavior is unchanged; it only guards a pathological decisions table.
- **global ceiling** — new `enforceSessionPayloadCeiling`: a last-resort 60KB cap on the whole payload that collapses `active_conversations` (the softest section) and sets `payload_capped` if a **P0 flood** — which legitimately bypasses the per-section soft budgets (priority is caller-settable) — would otherwise exceed the tool cap.

## Verified
- `go build/vet/test -tags fts5` green (**378** full suite, incl. the existing "303K session_context payload" regression test).
- New tests: conversation count+title cap; skills cap stays valid JSON + malformed→`[]`; global ceiling collapses conversations + flags `payload_capped`, leaves a small payload untouched.

---

## review-wraith verdict: SHIP
Scope: internal/relay/project.go (projectConversations, projectProfile, capJSONArray, enforceSessionPayloadCeiling), internal/relay/handlers.go (buildSessionContext wiring), internal/db/memories.go (decisions LIMIT), tests
Gate: build -tags fts5 OK / vet OK / gofmt OK / test -tags fts5 OK (378)

BLOCKERS: none

Invariants verified:
- No schema/migration change; LIMIT 500 is additive and additive-only (no behavior change under the 40-item projection). agentColumns/scanAgent untouched.
- Higher-priority boot sections (tasks, unread P0s, constraints memories, decisions) are never trimmed by the global ceiling — only active_conversations collapses; the paper's constraint-priority (Def. 3) holds.
- Existing "303K payload" regression test still green.
- Read-only path; no new hot-path write.

NITS (non-blocking):
- The 60KB ceiling is a coarse net (collapses conversations only). If a P0 flood alone exceeds it, payload_capped is flagged but P0s still surface (by design). Finer global trimming could be a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
