### PR TITLE
feat(linear): route N relay projects onto one shared Linear team

### DIFF
--- a/internal/connector/linear/backfill.go
+++ b/internal/connector/linear/backfill.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+
+	"agent-relay/internal/models"
 )
 
 // agentProjectName maps a relay agent/profile to a Linear project NAME (owner's
@@ -84,9 +86,15 @@ func (c *Connector) Backfill(ctx context.Context, dryRun bool, limit int) (Backf
 		}
 	}
 
-	tasks, err := c.db.ListBackfillTasks(c.project)
-	if err != nil {
-		return res, err
+	// Backfill spans every relay project this mirror serves (default + mapped
+	// lanes), so tasks living in a mapped project are linked/created too.
+	var tasks []models.Task
+	for _, proj := range c.mirrorProjects() {
+		pt, err := c.db.ListBackfillTasks(proj)
+		if err != nil {
+			return res, err
+		}
+		tasks = append(tasks, pt...)
 	}
 	res.Eligible = len(tasks)
 

--- a/internal/connector/linear/linear_test.go
+++ b/internal/connector/linear/linear_test.go
@@ -823,3 +823,128 @@ func TestUpsertLinearMirrorProfileSlugNonDestructive(t *testing.T) {
 		t.Errorf("profile_slug = %q, want it preserved as wraith-backend", task.ProfileSlug)
 	}
 }
