### PR TITLE
feat(relay): Phase 0 referential-integrity scan (detect+log+quarantine)

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -826,6 +826,29 @@ func migrate(conn *sql.DB) error {
 	)`)
 	_, _ = conn.Exec(`CREATE INDEX IF NOT EXISTS idx_linear_sync_log_ts ON linear_sync_log(id DESC)`)
 
+	// Referential-integrity quarantine (Phase 0, task 536ecc40). A SIDE-TABLE (not
+	// flag columns on tasks/agents) so the taskColumns↔scanTask / agentColumns↔
+	// scanAgent lockstep is never touched and every ref class logs uniformly. It is
+	// pure OBSERVABILITY: a row here records that some referencing row points at an
+	// identity that does not resolve (or resolves to a dead one). NOTHING reads it to
+	// change behavior in Phase 0 — the offending task/agent keeps its real status and
+	// stays claimable/visible exactly as before. resolved_at stamps when a ref later
+	// resolves (audit trail, never a delete). UNIQUE(table_name,row_id,ref_col,class)
+	// makes the scan an idempotent upsert. See internal/db/integrity.go.
+	_, _ = conn.Exec(`CREATE TABLE IF NOT EXISTS integrity_quarantine (
+		id          INTEGER PRIMARY KEY AUTOINCREMENT,
+		table_name  TEXT NOT NULL,
+		row_id      TEXT NOT NULL,
+		ref_col     TEXT NOT NULL,
+		ref_value   TEXT NOT NULL DEFAULT '',
+		class       TEXT NOT NULL,
+		project     TEXT NOT NULL DEFAULT '',
+		detected_at TEXT NOT NULL,
+		resolved_at TEXT,
+		UNIQUE(table_name, row_id, ref_col, class)
+	)`)
+	_, _ = conn.Exec(`CREATE INDEX IF NOT EXISTS idx_integrity_open ON integrity_quarantine(class, resolved_at)`)
+
 	// Teams + Orgs
 	_, _ = conn.Exec(`CREATE TABLE IF NOT EXISTS orgs (
 		id          TEXT PRIMARY KEY,
@@ -1238,6 +1261,17 @@ func migrate(conn *sql.DB) error {
 	// see board_routing.go. Runs once (settings-marker guarded); new dispatches
 	// self-route going forward via DispatchTask.
 	runProductBoardRoutingBackfill(conn)
+
+	// Referential-integrity scan (Phase 0, task 536ecc40): detect + log + quarantine
+	// dangling identity references. Read-mostly (writes only the quarantine
+	// side-table), idempotent, NO behavior change — the offending rows are untouched.
+	// Runs on every boot (fast, bounded) so a fresh upgrade immediately surfaces the
+	// existing orphans/limbo; the periodic sweep (StartCleanup) keeps it current.
+	if counts, err := runReferentialScan(conn); err != nil {
+		log.Printf("integrity: startup referential scan error: %v", err)
+	} else {
+		logReferentialCounts("startup", counts)
+	}
 
 	return nil
 }

--- a/internal/db/referential_integrity.go
+++ b/internal/db/referential_integrity.go
@@ -1,0 +1,320 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log"
+	"sort"
+	"strings"
+	"time"
+)
+
+// Referential-integrity scan — Phase 0 (task 536ecc40, design
+// trovex/7c0e0b8cc39b41ff8dff486b83695f3d, ruled by cto-tsukumo 2026-09-01).
+//
+// NOTE: this is distinct from integrity.go, which does STRUCTURAL integrity
+// (SQLite PRAGMA integrity_check / foreign_key_check on the file). Here we check
+// REFERENTIAL integrity: dangling string-natural-key references between rows.
+//
+// The relay's whole identity/namespace model rests on STRING natural keys (agent
+// name, project name, profile slug) referenced by string across ~34 tables, with
+// no enforced FK on those refs. Rows accumulate that point at an identity which
+// no longer resolves (a deactivated/deleted agent, an unbacked profile slug) —
+// the silent orphan/misroute/limbo class. This pass DETECTS and LOGS those
+// dangling references into the integrity_quarantine side-table.
+//
+// Phase 0 is pure OBSERVABILITY: it changes NOTHING about how a flagged row
+// behaves. The task keeps its real status and stays claimable/visible exactly as
+// before; a quarantine row is inert metadata a human/CTO (and, later, the ledger
+// seam) can read. No enforcement, no reroute, no deletion. Phases 1/2 (separate
+// PRs) add reconcile + soft-cascade on top of this surface.
+//
+// Design decisions (ruled):
+//   - Storage is a SIDE-TABLE, never flag columns on tasks/agents, so the
+//     taskColumns↔scanTask / agentColumns↔scanAgent lockstep is untouched.
+//   - Sentinel principals {linear, cron, user} are VALID non-agent references and
+//     are never flagged. Service agents (is_service=1) have real agent rows, so
+//     hard-orphan checks resolve them automatically; the limbo check excludes
+//     them explicitly (they are exempt from the liveness gate).
+//   - A value that equals a profile SLUG but has a matching agent NAME row (the
+//     analytics-lead / cro-lead name==slug collision) RESOLVES and is not an
+//     orphan — detection asks only "does an agent row exist for (project,value)?",
+//     so the name-vs-slug ambiguity never mis-flags a live agent.
+//   - profile_slug orphans are STRUCTURAL (the profiles table is sparse; many
+//     valid dispatch profiles have no formal profiles row). They are TOLERATED +
+//     marked here, NEVER rewritten to an agent name (that would defeat the
+//     profile-pool dispatch model).
+
+// integritySentinels are the reserved non-agent principals that legitimately
+// have no agents row. Lowercase; matched case-insensitively. Kept a const map
+// (deterministic, code-is-law) rather than config; service agents are handled
+// dynamically via their is_service row, not by name.
+var integritySentinels = map[string]bool{
+	"linear": true,
+	"cron":   true,
+	"user":   true,
+}
+
+// sentinelSQLList renders the sentinel set as a SQL literal list for a
+// `LOWER(col) NOT IN (...)` guard. Sorted so the generated SQL is deterministic.
+func sentinelSQLList() string {
+	vals := make([]string, 0, len(integritySentinels))
+	for k := range integritySentinels {
+		vals = append(vals, "'"+k+"'")
+	}
+	sort.Strings(vals)
+	return strings.Join(vals, ", ")
+}
+
+// refCheck is one orphan class. orphanSQL selects the CURRENT offending rows with
+// EXACTLY three output columns aliased row_id, ref_value, project. class↔(table,
+// refCol) is 1:1, so a class name alone keys a row's quarantine lifecycle.
+type refCheck struct {
+	class     string
+	table     string
+	refCol    string
+	orphanSQL string
+}
+
+// refChecks builds the full check set. It is a function (not a package var)
+// because the sentinel guard is interpolated into the SQL.
+func refChecks() []refCheck {
+	sent := sentinelSQLList()
+	return []refCheck{
+		// --- task agent-name references (the big orphan counts) ---
+		{
+			class: "orphan_dispatcher", table: "tasks", refCol: "dispatched_by",
+			orphanSQL: `SELECT t.id AS row_id, t.dispatched_by AS ref_value, t.project AS project
+				FROM tasks t
+				WHERE t.dispatched_by IS NOT NULL AND t.dispatched_by <> ''
+				  AND t.archived_at IS NULL
+				  AND LOWER(t.dispatched_by) NOT IN (` + sent + `)
+				  AND NOT EXISTS (SELECT 1 FROM agents a WHERE a.project = t.project AND LOWER(a.name) = LOWER(t.dispatched_by))`,
+		},
+		{
+			class: "orphan_assignee", table: "tasks", refCol: "assigned_to",
+			orphanSQL: `SELECT t.id AS row_id, t.assigned_to AS ref_value, t.project AS project
+				FROM tasks t
+				WHERE t.assigned_to IS NOT NULL AND t.assigned_to <> ''
+				  AND t.archived_at IS NULL
+				  AND LOWER(t.assigned_to) NOT IN (` + sent + `)
+				  AND NOT EXISTS (SELECT 1 FROM agents a WHERE a.project = t.project AND LOWER(a.name) = LOWER(t.assigned_to))`,
+		},
+		{
+			class: "orphan_claimer", table: "tasks", refCol: "claimed_by",
+			orphanSQL: `SELECT t.id AS row_id, t.claimed_by AS ref_value, t.project AS project
+				FROM tasks t
+				WHERE t.claimed_by IS NOT NULL AND t.claimed_by <> ''
+				  AND t.archived_at IS NULL
+				  AND LOWER(t.claimed_by) NOT IN (` + sent + `)
+				  AND NOT EXISTS (SELECT 1 FROM agents a WHERE a.project = t.project AND LOWER(a.name) = LOWER(t.claimed_by))`,
+		},
+		// --- limbo: a NON-TERMINAL task assigned to an agent that EXISTS but is
+		// not active (deactivated/deleted/sleeping) and is not a service identity.
+		// This is the permanent-claim-limbo class the audit called out — the task
+		// can never be picked up because its assignee is dead. Distinct from
+		// orphan_assignee (no agent row at all).
+		{
+			class: "limbo", table: "tasks", refCol: "assigned_to",
+			orphanSQL: `SELECT t.id AS row_id, t.assigned_to AS ref_value, t.project AS project
+				FROM tasks t
+				JOIN agents a ON a.project = t.project AND LOWER(a.name) = LOWER(t.assigned_to)
+				WHERE t.status NOT IN ('done', 'cancelled')
+				  AND t.assigned_to IS NOT NULL AND t.assigned_to <> ''
+				  AND t.archived_at IS NULL
+				  AND a.status <> 'active'
+				  AND a.is_service = 0`,
+		},
+		// --- task profile_slug: STRUCTURAL orphan (sparse profiles table).
+		// Tolerated + marked, never rewritten. Empty slug (Linear mirror inserts '')
+		// is not an orphan.
+		{
+			class: "orphan_profile", table: "tasks", refCol: "profile_slug",
+			orphanSQL: `SELECT t.id AS row_id, t.profile_slug AS ref_value, t.project AS project
+				FROM tasks t
+				WHERE t.profile_slug IS NOT NULL AND t.profile_slug <> ''
+				  AND t.archived_at IS NULL
+				  AND NOT EXISTS (SELECT 1 FROM profiles p WHERE p.project = t.project AND LOWER(p.slug) = LOWER(t.profile_slug))`,
+		},
+		// --- task id references (uuid) ---
+		{
+			class: "orphan_parent", table: "tasks", refCol: "parent_task_id",
+			orphanSQL: `SELECT t.id AS row_id, t.parent_task_id AS ref_value, t.project AS project
+				FROM tasks t
+				WHERE t.parent_task_id IS NOT NULL AND t.parent_task_id <> ''
+				  AND t.archived_at IS NULL
+				  AND NOT EXISTS (SELECT 1 FROM tasks p WHERE p.id = t.parent_task_id)`,
+		},
+		{
+			class: "orphan_board", table: "tasks", refCol: "board_id",
+			orphanSQL: `SELECT t.id AS row_id, t.board_id AS ref_value, t.project AS project
+				FROM tasks t
+				WHERE t.board_id IS NOT NULL AND t.board_id <> ''
+				  AND t.archived_at IS NULL
+				  AND NOT EXISTS (SELECT 1 FROM boards b WHERE b.id = t.board_id)`,
+		},
+		// --- task project reference ---
+		{
+			class: "orphan_task_project", table: "tasks", refCol: "project",
+			orphanSQL: `SELECT t.id AS row_id, t.project AS ref_value, t.project AS project
+				FROM tasks t
+				WHERE t.project IS NOT NULL AND t.project <> ''
+				  AND t.archived_at IS NULL
+				  AND NOT EXISTS (SELECT 1 FROM projects p WHERE p.name = t.project)`,
+		},
+		// --- agent self references ---
+		{
+			class: "orphan_reports_to", table: "agents", refCol: "reports_to",
+			orphanSQL: `SELECT a.id AS row_id, a.reports_to AS ref_value, a.project AS project
+				FROM agents a
+				WHERE a.reports_to IS NOT NULL AND a.reports_to <> ''
+				  AND LOWER(a.reports_to) NOT IN (` + sent + `)
+				  AND NOT EXISTS (SELECT 1 FROM agents b WHERE b.project = a.project AND LOWER(b.name) = LOWER(a.reports_to))`,
+		},
+		{
+			class: "orphan_agent_profile", table: "agents", refCol: "profile_slug",
+			orphanSQL: `SELECT a.id AS row_id, a.profile_slug AS ref_value, a.project AS project
+				FROM agents a
+				WHERE a.profile_slug IS NOT NULL AND a.profile_slug <> ''
+				  AND NOT EXISTS (SELECT 1 FROM profiles p WHERE p.project = a.project AND LOWER(p.slug) = LOWER(a.profile_slug))`,
+		},
+		// --- message recipient / sender. Broadcast ('*'), team ('team:%') and
+		// empty (conversation-scoped) targets are addressing forms, not agent names.
+		{
+			class: "orphan_recipient", table: "messages", refCol: "to_agent",
+			orphanSQL: `SELECT m.id AS row_id, m.to_agent AS ref_value, m.project AS project
+				FROM messages m
+				WHERE m.to_agent IS NOT NULL AND m.to_agent <> '' AND m.to_agent <> '*'
+				  AND m.to_agent NOT LIKE 'team:%'
+				  AND LOWER(m.to_agent) NOT IN (` + sent + `)
+				  AND NOT EXISTS (SELECT 1 FROM agents a WHERE a.project = m.project AND LOWER(a.name) = LOWER(m.to_agent))`,
+		},
+		{
+			class: "orphan_sender", table: "messages", refCol: "from_agent",
+			orphanSQL: `SELECT m.id AS row_id, m.from_agent AS ref_value, m.project AS project
+				FROM messages m
+				WHERE m.from_agent IS NOT NULL AND m.from_agent <> ''
+				  AND LOWER(m.from_agent) NOT IN (` + sent + `)
+				  AND NOT EXISTS (SELECT 1 FROM agents a WHERE a.project = m.project AND LOWER(a.name) = LOWER(m.from_agent))`,
+		},
+	}
+}
+
+// referentialScanTimeout bounds the whole scan (all checks share one writer tx).
+// A var, not a const, so a test can shrink it.
+var referentialScanTimeout = 30 * time.Second
+
+// runReferentialScan runs every referential check inside one writer transaction
+// and upserts the results into integrity_quarantine. It returns the count of
+// currently-OPEN (unresolved) quarantine rows per class. Idempotent: re-running
+// on an unchanged DB inserts nothing and flips no marker. Backward-compatible:
+// only the side-table is written; no existing row is touched.
+//
+// Per check, three steps keep the lifecycle correct and re-run-safe:
+//  1. INSERT OR IGNORE the current orphans (new ones get detected_at; the UNIQUE
+//     key dedupes existing ones — first-seen detected_at is preserved).
+//  2. RE-OPEN any row that had been marked resolved but is orphan again.
+//  3. MARK RESOLVED any open row whose ref now resolves (no delete — audit trail).
+func runReferentialScan(conn *sql.DB) (map[string]int, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), referentialScanTimeout)
+	defer cancel()
+
+	tx, err := conn.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("referential scan: begin: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }() // no-op after commit
+
+	now := time.Now().UTC().Format(memoryTimeFmt)
+
+	for _, c := range refChecks() {
+		// 1. insert new orphans
+		if _, err := tx.ExecContext(ctx,
+			`INSERT OR IGNORE INTO integrity_quarantine
+			   (table_name, row_id, ref_col, ref_value, class, project, detected_at)
+			 SELECT ?, o.row_id, ?, o.ref_value, ?, o.project, ?
+			 FROM (`+c.orphanSQL+`) o`,
+			c.table, c.refCol, c.class, now,
+		); err != nil {
+			return nil, fmt.Errorf("referential scan %s: insert: %w", c.class, err)
+		}
+		// 2. re-open regressed rows (resolved before, orphan again)
+		if _, err := tx.ExecContext(ctx,
+			`UPDATE integrity_quarantine
+			 SET resolved_at = NULL, detected_at = ?
+			 WHERE class = ? AND resolved_at IS NOT NULL
+			   AND row_id IN (SELECT o.row_id FROM (`+c.orphanSQL+`) o)`,
+			now, c.class,
+		); err != nil {
+			return nil, fmt.Errorf("referential scan %s: reopen: %w", c.class, err)
+		}
+		// 3. mark healed rows resolved (ref now resolves) — never deleted
+		if _, err := tx.ExecContext(ctx,
+			`UPDATE integrity_quarantine
+			 SET resolved_at = ?
+			 WHERE class = ? AND resolved_at IS NULL
+			   AND row_id NOT IN (SELECT o.row_id FROM (`+c.orphanSQL+`) o)`,
+			now, c.class,
+		); err != nil {
+			return nil, fmt.Errorf("referential scan %s: resolve: %w", c.class, err)
+		}
+	}
+
+	counts := map[string]int{}
+	rows, err := tx.QueryContext(ctx,
+		`SELECT class, COUNT(*) FROM integrity_quarantine WHERE resolved_at IS NULL GROUP BY class`)
+	if err != nil {
+		return nil, fmt.Errorf("referential scan: count: %w", err)
+	}
+	for rows.Next() {
+		var class string
+		var n int
+		if err := rows.Scan(&class, &n); err != nil {
+			_ = rows.Close()
+			return nil, fmt.Errorf("referential scan: count scan: %w", err)
+		}
+		counts[class] = n
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return nil, fmt.Errorf("referential scan: count rows: %w", err)
+	}
+	_ = rows.Close()
+
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("referential scan: commit: %w", err)
+	}
+	return counts, nil
+}
+
+// NOTE (Phase 0 scope): the scan runs only at startup, inside migrate(), which
+// executes on the single writer connection BEFORE the relay serves — so it never
+// contends with live writes. A PERIODIC re-scan (to surface orphans created
+// during a long uptime without a reboot) is deliberately deferred to Phase 2,
+// where it is paired with the reconcile/GC that acts on the markers and can be
+// tuned to run off the writer hot path (design §7.3). Adding it to the 5-minute
+// StartCleanup loop now would put a heavy multi-full-scan writer transaction on a
+// hot path for markers nothing yet consumes.
+
+// logReferentialCounts emits a single deterministic summary line for a scan pass.
+// Silent when nothing is open (no noise on a clean DB). Keys are sorted so the
+// line is stable across runs.
+func logReferentialCounts(phase string, counts map[string]int) {
+	if len(counts) == 0 {
+		return
+	}
+	classes := make([]string, 0, len(counts))
+	total := 0
+	for c, n := range counts {
+		classes = append(classes, c)
+		total += n
+	}
+	sort.Strings(classes)
+	parts := make([]string, 0, len(classes))
+	for _, c := range classes {
+		parts = append(parts, fmt.Sprintf("%s=%d", c, counts[c]))
+	}
+	log.Printf("integrity: %s referential scan — %d open across %d class(es): %s",
+		phase, total, len(classes), strings.Join(parts, " "))
+}

