### PR TITLE
fix(linear): carry profile_slug (routing lane) onto Linear mirror tasks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,9 @@ jobs:
       - name: Run tests
         env:
           CGO_ENABLED: "1"
-        run: go test -race -count=1 ./...
+        # -tags fts5 matches the Makefile `test:` target and the build: without it
+        # the FTS5 module is absent and the memories/vault FTS tests fail at runtime.
+        run: go test -tags fts5 -race -count=1 ./...
 
       # Non-blocking: surfaces known vulnerabilities in PRs without freezing the
       # pipeline on stdlib advisories that only a Go toolchain release can fix.

--- a/internal/connector/linear/linear_test.go
+++ b/internal/connector/linear/linear_test.go
@@ -705,3 +705,121 @@ func TestReconcileDropoutSync(t *testing.T) {
 		t.Fatalf("dropped-out Done issue: mirror status = %q, want done", task.Status)
 	}
 }
+
+// TestIngestFullyTypedIssueRendersTyped is the positive control for the
+// Linear→task metadata carry (TSU linear-mirror ticket): a FULLY-TYPED issue —
+// real title, a Goal, ≥1 Acceptance Criterion, a DoD, and an agent lead — must
+// mirror as a typed, routable task. Asserting the happy path proves a later
+// "0 untitled / 0 unrouted" result comes from the carry actually working, not
+// from the guard never running against real data.
+func TestIngestFullyTypedIssueRendersTyped(t *testing.T) {
+	database := newTestDB(t)
+	c := newTestConn(t, database)
+	now := time.Now().UnixMilli()
+
+	iss := baseIssue()
+	iss["id"] = "issue-typed-1"
+	iss["identifier"] = "SYN-777"
+	iss["number"] = 777
+	iss["title"] = "Carry Linear metadata into the mirror"
+	iss["description"] = "## Goal\nMirror keeps the ticket typed.\n\n" +
+		"## Acceptance Criteria\n- title survives\n- goal survives\n- dod survives\n\n" +
+		"## DoD\nAll three sections round-trip to the task."
+	// assignee "lead" is an agent -> the resolved routing lane.
+	body := issueFixture("create", now, "human-1", iss, nil)
+
+	if _, err := c.Ingest(body, sign(testSecret, body)); err != nil {
+		t.Fatalf("Ingest: %v", err)
+	}
+	task, err := database.GetTaskByLinearIssueID(c.project, "issue-typed-1")
+	if err != nil || task == nil {
+		t.Fatalf("mirror row not found: %v", err)
+	}
+
+	// Title = the Linear title — never "Untitled task {id}".
+	if task.Title != "Carry Linear metadata into the mirror" {
+		t.Errorf("title = %q, want the Linear title", task.Title)
+	}
+	if strings.Contains(strings.ToLower(task.Title), "untitled") {
+		t.Errorf("title fell back to a placeholder: %q", task.Title)
+	}
+	// linear_key populated (traceable back to Linear).
+	if task.LinearKey == nil || *task.LinearKey != "SYN-777" {
+		t.Errorf("linear_key = %v, want SYN-777", task.LinearKey)
+	}
+	// Typed: goal + acceptance_criteria + DoD all carried.
+	if task.Goal != "Mirror keeps the ticket typed." {
+		t.Errorf("goal = %q", task.Goal)
+	}
+	for _, want := range []string{"title survives", "goal survives", "dod survives"} {
+		if !strings.Contains(task.AcceptanceCriteria, want) {
+			t.Errorf("acceptance_criteria missing %q: %s", want, task.AcceptanceCriteria)
+		}
+	}
+	if task.AcceptanceCriteria == "[]" || strings.TrimSpace(task.AcceptanceCriteria) == "" {
+		t.Errorf("acceptance_criteria rendered empty: %q", task.AcceptanceCriteria)
+	}
+	if task.Dod != "All three sections round-trip to the task." {
+		t.Errorf("dod = %q", task.Dod)
+	}
+	// Routing lane populated from the resolved lead (assignee "lead").
+	if task.ProfileSlug != "lead" {
+		t.Errorf("profile_slug = %q, want lead (the routing lane)", task.ProfileSlug)
+	}
+}
+
+// TestIngestProfileSlugFromProjectRoute checks the routing lane is taken from
+// the owner-configured project route when present (it wins over the assignee),
+// matching dispatchTarget's precedence.
+func TestIngestProfileSlugFromProjectRoute(t *testing.T) {
+	database := newTestDB(t)
+	c := newTestConn(t, database)
+	// Route the issue's Linear project to a specific lead.
+	database.SetSetting("linear_routing", `{"proj-9":"wraith-backend"}`)
+	now := time.Now().UnixMilli()
+
+	iss := baseIssue()
+	iss["id"] = "issue-routed-1"
+	iss["project"] = map[string]any{"id": "proj-9", "name": "wrai.th"}
+	body := issueFixture("create", now, "human-1", iss, nil)
+
+	if _, err := c.Ingest(body, sign(testSecret, body)); err != nil {
+		t.Fatalf("Ingest: %v", err)
+	}
+	task, err := database.GetTaskByLinearIssueID(c.project, "issue-routed-1")
+	if err != nil || task == nil {
+		t.Fatalf("mirror row not found: %v", err)
+	}
+	if task.ProfileSlug != "wraith-backend" {
+		t.Errorf("profile_slug = %q, want wraith-backend (project route wins)", task.ProfileSlug)
+	}
+}
+
+// TestUpsertLinearMirrorProfileSlugNonDestructive guards that a content re-sync
+// never blanks a routing lane that a relay reassignment already set: an update
+// carrying an empty ProfileSlug must leave the stored slug intact.
+func TestUpsertLinearMirrorProfileSlugNonDestructive(t *testing.T) {
+	database := newTestDB(t)
+
+	// First sync sets the lane.
+	if _, _, err := database.UpsertLinearMirror(db.LinearMirrorSeed{
+		Project: "default", LinearIssueID: "iss-keep", Title: "T",
+		ProfileSlug: "wraith-backend", Status: "pending",
+	}); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	// A later content re-sync with no target must not blank it.
+	if _, _, err := database.UpsertLinearMirror(db.LinearMirrorSeed{
+		Project: "default", LinearIssueID: "iss-keep", Title: "T2",
+		ProfileSlug: "", Status: "in-progress",
+	}); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	task, err := database.GetTaskByLinearIssueID("default", "iss-keep")
+	if err != nil || task == nil {
+		t.Fatalf("row: %v", err)
+	}
+	if task.ProfileSlug != "wraith-backend" {
+		t.Errorf("profile_slug = %q, want it preserved as wraith-backend", task.ProfileSlug)
+	}
+}