+
+// TestIngestMultiProjectRouting is the core of the multi-project mirror: two
+// relay projects share one Linear team. linear_project_map routes each Linear
+// project's issues into its own relay project's mirror; an unmapped project
+// falls back to the connector's default project. Before this, every mirror row
+// landed under c.project regardless of the Linear project — the other relay
+// project's queue never saw its tasks.
+func TestIngestMultiProjectRouting(t *testing.T) {
+	database := newTestDB(t)
+	c := newTestConn(t, database)
+	// Both Linear projects are routed to an agent (scope guard) AND mapped to
+	// their own relay project.
+	database.SetSetting("linear_routing", `{"lp-a":"lead-a","lp-b":"lead-b"}`)
+	database.SetSetting("linear_project_map", `{"lp-a":"relay-a","lp-b":"relay-b"}`)
+	now := time.Now().UnixMilli()
+
+	ingest := func(id, projectID string) {
+		iss := baseIssue()
+		iss["id"] = id
+		iss["project"] = map[string]any{"id": projectID, "name": projectID}
+		body := issueFixture("create", now, "human-1", iss, nil)
+		if _, err := c.Ingest(body, sign(testSecret, body)); err != nil {
+			t.Fatalf("Ingest %s: %v", id, err)
+		}
+	}
+	ingest("iss-a", "lp-a")
+	ingest("iss-b", "lp-b")
+
+	// iss-a mirrors into relay-a only.
+	if task, _ := database.GetTaskByLinearIssueID("relay-a", "iss-a"); task == nil {
+		t.Error("iss-a not mirrored into relay-a")
+	}
+	if task, _ := database.GetTaskByLinearIssueID("relay-b", "iss-a"); task != nil {
+		t.Error("iss-a leaked into relay-b")
+	}
+	if task, _ := database.GetTaskByLinearIssueID(c.project, "iss-a"); task != nil {
+		t.Error("iss-a leaked into the default project")
+	}
+	// iss-b mirrors into relay-b only.
+	if task, _ := database.GetTaskByLinearIssueID("relay-b", "iss-b"); task == nil {
+		t.Error("iss-b not mirrored into relay-b")
+	}
+}
+
+// TestIngestUnmappedProjectFallsBackToDefault checks an issue whose Linear
+// project has no linear_project_map entry lands in the connector's default
+// project (backward-compatible with the single-project mirror).
+func TestIngestUnmappedProjectFallsBackToDefault(t *testing.T) {
+	database := newTestDB(t)
+	c := newTestConn(t, database)
+	database.SetSetting("linear_routing", `{"lp-x":"lead-x"}`)
+	database.SetSetting("linear_project_map", `{"lp-a":"relay-a"}`) // no entry for lp-x
+	now := time.Now().UnixMilli()
+
+	iss := baseIssue()
+	iss["id"] = "iss-x"
+	iss["project"] = map[string]any{"id": "lp-x", "name": "lp-x"}
+	body := issueFixture("create", now, "human-1", iss, nil)
+	if _, err := c.Ingest(body, sign(testSecret, body)); err != nil {
+		t.Fatalf("Ingest: %v", err)
+	}
+	if task, _ := database.GetTaskByLinearIssueID(c.project, "iss-x"); task == nil {
+		t.Errorf("unmapped project issue did not fall back to default project %q", c.project)
+	}
+	if task, _ := database.GetTaskByLinearIssueID("relay-a", "iss-x"); task != nil {
+		t.Error("unmapped issue leaked into a mapped project")
+	}
+}
+
+// TestReconcileMultiProjectDropoutSweep proves the reconcile poll heals AND
+// closes mirrors across every mapped relay project, not just the default one.
+// A mirror living in a mapped project that drops out of the open set (issue
+// moved to Done in Linear) must be closed by the dropout sweep — before the
+// multi-project sweep it was invisible and stayed active forever.
+func TestReconcileMultiProjectDropoutSweep(t *testing.T) {
+	database := newTestDB(t)
+	c := newTestConn(t, database)
+	database.SetSetting("linear_routing", `{"lp-a":"lead-a"}`)
+	database.SetSetting("linear_project_map", `{"lp-a":"relay-a"}`)
+
+	open := true
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		query := readQuery(r)
+		switch {
+		case strings.Contains(query, "TeamOpenIssues"):
+			if open {
+				writeData(w, `{"issues":{"pageInfo":{"hasNextPage":false,"endCursor":""},"nodes":[
+					{"id":"i-a","identifier":"SYN-9","number":9,"title":"A","priority":2,"url":"u","state":{"id":"s1","name":"In Progress","type":"started"},"assignee":{"id":"u1","name":"lead-a","displayName":"Lead A"},"project":{"id":"lp-a","name":"relay-a"},"labels":{"nodes":[]}}
+				]}}`)
+			} else {
+				writeData(w, `{"issues":{"pageInfo":{"hasNextPage":false,"endCursor":""},"nodes":[]}}`)
+			}
+		case strings.Contains(query, "IssuesByIDs"):
+			// The dropped issue is now Done in Linear.
+			writeData(w, `{"issues":{"nodes":[{"id":"i-a","state":{"id":"s9","name":"Done","type":"completed"}}]}}`)
+		default:
+			writeData(w, `{}`)
+		}
+	}))
+	defer srv.Close()
+	c.gql.url = srv.URL
+
+	// Poll 1: i-a is open and mirrors into relay-a (the mapped project).
+	if _, err := c.ReconcileCycle(c.project); err != nil {
+		t.Fatalf("reconcile 1: %v", err)
+	}
+	task, _ := database.GetTaskByLinearIssueID("relay-a", "i-a")
+	if task == nil {
+		t.Fatal("i-a not mirrored into mapped project relay-a")
+	}
+
+	// Poll 2: i-a dropped out of the open set (moved to Done). The sweep must
+	// find its mirror in relay-a and close it.
+	open = false
+	if _, err := c.ReconcileCycle(c.project); err != nil {
+		t.Fatalf("reconcile 2: %v", err)
+	}
+	closed, _ := database.GetTaskByLinearIssueID("relay-a", "i-a")
+	if closed == nil {
+		t.Fatal("mirror vanished")
+	}
+	if closed.Status != "done" {
+		t.Errorf("mapped-project mirror status = %q, want done (dropout sweep must cover mapped projects)", closed.Status)
+	}
+}