--- a/internal/db/referential_integrity_test.go
+++ b/internal/db/referential_integrity_test.go
@@ -1,0 +1,287 @@
+package db
+
+import (
+	"database/sql"
+	"testing"
+)
+
+// seedAgent inserts an agent row with explicit status/is_service so the test can
+// craft dead / service / live identities deterministically.
+func seedAgent(t *testing.T, conn *sql.DB, project, name, status, profileSlug, reportsTo string, isService int) {
+	t.Helper()
+	_, err := conn.Exec(
+		`INSERT INTO agents (id, name, role, description, registered_at, last_seen, project, reports_to, profile_slug, status, is_executive, interest_tags, max_context_bytes, is_service, cwd)
+		 VALUES (?, ?, '', '', '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z', ?, ?, ?, ?, 0, '[]', 16384, ?, '')`,
+		"ag-"+name, name, project, nullIfEmpty(reportsTo), nullIfEmpty(profileSlug), status, isService,
+	)
+	if err != nil {
+		t.Fatalf("seed agent %s: %v", name, err)
+	}
+}
+
+// seedTask inserts a task row with the ref columns the test controls; everything
+// else gets a safe default. archived=true stamps archived_at (excluded by scans).
+func seedTask(t *testing.T, conn *sql.DB, id, project, status, dispatchedBy, assignedTo, claimedBy, profileSlug, parentID, boardID string, archived bool) {
+	t.Helper()
+	var archivedAt interface{}
+	if archived {
+		archivedAt = "2026-01-01T00:00:00Z"
+	}
+	_, err := conn.Exec(
+		`INSERT INTO tasks (id, profile_slug, dispatched_by, assigned_to, claimed_by, title, status, project, dispatched_at, parent_task_id, board_id, archived_at, labels, blocked_periods, goal, acceptance_criteria, dod)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, '2026-01-01T00:00:00Z', ?, ?, ?, '[]', '[]', '', '[]', '')`,
+		id, profileSlug, dispatchedBy, nullIfEmpty(assignedTo), nullIfEmpty(claimedBy), "T "+id, status, project,
+		nullIfEmpty(parentID), nullIfEmpty(boardID), archivedAt,
+	)
+	if err != nil {
+		t.Fatalf("seed task %s: %v", id, err)
+	}
+}
+
+func seedProject(t *testing.T, conn *sql.DB, name string) {
+	t.Helper()
+	if _, err := conn.Exec(`INSERT OR IGNORE INTO projects (name, planet_type, created_at) VALUES (?, '', '2026-01-01T00:00:00Z')`, name); err != nil {
+		t.Fatalf("seed project %s: %v", name, err)
+	}
+}
+
+func seedProfile(t *testing.T, conn *sql.DB, project, slug string) {
+	t.Helper()
+	if _, err := conn.Exec(
+		`INSERT INTO profiles (id, slug, name, project, created_at, updated_at) VALUES (?, ?, ?, ?, '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z')`,
+		"pf-"+project+"-"+slug, slug, slug, project,
+	); err != nil {
+		t.Fatalf("seed profile %s/%s: %v", project, slug, err)
+	}
+}
+
+func seedMessage(t *testing.T, conn *sql.DB, id, project, from, to string) {
+	t.Helper()
+	if _, err := conn.Exec(
+		`INSERT INTO messages (id, from_agent, to_agent, type, subject, content, created_at, project) VALUES (?, ?, ?, 'notification', '', '', '2026-01-01T00:00:00Z', ?)`,
+		id, from, to, project,
+	); err != nil {
+		t.Fatalf("seed message %s: %v", id, err)
+	}
+}
+
+func nullIfEmpty(s string) interface{} {
+	if s == "" {
+		return nil
+	}
+	return s
+}
+
+// openCount returns the number of OPEN (unresolved) quarantine rows for a class.
+func openCount(t *testing.T, conn *sql.DB, class string) int {
+	t.Helper()
+	var n int
+	if err := conn.QueryRow(`SELECT COUNT(*) FROM integrity_quarantine WHERE class = ? AND resolved_at IS NULL`, class).Scan(&n); err != nil {
+		t.Fatalf("openCount %s: %v", class, err)
+	}
+	return n
+}
+
+func quarantineRowExists(t *testing.T, conn *sql.DB, class, rowID string) bool {
+	t.Helper()
+	var n int
+	if err := conn.QueryRow(`SELECT COUNT(*) FROM integrity_quarantine WHERE class = ? AND row_id = ? AND resolved_at IS NULL`, class, rowID).Scan(&n); err != nil {
+		t.Fatalf("quarantineRowExists: %v", err)
+	}
+	return n > 0
+}
+
+// TestReferentialScanDetectsOrphanClasses seeds one representative of every
+// orphan class plus the tricky non-orphans (sentinels, a live name==slug
+// collision, a service assignee, an archived orphan) and asserts the scan flags
+// exactly the right rows.
+func TestReferentialScanDetectsOrphanClasses(t *testing.T) {
+	d := testDB(t)
+	c := d.conn
+
+	seedProject(t, c, "p1")
+	seedProfile(t, c, "p1", "backend")
+	// 'analytics-lead' is BOTH a registered agent name AND a profile slug — the
+	// name==slug collision. A ref to it must RESOLVE (agent row exists), not flag.
+	seedProfile(t, c, "p1", "analytics-lead")
+	seedAgent(t, c, "p1", "alice", "active", "backend", "", 0)
+	seedAgent(t, c, "p1", "analytics-lead", "active", "backend", "", 0)
+	seedAgent(t, c, "p1", "zombie", "deleted", "backend", "", 0)       // dead → limbo source
+	seedAgent(t, c, "p1", "svc", "inactive", "backend", "", 1)         // service → limbo-exempt
+	seedAgent(t, c, "p1", "bob", "active", "backend", "ghost-boss", 0) // orphan_reports_to
+	seedAgent(t, c, "p1", "carol", "active", "no-profile", "", 0)      // orphan_agent_profile
+
+	// tasks
+	seedTask(t, c, "t-clean", "p1", "in-progress", "alice", "alice", "alice", "backend", "", "", false)        // clean
+	seedTask(t, c, "t-odisp", "p1", "pending", "ghost", "", "", "backend", "", "", false)                      // orphan_dispatcher
+	seedTask(t, c, "t-oassign", "p1", "pending", "alice", "ghost", "", "backend", "", "", false)               // orphan_assignee
+	seedTask(t, c, "t-sentinel", "p1", "pending", "linear", "", "", "", "", "", false)                         // sentinel dispatcher, empty slug → clean
+	seedTask(t, c, "t-cron", "p1", "pending", "cron", "", "", "", "", "", false)                               // sentinel → clean
+	seedTask(t, c, "t-limbo", "p1", "in-progress", "alice", "zombie", "", "backend", "", "", false)            // limbo (dead assignee)
+	seedTask(t, c, "t-svc", "p1", "in-progress", "alice", "svc", "", "backend", "", "", false)                 // service assignee → NOT limbo
+	seedTask(t, c, "t-nameslug", "p1", "in-progress", "alice", "analytics-lead", "", "backend", "", "", false) // resolves → clean
+	seedTask(t, c, "t-oprofile", "p1", "pending", "alice", "", "", "no-such-profile", "", "", false)           // orphan_profile
+	seedTask(t, c, "t-archived", "p1", "cancelled", "ghost", "", "", "backend", "", "", true)                  // archived → excluded
+	seedTask(t, c, "t-oproject", "ghost-project", "pending", "linear", "", "", "", "", "", false)              // orphan_task_project (sentinel dispatcher isolates it)
+	seedTask(t, c, "t-oboard", "p1", "pending", "linear", "", "", "", "", "no-board", false)                   // orphan_board
+	seedTask(t, c, "t-oparent", "p1", "pending", "linear", "", "", "", "no-parent", "", false)                 // orphan_parent
+
+	// messages
+	seedMessage(t, c, "m-orecip", "p1", "alice", "ghost")  // orphan_recipient (to)
+	seedMessage(t, c, "m-osend", "p1", "ghost", "alice")   // orphan_sender (from)
+	seedMessage(t, c, "m-broadcast", "p1", "alice", "*")   // clean (broadcast)
+	seedMessage(t, c, "m-team", "p1", "alice", "team:eng") // clean (team addressing)
+	seedMessage(t, c, "m-linear", "p1", "linear", "alice") // clean (sentinel sender)
+
+	counts, err := runReferentialScan(c)
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+
+	want := map[string]int{
+		"orphan_dispatcher":    1, // t-odisp
+		"orphan_assignee":      1, // t-oassign
+		"limbo":                1, // t-limbo
+		"orphan_profile":       1, // t-oprofile
+		"orphan_task_project":  1, // t-oproject
+		"orphan_board":         1, // t-oboard
+		"orphan_parent":        1, // t-oparent
+		"orphan_reports_to":    1, // bob
+		"orphan_agent_profile": 1, // carol
+		"orphan_recipient":     1, // m-orecip
+		"orphan_sender":        1, // m-osend
+	}
+	for class, exp := range want {
+		if got := counts[class]; got != exp {
+			t.Errorf("class %s: got %d open, want %d", class, got, exp)
+		}
+	}
+	// orphan_claimer must be ZERO (no claimed_by orphan seeded).
+	if got := counts["orphan_claimer"]; got != 0 {
+		t.Errorf("orphan_claimer: got %d, want 0", got)
+	}
+
+	// Explicit non-orphan assertions.
+	if quarantineRowExists(t, c, "orphan_dispatcher", "t-sentinel") || quarantineRowExists(t, c, "orphan_dispatcher", "t-cron") {
+		t.Error("sentinel dispatcher (linear/cron) must not be flagged")
+	}
+	if quarantineRowExists(t, c, "orphan_assignee", "t-nameslug") || quarantineRowExists(t, c, "limbo", "t-nameslug") {
+		t.Error("live name==slug collision (analytics-lead) must resolve, not flag")
+	}
+	if quarantineRowExists(t, c, "limbo", "t-svc") {
+		t.Error("service-agent assignee must be limbo-exempt")
+	}
+	if quarantineRowExists(t, c, "orphan_dispatcher", "t-archived") {
+		t.Error("archived task must be excluded from the scan")
+	}
+	// The clean task must be flagged by NOTHING.
+	var cleanFlags int
+	if err := c.QueryRow(`SELECT COUNT(*) FROM integrity_quarantine WHERE row_id = 't-clean'`).Scan(&cleanFlags); err != nil {
+		t.Fatal(err)
+	}
+	if cleanFlags != 0 {
+		t.Errorf("t-clean flagged %d time(s), want 0", cleanFlags)
+	}
+}
+
+// TestReferentialScanIdempotent proves re-running the scan on an unchanged DB
+// adds no duplicate quarantine rows and reports identical counts (the AC's
+// "re-run safe on a DB with pre-existing orphans").
+func TestReferentialScanIdempotent(t *testing.T) {
+	d := testDB(t)
+	c := d.conn
+	seedProject(t, c, "p1")
+	seedProfile(t, c, "p1", "backend")
+	seedAgent(t, c, "p1", "alice", "active", "backend", "", 0)
+	seedTask(t, c, "t-odisp", "p1", "pending", "ghost", "", "", "backend", "", "", false)
+	seedTask(t, c, "t-oassign", "p1", "pending", "alice", "ghost2", "", "backend", "", "", false)
+
+	first, err := runReferentialScan(c)
+	if err != nil {
+		t.Fatalf("scan 1: %v", err)
+	}
+	var rowsAfter1 int
+	_ = c.QueryRow(`SELECT COUNT(*) FROM integrity_quarantine`).Scan(&rowsAfter1)
+
+	second, err := runReferentialScan(c)
+	if err != nil {
+		t.Fatalf("scan 2: %v", err)
+	}
+	var rowsAfter2 int
+	_ = c.QueryRow(`SELECT COUNT(*) FROM integrity_quarantine`).Scan(&rowsAfter2)
+
+	if rowsAfter1 != rowsAfter2 {
+		t.Errorf("re-run added rows: %d then %d (must be identical — idempotent)", rowsAfter1, rowsAfter2)
+	}
+	if first["orphan_dispatcher"] != second["orphan_dispatcher"] || first["orphan_assignee"] != second["orphan_assignee"] {
+		t.Errorf("re-run changed counts: %v then %v", first, second)
+	}
+}
+
+// TestReferentialScanResolvesHealedRefs proves a ref that later resolves (the
+// missing agent registers) is stamped resolved_at on the next scan — NOT deleted
+// (audit trail) — and drops out of the open count.
+func TestReferentialScanResolvesHealedRefs(t *testing.T) {
+	d := testDB(t)
+	c := d.conn
+	seedProject(t, c, "p1")
+	seedProfile(t, c, "p1", "backend")
+	seedTask(t, c, "t-odisp", "p1", "pending", "latecomer", "", "", "backend", "", "", false)
+
+	if _, err := runReferentialScan(c); err != nil {
+		t.Fatalf("scan 1: %v", err)
+	}
+	if openCount(t, c, "orphan_dispatcher") != 1 {
+		t.Fatal("expected 1 open orphan_dispatcher before heal")
+	}
+
+	// The referenced agent now exists → the ref resolves.
+	seedAgent(t, c, "p1", "latecomer", "active", "backend", "", 0)
+
+	if _, err := runReferentialScan(c); err != nil {
+		t.Fatalf("scan 2: %v", err)
+	}
+	if openCount(t, c, "orphan_dispatcher") != 0 {
+		t.Error("healed ref must drop out of the open count")
+	}
+	// The row is RESOLVED, not deleted (audit trail preserved).
+	var resolved int
+	if err := c.QueryRow(`SELECT COUNT(*) FROM integrity_quarantine WHERE class='orphan_dispatcher' AND row_id='t-odisp' AND resolved_at IS NOT NULL`).Scan(&resolved); err != nil {
+		t.Fatal(err)
+	}
+	if resolved != 1 {
+		t.Errorf("healed quarantine row must be stamped resolved (not deleted): got %d", resolved)
+	}
+}
+
+// TestReferentialScanReopensRegressedRef proves a ref that resolved and then
+// broke again (agent deactivated/deleted, or the row edited) is re-opened rather
+// than left stale-resolved.
+func TestReferentialScanReopensRegressedRef(t *testing.T) {
+	d := testDB(t)
+	c := d.conn
+	seedProject(t, c, "p1")
+	seedProfile(t, c, "p1", "backend")
+	seedAgent(t, c, "p1", "flaky", "active", "backend", "", 0)
+	seedTask(t, c, "t-odisp", "p1", "pending", "flaky", "", "", "backend", "", "", false)
+
+	// Scan 1: resolves (flaky exists) → no open orphan.
+	if _, err := runReferentialScan(c); err != nil {
+		t.Fatalf("scan 1: %v", err)
+	}
+	if openCount(t, c, "orphan_dispatcher") != 0 {
+		t.Fatal("expected 0 open before regression")
+	}
+
+	// The agent is hard-removed from the table (simulating a purge) → ref dangles.
+	if _, err := c.Exec(`DELETE FROM agents WHERE name = 'flaky' AND project = 'p1'`); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := runReferentialScan(c); err != nil {
+		t.Fatalf("scan 2: %v", err)
+	}
+	if openCount(t, c, "orphan_dispatcher") != 1 {
+		t.Error("regressed ref must be re-opened as an orphan")
+	}
+}