--- a/internal/connector/linear/webhook.go
+++ b/internal/connector/linear/webhook.go
@@ -309,6 +309,14 @@ func (c *Connector) seedFromIssue(iss gqlIssue) db.LinearMirrorSeed {
 	if a := issueAssignee(iss); a != "" {
 		seed.Assignee = strptr(a)
 	}
+	// Routing lane: the resolved dispatch target (project route → delegate →
+	// assignee) IS the lead this issue routes to, so it becomes the mirror task's
+	// profile_slug — the field GetOldestPendingTaskForProfile pulls a lane's queue
+	// by. Without it every Linear-born task inserted blank and was unroutable.
+	// Only an agent target sets it; a human/empty target leaves profile_slug unset.
+	if target := c.dispatchTarget(iss); isAgent(target) {
+		seed.ProfileSlug = target
+	}
 	if pid := issueProjectID(iss); pid != "" {
 		seed.LinearProjectID = strptr(pid)
 	}

--- a/internal/db/comms_metrics_test.go
+++ b/internal/db/comms_metrics_test.go
@@ -19,8 +19,8 @@ func TestCommsMetricsSnapshot(t *testing.T) {
 	}
 	q, _ := d.InsertMessageWithDeliveries("p", "cto", "b", "question", "s", "x", "{}", "P2", 3600, nil, nil, []string{"b"}, "")
 	// worker: two no-wakes.
-	d.InsertMessageWithDeliveries("p", "worker", "b", "fyi", "s", "x", "{}", "P2", 3600, nil, nil, []string{"b"}, "")
-	d.InsertMessageWithDeliveries("p", "worker", "b", "status", "s", "x", "{}", "P2", 3600, nil, nil, []string{"b"}, "")
+	_, _ = d.InsertMessageWithDeliveries("p", "worker", "b", "fyi", "s", "x", "{}", "P2", 3600, nil, nil, []string{"b"}, "")
+	_, _ = d.InsertMessageWithDeliveries("p", "worker", "b", "status", "s", "x", "{}", "P2", 3600, nil, nil, []string{"b"}, "")
 
 	// Deterministic read receipt on the task: read 30s after send → under-1m bucket.
 	created, _ := time.Parse(memoryTimeFmt, task.CreatedAt)

--- a/internal/db/linear.go
+++ b/internal/db/linear.go
@@ -21,6 +21,7 @@ type LinearMirrorSeed struct {
 	Project         string
 	LinearIssueID   string // Linear issue UUID — the mirror key
 	LinearKey       *string
+	ProfileSlug     string // routing lane (the resolved lead), from the issue's dispatch target; "" leaves it unset
 	Title           string
 	Description     string
 	Priority        string
@@ -72,6 +73,12 @@ func (d *DB) GetTaskByLinearIssueID(project, linearIssueID string) (*models.Task
 //
 // Source is forced to 'linear'. On first insert a UUID is minted; on update the
 // existing row's id is reused so overlay/temporal state survives.
+//
+// profile_slug (the routing lane) is carried from the seed so a Linear-born task
+// lands in the right lead's queue — it used to insert blank, leaving every mirror
+// unroutable. The UPDATE only overwrites with a non-empty slug, so a later relay
+// reassignment (transitionTask recomputing profile_slug from the new assignee) is
+// never clobbered by a content re-sync.
 func (d *DB) UpsertLinearMirror(s LinearMirrorSeed) (taskID string, created bool, err error) {
 	if s.LinearIssueID == "" {
 		return "", false, fmt.Errorf("upsert linear mirror: empty linear_issue_id")
@@ -108,6 +115,7 @@ func (d *DB) UpsertLinearMirror(s LinearMirrorSeed) (taskID string, created bool
 			   assignee=?, cycle_id=?, cycle_name=?, cycle_start=?, cycle_end=?,
 			   linear_project_id=COALESCE(?, linear_project_id),
 			   parent_task_id=COALESCE(?, parent_task_id),
+			   profile_slug=COALESCE(NULLIF(?, ''), profile_slug),
 			   goal=?, acceptance_criteria=?, dod=?
 			 WHERE id=? AND project=?`,
 			s.Title, s.Description, s.Priority, s.Status,
@@ -115,6 +123,7 @@ func (d *DB) UpsertLinearMirror(s LinearMirrorSeed) (taskID string, created bool
 			s.Assignee, s.CycleID, s.CycleName, s.CycleStart, s.CycleEnd,
 			s.LinearProjectID,
 			s.ParentTaskID,
+			s.ProfileSlug,
 			s.Goal, s.AcceptanceCriteria, s.Dod,
 			existing.ID, s.Project,
 		)
@@ -139,8 +148,8 @@ func (d *DB) UpsertLinearMirror(s LinearMirrorSeed) (taskID string, created bool
 		    source, linear_issue_id, linear_key, external_url, points, labels, linear_state, assignee,
 		    cycle_id, cycle_name, cycle_start, cycle_end, parent_task_id, linear_project_id, last_activity_at, blocked_periods,
 		    goal, acceptance_criteria, dod)
-		 VALUES (?, '', 'linear', ?, ?, ?, ?, ?, ?, 'linear', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, '[]', ?, ?, ?)`,
-		id, s.Title, s.Description, s.Priority, s.Status, s.Project, now,
+		 VALUES (?, ?, 'linear', ?, ?, ?, ?, ?, ?, 'linear', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, '[]', ?, ?, ?)`,
+		id, s.ProfileSlug, s.Title, s.Description, s.Priority, s.Status, s.Project, now,
 		s.LinearIssueID, s.LinearKey, s.ExternalURL, s.Points, s.Labels, s.LinearState, s.Assignee,
 		s.CycleID, s.CycleName, s.CycleStart, s.CycleEnd, s.ParentTaskID, s.LinearProjectID, now,
 		s.Goal, s.AcceptanceCriteria, s.Dod,

--- a/internal/relay/backlog_handler_test.go
+++ b/internal/relay/backlog_handler_test.go
@@ -30,14 +30,14 @@ func TestBacklogDispatch_SkipsNotifyUntilPromote(t *testing.T) {
 	}
 
 	// Promote → pending; now the worker is notified.
-	h.HandlePromoteTask(ctx, call(map[string]any{"project": "p1", "as": "cto", "task_id": taskID}))
+	_, _ = h.HandlePromoteTask(ctx, call(map[string]any{"project": "p1", "as": "cto", "task_id": taskID}))
 	if n, _ := h.db.UnreadCountForAgent("p1", "w1"); n != 1 {
 		t.Fatalf("promote must notify the profile, got %d unread", n)
 	}
 
 	// Double-promote (task already pending) must be an idempotent no-op — no second
 	// wake/delivery (review-121f0ff5 finding).
-	h.HandlePromoteTask(ctx, call(map[string]any{"project": "p1", "as": "cto", "task_id": taskID}))
+	_, _ = h.HandlePromoteTask(ctx, call(map[string]any{"project": "p1", "as": "cto", "task_id": taskID}))
 	if n, _ := h.db.UnreadCountForAgent("p1", "w1"); n != 1 {
 		t.Fatalf("double-promote must not re-notify, got %d unread", n)
 	}


### PR DESCRIPTION
## Problem
The Linear→task sync inserted `profile_slug=''` on every mirror row, so a Linear-born task never landed in its lead's queue — `GetOldestPendingTaskForProfile` pulls a lane by `profile_slug`. Mirror tasks were unroutable.

## Fix (behavior-only, no schema change)
- `internal/db/linear.go`: add `ProfileSlug` to `LinearMirrorSeed`; INSERT binds it; UPDATE uses `profile_slug = COALESCE(NULLIF(?, ''), profile_slug)` — sets a non-empty lane but never blanks a later relay reassignment on a content re-sync.
- `internal/connector/linear/webhook.go` (`seedFromIssue`): derive from the resolved dispatch target (project route → delegate → assignee), same precedence as dispatch. Only an agent target sets it.

## Already carried by the mirror (verified, not this PR)
title, goal, acceptance_criteria, DoD, linear_key — landed in the earlier typed-ticket-seed work.

## Out of scope
The niwa review-gate render (`human_title`, `parse_criteria`, `route_escalation`, `archive_rec`) — separate niwa ticket. The relay-side "Untitled" heal happens automatically on the next idempotent reconcile poll.

## Tests
Positive control: a fully-typed issue mirrors typed + routable (title / linear_key / goal / AC / DoD / profile_slug asserted); project-route precedence; non-destructive-update guard. Full suite: 606 passed (`go test -tags fts5 ./...`).

## review-wraith verdict: SHIP
Scope: internal/db/linear.go (UpsertLinearMirror), internal/connector/linear/webhook.go (seedFromIssue), internal/connector/linear/linear_test.go
Gate: build -tags fts5 OK / vet OK / gofmt OK / test -tags fts5 OK (606 passed)

BLOCKERS: none
- No schema change; taskColumns/scanTask already carry profile_slug (no column-count drift).
- UPDATE is non-destructive: profile_slug=COALESCE(NULLIF(?,'), profile_slug) never blanks a relay reassignment.
- Content upsert, not a state transition — no TOCTOU/double-claim surface. Single writer preserved.

NITS: none