--- a/internal/connector/linear/reconcile.go
+++ b/internal/connector/linear/reconcile.go
@@ -32,8 +32,7 @@ func (c *Connector) ReconcileCycle(_ string) (int, error) {
 	// status is the dedupe — once the row is in-progress, later polls skip it.
 	upserted := 0
 	hasParent := false
-	requireTicket := c.db.ProjectRequiresTypedTicket(c.project) // constant this cycle
-	seen := make(map[string]bool, len(issues))                  // every OPEN issue id this poll saw
+	seen := make(map[string]bool, len(issues)) // every OPEN issue id this poll saw
 	for _, iss := range issues {
 		if iss.ID == "" {
 			continue
@@ -49,8 +48,12 @@ func (c *Connector) ReconcileCycle(_ string) (int, error) {
 		if !isAgent(target) {
 			continue
 		}
-		prior, _ := c.db.GetTaskByLinearIssueID(c.project, iss.ID)
+		// Per-issue relay project (multi-project mirror): the seed resolves it via
+		// projectFor, and every lookup/gate below scopes to seed.Project — the poll
+		// heals issues across all mapped relay projects, not just the default one.
 		seed := c.seedFromIssue(iss)
+		prior, _ := c.db.GetTaskByLinearIssueID(seed.Project, iss.ID)
+		requireTicket := c.db.ProjectRequiresTypedTicket(seed.Project)
 
 		// Typed-ticket enforcement, unified with the webhook path on the refused
 		// mirror row + marker (see handleTypedTicket). A non-conforming issue that
@@ -141,17 +144,22 @@ func (c *Connector) ReconcileCycle(_ string) (int, error) {
 // blip never cancels live work. A genuine reopen re-enters the open set and
 // re-dispatches via the normal path.
 func (c *Connector) syncDroppedMirrors(ctx context.Context, seen map[string]bool) {
-	active, err := c.db.ActiveLinearMirrors(c.project)
-	if err != nil {
-		log.Printf("[linear] reconcile dropout-sync list: %v", err)
-		return
-	}
+	// Sweep every relay project this mirror writes to (default + mapped lanes) —
+	// a dropped issue's mirror may live in any of them. Linear issue ids are
+	// globally unique, so aggregating across projects never collides.
 	taskByIssue := map[string]string{}
 	var missing []string
-	for _, m := range active {
-		if !seen[m.LinearIssueID] {
-			missing = append(missing, m.LinearIssueID)
-			taskByIssue[m.LinearIssueID] = m.TaskID
+	for _, proj := range c.mirrorProjects() {
+		active, err := c.db.ActiveLinearMirrors(proj)
+		if err != nil {
+			log.Printf("[linear] reconcile dropout-sync list (%s): %v", proj, err)
+			continue
+		}
+		for _, m := range active {
+			if !seen[m.LinearIssueID] {
+				missing = append(missing, m.LinearIssueID)
+				taskByIssue[m.LinearIssueID] = m.TaskID
+			}
 		}
 	}
 	if len(missing) == 0 {

--- a/internal/connector/linear/webhook.go
+++ b/internal/connector/linear/webhook.go
@@ -178,8 +178,8 @@ func (c *Connector) Ingest(payload []byte, sig string) ([]connector.TaskEvent, e
 	// refused either (kept symmetric with the poll, which skips non-agent issues
 	// before enforcement). Work already in flight is never retro-refused.
 	if !strings.EqualFold(env.Action, "remove") &&
-		c.db.ProjectRequiresTypedTicket(c.project) && isAgent(c.dispatchTarget(iss)) {
-		existing, err := c.db.GetTaskByLinearIssueID(c.project, iss.ID)
+		c.db.ProjectRequiresTypedTicket(seed.Project) && isAgent(c.dispatchTarget(iss)) {
+		existing, err := c.db.GetTaskByLinearIssueID(seed.Project, iss.ID)
 		if err != nil {
 			return nil, err
 		}
@@ -228,7 +228,7 @@ func (c *Connector) dispatchEvent(taskID, title, agent string, seed db.LinearMir
 	// already started work (start_task), a different lifecycle moment.
 	return connector.TaskEvent{
 		Type:    "task.dispatched",
-		Project: c.project,
+		Project: seed.Project,
 		Agent:   agent,
 		Payload: map[string]any{
 			"agent":             agent,
@@ -285,7 +285,7 @@ func stateChanged(updatedFrom map[string]json.RawMessage) bool {
 // parent has already been mirrored.
 func (c *Connector) seedFromIssue(iss gqlIssue) db.LinearMirrorSeed {
 	seed := db.LinearMirrorSeed{
-		Project:       c.project,
+		Project:       c.projectFor(iss),
 		LinearIssueID: iss.ID,
 		Title:         iss.Title,
 		Description:   iss.Description,
@@ -333,7 +333,10 @@ func (c *Connector) seedFromIssue(iss gqlIssue) db.LinearMirrorSeed {
 		}
 	}
 	if pid := iss.parentLinearID(); pid != "" {
-		if parent, err := c.db.GetTaskByLinearIssueID(c.project, pid); err == nil && parent != nil {
+		// Parent resolves within the child's own relay project. A sub-issue in a
+		// different Linear project than its parent is not linked (cross-project
+		// parenting is out of scope); same-project parenting is the common case.
+		if parent, err := c.db.GetTaskByLinearIssueID(seed.Project, pid); err == nil && parent != nil {
 			seed.ParentTaskID = strptr(parent.ID)
 		}
 	}
@@ -405,7 +408,21 @@ func issueProjectID(iss gqlIssue) string {
 // linearRouting reads the owner-configured project→agent map (setting
 // "linear_routing", JSON {linearProjectId: agentName}). Empty when unset.
 func (c *Connector) linearRouting() map[string]string {
-	raw := strings.TrimSpace(c.db.GetSetting("linear_routing"))
+	return c.settingMap("linear_routing")
+}
+
+// projectMap reads the owner-configured Linear-project→relay-project map
+// (setting "linear_project_map", JSON {linearProjectId: relayProjectName}).
+// It lets several relay projects share one Linear team: each Linear project
+// routes its issues into its own relay project's mirror. Empty when unset —
+// every issue then falls back to the connector's default project (c.project).
+func (c *Connector) projectMap() map[string]string {
+	return c.settingMap("linear_project_map")
+}
+
+// settingMap decodes a JSON string→string settings value; nil on empty/invalid.
+func (c *Connector) settingMap(key string) map[string]string {
+	raw := strings.TrimSpace(c.db.GetSetting(key))
 	if raw == "" {
 		return nil
 	}
@@ -414,6 +431,37 @@ func (c *Connector) linearRouting() map[string]string {
 		return nil
 	}
 	return m
+}
+
+// projectFor resolves the relay project an issue's mirror lives under. The
+// linear_project_map routes each Linear project to its own relay project;
+// unmapped issues fall back to the connector's default project (c.project).
+// This is the ONE decision that makes the mirror multi-project: every write and
+// lookup for an issue must scope to projectFor(iss), never a hardcoded c.project.
+func (c *Connector) projectFor(iss gqlIssue) string {
+	if pid := issueProjectID(iss); pid != "" {
+		if p := c.projectMap()[pid]; p != "" {
+			return strings.ToLower(strings.TrimSpace(p))
+		}
+	}
+	return c.project
+}
+
+// mirrorProjects returns every relay project this connector's mirror may write
+// to: the default project plus every distinct target in linear_project_map.
+// Used by cross-project sweeps (the dropout-sync) that must cover all lanes, not
+// just the default one. The default is always first and never duplicated.
+func (c *Connector) mirrorProjects() []string {
+	out := []string{c.project}
+	seen := map[string]bool{c.project: true}
+	for _, p := range c.projectMap() {
+		p = strings.ToLower(strings.TrimSpace(p))
+		if p != "" && !seen[p] {
+			seen[p] = true
+			out = append(out, p)
+		}
+	}
+	return out
 }
 
 // dispatchTarget resolves the agent to dispatch an issue to, in priority order:

--- a/internal/relay/api.go
+++ b/internal/relay/api.go
@@ -382,6 +382,7 @@ func (r *Relay) apiGetSettings(w http.ResponseWriter) {
 			"enabled":        enabled,
 			"team_key":       teamKey,
 			"project":        r.linearProjectName(teamKey, enabled),
+			"projects":       r.linearMirrorProjects(teamKey, enabled),
 			"api_key_masked": masked,
 			"interval":       interval.String(),
 			"source":         source,
@@ -401,6 +402,7 @@ var writableSettings = map[string]bool{
 	setLinearProject:   true,
 	setLinearInterval:  true,
 	setLinearRouting:   true,
+	setLinearProjMap:   true,
 	setFederationPeers: true,
 }
 

--- a/internal/relay/linear_manager.go
+++ b/internal/relay/linear_manager.go
@@ -1,6 +1,7 @@
 package relay
 
 import (
+	"encoding/json"
 	"log"
 	"strings"
 	"time"
@@ -17,7 +18,8 @@ const (
 	setLinearTeamKey  = "linear_team_key" // e.g. SYN
 	setLinearProject  = "linear_project"  // relay project hosting the mirror (default: lowercased team key)
 	setLinearInterval = "linear_reconcile_interval"
-	setLinearRouting  = "linear_routing" // JSON {linearProjectId: agentName} — project→agent auto-dispatch
+	setLinearRouting  = "linear_routing"     // JSON {linearProjectId: agentName} — project→agent auto-dispatch
+	setLinearProjMap  = "linear_project_map" // JSON {linearProjectId: relayProject} — project→relay-project mirror routing
 )
 
 // effectiveLinearConfig resolves the Linear connector configuration: env wins
@@ -106,4 +108,33 @@ func (r *Relay) linearProjectName(teamKey string, enabled bool) string {
 		p = "default"
 	}
 	return p
+}
+
+// linearMirrorProjects returns every relay project the Linear mirror writes to:
+// the default project plus each distinct target in linear_project_map. The UI
+// uses it to mark ALL mirror lanes read-only (Linear is SSOT), not just the
+// default. Empty when the connector is disabled. Default is first, deduplicated.
+func (r *Relay) linearMirrorProjects(teamKey string, enabled bool) []string {
+	def := r.linearProjectName(teamKey, enabled)
+	if def == "" {
+		return nil
+	}
+	out := []string{def}
+	seen := map[string]bool{def: true}
+	raw := strings.TrimSpace(r.DB.GetSetting(setLinearProjMap))
+	if raw == "" {
+		return out
+	}
+	var m map[string]string
+	if err := json.Unmarshal([]byte(raw), &m); err != nil {
+		return out
+	}
+	for _, p := range m {
+		p = strings.ToLower(strings.TrimSpace(p))
+		if p != "" && !seen[p] {
+			seen[p] = true
+			out = append(out, p)
+		}
+	}
+	return out
 }

--- a/internal/web/static/v2/v2.js
+++ b/internal/web/static/v2/v2.js
@@ -39,7 +39,15 @@ const ctx = {
   get scope() { return current; },
   currentPage: () => current.page,
   projNames: () => projects.map((p) => p.name),
-  isMirror: (p) => !!(settings.linear && settings.linear.project && p === settings.linear.project),
+  isMirror: (p) => {
+    if (!settings.linear) return false;
+    // Multi-project mirror: any relay project the connector writes to is a
+    // read-only SSOT mirror. Prefer the full projects[] set; fall back to the
+    // single default project for older settings payloads.
+    const set = settings.linear.projects;
+    if (Array.isArray(set) && set.length) return set.includes(p);
+    return !!(settings.linear.project && p === settings.linear.project);
+  },
   // Linear team URL (workspace unknown — lands the logged-in user on Linear).
   linearTeamURL: () => 'https://linear.app/',
   onEvent(fn) { eventSubs.add(fn); return () => eventSubs.delete(fn); },


### PR DESCRIPTION
## Problem
Le connecteur Linear est un singleton lié à UN projet relay (`c.project`, la team key en minuscules). Chaque issue mirroir était écrite `seed.Project = c.project` quel que soit son projet Linear — donc deux projets relay ne pouvaient pas partager une team Linear : les issues destinées au second atterrissaient dans le premier, et l'agent routé (enregistré sous l'autre projet) ne les voyait jamais (`GetOldestPendingTaskForProfile` scope `WHERE project = ? AND profile_slug = ?`).

## Fix (comportement seul, pas de changement de schéma)
Nouveau réglage owner `linear_project_map` — JSON `{linearProjectId: relayProject}`, parallèle à `linear_routing` `{linearProjectId: agent}`. Le projet relay destination devient **par-issue** :
- `webhook.go` : ajoute `projectFor(iss)` / `projectMap()` / `mirrorProjects()` ; `seedFromIssue` pose `Project = projectFor(iss)` ; gate typed-ticket, parent-lookup et `dispatchEvent` scopent à `seed.Project` au lieu de `c.project` en dur.
- `reconcile.go` : projet par-issue (`prior` + `requireTicket` résolus par `seed.Project`) ; `syncDroppedMirrors` balaie **tous** les projets relay mappés, pas seulement le défaut.
- `backfill.go` : itère `mirrorProjects()`.
- relay : whitelist `linear_project_map` ; l'API settings expose `linear.projects[]` (défaut + mappés) ; le web `isMirror()` marque chaque lane miroir read-only.

Projet Linear non-mappé → fallback `c.project` = **byte-identique au miroir mono-projet actuel**. Le connecteur reste singleton (1 team, 1 webhook, 1 reconcile séquentiel) ; seule la CIBLE write/lookup est routée. Rétro-compatible (DB/agents anciens OK).

## Config (owner, aucun redémarrage)
Chaque agent routé doit être enregistré **sous le projet relay ciblé** (sinon `GetOldestPendingTaskForProfile` le rate).

## Tests
- `TestIngestMultiProjectRouting` : deux projets Linear → deux projets relay, sans fuite croisée.
- `TestIngestUnmappedProjectFallsBackToDefault` : fallback préservé.
- `TestReconcileMultiProjectDropoutSweep` : le sweep Done-dropout ferme un miroir vivant dans un projet mappé (non-défaut).
- Suite complète : 609 passed (`go build/vet/test -tags fts5 ./...`).

## review-wraith verdict: SHIP
BLOCKERS: none. NITS: `projectMap()` re-parse le setting par-issue (RO pool, pas hot path) ; map + routing doivent s'accorder (erreur de config, pas de code).

https://claude.ai/code/session_017wjp7inBDPnQ8jvt6NMV6D