### PR DESCRIPTION
## Summary
Phase 0 of the referential-integrity work (task 536ecc40, founder-approved; design ruled by cto-tsukumo, trovex `7c0e0b8cc39b41ff8dff486b83695f3d`). The relay's identity model rests on string natural keys referenced across ~34 tables with no enforced FK; rows accumulate that point at an identity which no longer resolves (audit: ~26% of tasks orphaned, 14 live tasks in permanent claim-limbo).

This adds a **startup scan that detects, logs, and quarantines** those dangling references. **Pure observability** — no enforcement, no reroute, no deletion. Every flagged row keeps its real status and stays claimable/visible exactly as before.

### What's in it
- **`integrity_quarantine` SIDE-TABLE** (ruled §5B, not flag columns) so the `taskColumns↔scanTask` / `agentColumns↔scanAgent` lockstep is never touched; uniform logging across every ref class; trivially GC-able. `UNIQUE(table_name,row_id,ref_col,class)` makes the scan an idempotent upsert.
- **`runReferentialScan`** — 13 orphan classes: task `dispatched_by`/`assigned_to`/`claimed_by`, `limbo` (non-terminal task assigned to a dead **non-service** agent), structural `profile_slug` (tolerated + marked, never rewritten — per ruling Q5), id refs (`parent_task_id`/`board_id`), `project`, and message `to_agent`/`from_agent`. One writer tx; 3-step lifecycle per class: insert-new / reopen-regressed / mark-healed-resolved (**never delete** — audit trail).
- **Sentinels** `{linear,cron,user}` allowlisted (const, ruled Q4); **service agents** (`is_service=1`) resolve via their row and are limbo-exempt (dynamic lookup); a **live name==slug agent** (e.g. `analytics-lead`) resolves and is never mis-flagged (detection asks only "does an agent row exist?").
- Runs **only at startup, inside `migrate()`** (pre-serving → zero write contention, additive, idempotent, every boot). Surfaces the existing orphans + 14 limbo tasks on the very next deploy.

