### PR TITLE
fix: CI red on main — race in fan-out test, pre-existing errcheck

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -243,7 +243,7 @@ func (d *DB) Backup(keep int) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("open backup connection: %w", err)
 	}
-	defer backupConn.Close()
+	defer func() { _ = backupConn.Close() }()
 	backupConn.SetMaxOpenConns(1)
 
 	if _, err := backupConn.Exec("VACUUM INTO ?", dst); err != nil {

--- a/internal/relay/linear_webhook_test.go
+++ b/internal/relay/linear_webhook_test.go
@@ -31,9 +31,17 @@ func (f *fakeTaskConn) Active() bool                         { return true }
 // a SECONDARY mirror task (linear_project_map routed its issue to several
 // relay projects; this row isn't the primary) must never push a Linear state
 // change — only the primary mirror does (single-write-back-per-issue, AC5).
+//
+// pushStatusAsync fires PushStatus from a goroutine, so the call count must be
+// observed through a channel (synchronized by Go's memory model), never a bare
+// shared counter — a plain `pushed++`/read pair here is a real data race under
+// `go test -race` even though it "worked" unraced locally.
 func TestPushStatusAsyncSkipsSecondaryMirror(t *testing.T) {
-	pushed := 0
-	fake := &fakeTaskConn{onPushStatus: func(string, string, string) error { pushed++; return nil }}
+	calls := make(chan struct{}, 2)
+	fake := &fakeTaskConn{onPushStatus: func(string, string, string) error {
+		calls <- struct{}{}
+		return nil
+	}}
 
 	issueID := "iss-x"
 	secondary := &models.Task{Source: "linear", LinearIssueID: &issueID, LinearSecondary: true}
@@ -42,13 +50,15 @@ func TestPushStatusAsyncSkipsSecondaryMirror(t *testing.T) {
 	pushStatusAsync(fake, secondary, "in-review", nil)
 	pushStatusAsync(fake, primary, "in-review", nil)
 
-	// pushStatusAsync fires the push in a goroutine; give it a beat to land.
-	deadline := time.Now().Add(time.Second)
-	for pushed == 0 && time.Now().Before(deadline) {
-		time.Sleep(time.Millisecond)
+	select {
+	case <-calls:
+	case <-time.After(time.Second):
+		t.Fatal("PushStatus never called — the primary mirror must push")
 	}
-	if pushed != 1 {
-		t.Errorf("PushStatus called %d times, want exactly 1 (secondary mirror must be skipped, primary must fire)", pushed)
+	select {
+	case <-calls:
+		t.Fatal("PushStatus called a second time — the secondary mirror must be skipped")
+	case <-time.After(100 * time.Millisecond):
 	}
 }
 
@@ -56,8 +66,11 @@ func TestPushStatusAsyncSkipsSecondaryMirror(t *testing.T) {
 // Secondary gate never touches a native task or a Linear task with no issue id
 // — pre-existing no-op paths must stay byte-identical.
 func TestPushStatusAsyncNativeAndNoLinearIDUnaffected(t *testing.T) {
-	pushed := 0
-	fake := &fakeTaskConn{onPushStatus: func(string, string, string) error { pushed++; return nil }}
+	calls := make(chan struct{}, 2)
+	fake := &fakeTaskConn{onPushStatus: func(string, string, string) error {
+		calls <- struct{}{}
+		return nil
+	}}
 
 	native := &models.Task{Source: "native"}
 	pushStatusAsync(fake, native, "in-review", nil)
@@ -65,8 +78,9 @@ func TestPushStatusAsyncNativeAndNoLinearIDUnaffected(t *testing.T) {
 	linearNoID := &models.Task{Source: "linear"}
 	pushStatusAsync(fake, linearNoID, "in-review", nil)
 
-	time.Sleep(20 * time.Millisecond)
-	if pushed != 0 {
-		t.Errorf("PushStatus called %d times, want 0 for native/no-issue-id tasks", pushed)
+	select {
+	case <-calls:
+		t.Fatal("PushStatus called for a native/no-issue-id task, want no-op")
+	case <-time.After(50 * time.Millisecond):
 	}
 }


### PR DESCRIPTION
## Summary
Trunk (`main`) went red after `a2cbb254e818` (Linear fan-out, #162) merged:

1. **Real data race** in my own new test `TestPushStatusAsyncSkipsSecondaryMirror` (`internal/relay/linear_webhook_test.go`): a bare `pushed++`/read pair observed across the `pushStatusAsync` goroutine and the test goroutine with no synchronization. Passed locally under plain `go test`, but CI runs `go test -tags fts5 -race -count=1 ./...` — I hadn't run `-race` locally before submitting, that's the gap (now fixed and verified with `-race` before this push). Rewrote both new `pushStatusAsync` tests to observe calls through a channel (synchronized by Go's memory model) instead of a shared counter. The underlying feature logic (primary-mirror-only write-back, `linear_secondary` gating) was never wrong — only the test's own synchronization was.
2. **Pre-existing golangci-lint errcheck** at `internal/db/db.go:246` (`defer backupConn.Close()`), introduced by an earlier unrelated commit (`2ade5fe`, serve-wedge-fix) — not part of the fan-out feature, but it was blocking this PR's lint gate so fixed here to get trunk green again. `defer func() { _ = backupConn.Close() }()`.

The CI logs' "sql: database is closed" spam around the race report is unrelated background noise from other tests' token-usage-flush goroutines in the same test binary, not caused by either of the above.

## Test plan
- [x] `go build -tags fts5 ./...`
- [x] `go vet -tags fts5 ./...`
- [x] `gofmt -l .` clean
- [x] `go test -tags fts5 -race -count=1 ./...` — 635 passed, zero races (ran exactly as CI does, which I skipped before the original PR — root cause of this incident)
- [x] `golangci-lint run --timeout=5m` (v2.12.2, installed locally to verify) — 0 issues

## review-wraith verdict: SHIP
Scope: internal/relay/linear_webhook_test.go (my own test's synchronization only, no logic change), internal/db/db.go (1-line unrelated errcheck fix)
Gate: build -tags fts5 OK / vet OK / gofmt OK / test -tags fts5 -race OK (635 passed) / golangci-lint OK (0 issues)

BLOCKERS: none
NITS: none — no production logic changed in internal/relay/linear_webhook_test.go (test-only synchronization fix); db.go fix is a 1-line errcheck silence on an already-correctly-scoped defer.

Not self-merging (touches shared db.go, and this is the fix for a trunk-red incident) — requesting CTO merge.