### PR TITLE
ci(release): skip cross-compiler apt install on native linux/amd64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,8 +48,13 @@ jobs:
         with:
           go-version-file: go.mod
 
+      # Only the cross-compiled Linux targets need these packages. The native
+      # linux/amd64 build uses the runner's own gcc (matrix.cc == 'gcc') and must
+      # NOT run apt here — it doesn't need the packages, and the apt step is a
+      # flaky hang point (mirror stalls with no timeout) that was blocking the
+      # release on the one job that gains nothing from it.
       - name: Install cross-compilers (Linux)
-        if: runner.os == 'Linux'
+        if: runner.os == 'Linux' && matrix.cc != 'gcc'
         run: |
           sudo apt-get update -qq
           sudo apt-get install -y -qq gcc-aarch64-linux-gnu gcc-mingw-w64-x86-64


### PR DESCRIPTION
The `Install cross-compilers (Linux)` step ran on **every** Linux matrix job, including `linux/amd64` — which builds natively with the runner's own `gcc` and needs none of `gcc-aarch64-linux-gnu` / `gcc-mingw-w64-x86-64`.

That apt step (no timeout) stalled on a mirror **twice in a row** during the v1.10.0 release and blocked the whole release on the one job that gains nothing from it (the other 4 builds were green in ~1min each).

Fix: gate the step to the cross-compiled targets only (`matrix.cc != 'gcc'`). `linux/arm64` and `windows/amd64` still install their cross toolchains; `linux/amd64` skips apt entirely and builds native.

## review-wraith verdict: SHIP
Scope: .github/workflows/release.yml (one `if:` condition)
Gate: n/a (CI workflow YAML; no Go change) — build/test unaffected

BLOCKERS: none
Invariants: no code/schema/DB change; the matrix, build flags (`-tags fts5`, CGO), and cross-compiled target toolchains are unchanged. Only removes an unneeded apt install from the native amd64 job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