### Scope note (self-review tightening)
My design (§5) also had a periodic re-scan in the 5m `StartCleanup` loop. On self-review I pulled it: it puts a heavy multi-full-scan **writer** transaction on a hot path for markers nothing yet consumes. The periodic re-scan is deferred to **Phase 2**, where my design (§7.3) already pairs it with the reconcile/GC that acts on the markers and can run off the writer hot path. Phase 0 = startup-only, which is exactly what the AC asks ("startup integrity-check pass").

## Constraint compliance
- Auto-migrate on startup, users do nothing ✓ (hooks `migrate()`, same path that shipped `linear_secondary`)
- Backward-compatible / additive-only ✓ (new side-table + `CREATE TABLE/INDEX IF NOT EXISTS`; an older binary never selects it)
- KEEP name-as-key, no name→int FK ✓
- `foreign_keys` unchanged, **zero** declared/enforced FK added ✓ (Phase 3 deferred)
- Idempotent, re-run-safe on an orphan-laden DB ✓ (proven by test)
- No `scanTask`/`scanAgent` lockstep touch ✓ (side-table)

## Distinct from `integrity.go`
That file is **structural** integrity (`PRAGMA integrity_check` / `VerifyDBFile` / backup verification). This is **referential** integrity (dangling cross-row refs). Kept in a separate file (`referential_integrity.go`) — no collision, clear separation.

## Test plan
- [x] `go build -tags fts5 ./...`
- [x] `go vet -tags fts5 ./...`
- [x] `gofmt -l .` clean
- [x] `go test -tags fts5 -race -count=1 ./...` — 639 passed (635 + 4 new), zero races (ran with `-race` locally — the gap that bit an earlier PR)
- [x] `golangci-lint run` (v2.12.2) — 0 issues
- [x] New tests: every orphan class detected with exact counts; sentinels / live-name==slug / service-assignee / archived-task NOT flagged; `orphan_claimer` correctly zero; idempotent re-run (no dup rows, identical counts); healed ref → `resolved_at` stamped (not deleted); regressed ref → re-opened

## review-wraith verdict: SHIP
Scope: internal/db/referential_integrity.go (new), internal/db/referential_integrity_test.go (new), internal/db/db.go (+table, +startup scan call)
Gate: build -tags fts5 OK / vet OK / gofmt OK / test -tags fts5 -race OK (639 passed) / golangci-lint OK (0 issues)

BLOCKERS: none
NITS: none — side-table avoids the scan-lockstep footgun entirely; startup-only avoids the writer-hot-path concern (found + fixed in self-review); no second writer; additive + idempotent; `foreign_keys` untouched.

Off current `origin/main` (905596e). Schema change (new table) — not self-merging; PR-to-cto. Phases 1+2 follow as separate gated PRs.