### PR TITLE
feat(relay): Phase 1 referential-integrity reconcile (heal-resolvable, mark-rest)

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -126,7 +126,16 @@ func New() (*DB, error) {
 	_, _ = reader.Exec("PRAGMA temp_store = MEMORY")
 	_, _ = reader.Exec("PRAGMA cache_size = -20000") // 20MB
 
-	return &DB{conn: writer, reader: reader, path: dbPath}, nil
+	d := &DB{conn: writer, reader: reader, path: dbPath}
+
+	// Referential-integrity reconcile (Phase 1, task 536ecc40). One-shot,
+	// settings-marker guarded, snapshot-backed. Lives here (not migrate()) because
+	// it needs *DB for the pre-mutation Backup()-style snapshot. Non-fatal: a
+	// reconcile hiccup logs and leaves the marker unset (retry next boot) but never
+	// blocks the relay from booting.
+	d.maybeReconcileOrphans()
+
+	return d, nil
 }
 
 func (d *DB) Close() error {

--- a/internal/db/referential_reconcile.go
+++ b/internal/db/referential_reconcile.go
@@ -1,0 +1,150 @@
+package db
+
+import (
+	"database/sql"
+	"fmt"
+	"log"
+	"os"
+)
+
+// Referential-integrity reconcile — Phase 1 (task 536ecc40, design §6, ruled by
+// cto-tsukumo 2026-09-01). Builds on the Phase 0 detection surface
+// (integrity_quarantine): it HEALS the mechanically-resolvable orphans and
+// leaves the rest MARKED (never deleted, never rerouted).
+//
+// It is a ONE-SHOT, settings-marker guarded, snapshot-backed pass. It runs from
+// New() (not migrate()) because the pre-mutation snapshot needs *DB. Each rule is
+// also independently idempotent (an UPDATE whose WHERE stops matching once the
+// row is healed), so a crash mid-pass is safe — the unset marker just retries the
+// whole idempotent pass on the next boot.
+//
+// Two reconcile rules (ruled — nothing else is auto-changed):
+//
+//	Rule A — sync a stale task.profile_slug to its LIVE assignee's own profile
+//	  (the existing backfillTaskProfileSlugs T3 rule, reused). Only touches a task
+//	  whose assignee resolves and carries a different, non-empty profile_slug.
+//
+//	Rule B — an ORPHAN task.assigned_to whose value is a profile SLUG with EXACTLY
+//	  ONE active agent of that profile in the project → resolve it to that agent's
+//	  NAME. This fixes the name-vs-slug misroute (the audit's analytics-lead class)
+//	  by making the task claimable by the one live agent that runs the profile.
+//	  More than one candidate, or none, → left unresolved (marked, not touched).
+//
+// NOT reconciled (left marked as unresolvable, per ruling):
+//   - profile_slug orphans that have no backed profile even via the assignee —
+//     STRUCTURAL, tolerated, NEVER rewritten to an agent name (Q5: profile_slug is
+//     the profile-pool key).
+//   - dispatched_by / claimed_by orphans — a historical record of who dispatched/
+//     claimed; resolving them to a different agent would fabricate history.
+//   - limbo (a non-terminal task whose assignee EXISTS but is dead) — reassigning
+//     it to another agent would be a REROUTE, which the ruling forbids; it stays
+//     surfaced for human/CTO triage.
+//   - sentinels {linear, cron, user} — valid non-agent principals, never touched.
+
+// reconcileOrphansMarker is the one-shot settings guard for the Phase 1 pass.
+const reconcileOrphansMarker = "reconcile_orphans_v1"
+
+// reconcileSnapshotSuffix names the dedicated pre-reconcile snapshot. It is NOT
+// part of the rotating hourly-backup set, so it survives as the data-rollback
+// escape hatch for this specific migration.
+const reconcileSnapshotSuffix = ".pre-reconcile-v1.bak"
+
+// maybeReconcileOrphans runs the Phase 1 reconcile once (guarded by
+// reconcileOrphansMarker), after taking a pre-mutation snapshot. It is
+// non-fatal: any failure logs and leaves the marker UNSET so the next boot
+// retries — booting the relay never depends on the reconcile succeeding.
+func (d *DB) maybeReconcileOrphans() {
+	if d.GetSetting(reconcileOrphansMarker) != "" {
+		return // already reconciled on a prior boot
+	}
+
+	// Snapshot BEFORE any mutation. If it fails, do NOT reconcile and do NOT set
+	// the marker — never mutate data without a rollback point.
+	snap, err := d.snapshotBeforeReconcile()
+	if err != nil {
+		log.Printf("integrity: Phase 1 reconcile SKIPPED — snapshot failed (no mutation done): %v", err)
+		return
+	}
+
+	// Rule A: sync stale task.profile_slug to the live assignee's own profile.
+	synced, err := backfillTaskProfileSlugs(d.conn)
+	if err != nil {
+		log.Printf("integrity: Phase 1 reconcile profile_slug sync error (marker left unset, will retry): %v", err)
+		return
+	}
+
+	// Rule B: resolve an orphan assignee that is a profile slug with a sole live
+	// agent to that agent's name.
+	resolved, err := reconcileAssigneeSoleAgent(d.conn)
+	if err != nil {
+		log.Printf("integrity: Phase 1 reconcile assignee error (marker left unset, will retry): %v", err)
+		return
+	}
+
+	// Re-scan so the quarantine markers for the now-healed refs are stamped
+	// resolved (audit trail). A rescan failure is not fatal — the DATA reconcile
+	// already succeeded; the markers refresh on the next boot's startup scan.
+	if _, err := runReferentialScan(d.conn); err != nil {
+		log.Printf("integrity: Phase 1 post-reconcile rescan error (non-fatal): %v", err)
+	}
+
+	d.SetSetting(reconcileOrphansMarker, "done")
+	log.Printf("integrity: Phase 1 reconcile complete — profile_slug synced=%d, assignee resolved=%d (snapshot %s); unresolvable orphans left marked, none deleted",
+		synced, resolved, snap)
+}
+
+// snapshotBeforeReconcile copies the live DB to a dedicated, non-rotating
+// snapshot via VACUUM INTO on a throwaway read-only connection (never the writer
+// pool — mirrors Backup()'s discipline so the copy can never wedge live writes).
+func (d *DB) snapshotBeforeReconcile() (string, error) {
+	dst := d.path + reconcileSnapshotSuffix
+	_ = os.Remove(dst) // VACUUM INTO fails if the target already exists
+
+	backupConn, err := sql.Open("sqlite3", d.path+"?_busy_timeout=10000&mode=ro")
+	if err != nil {
+		return "", fmt.Errorf("open snapshot connection: %w", err)
+	}
+	defer func() { _ = backupConn.Close() }()
+	backupConn.SetMaxOpenConns(1)
+
+	if _, err := backupConn.Exec("VACUUM INTO ?", dst); err != nil {
+		return "", fmt.Errorf("vacuum into %s: %w", dst, err)
+	}
+	return dst, nil
+}
+
+// reconcileAssigneeSoleAgent implements Rule B (see file header). It resolves an
+// orphan task.assigned_to — a value that is a profile SLUG with no agent by that
+// name — to the NAME of the sole active agent running that profile in the same
+// project. The COUNT(*) = 1 guard makes it unambiguous; the NOT EXISTS guard
+// makes it idempotent (once healed, assigned_to names a real agent and no longer
+// matches). Returns the number of rows resolved.
+func reconcileAssigneeSoleAgent(conn *sql.DB) (int, error) {
+	res, err := conn.Exec(`
+		UPDATE tasks
+		SET assigned_to = (
+			SELECT a.name FROM agents a
+			WHERE a.project = tasks.project
+			  AND LOWER(a.profile_slug) = LOWER(tasks.assigned_to)
+			  AND a.status = 'active'
+			LIMIT 1
+		)
+		WHERE assigned_to IS NOT NULL AND assigned_to <> ''
+		  AND archived_at IS NULL
+		  AND LOWER(assigned_to) NOT IN (` + sentinelSQLList() + `)
+		  AND NOT EXISTS (
+			SELECT 1 FROM agents a2
+			WHERE a2.project = tasks.project AND LOWER(a2.name) = LOWER(tasks.assigned_to)
+		  )
+		  AND (
+			SELECT COUNT(*) FROM agents a3
+			WHERE a3.project = tasks.project
+			  AND LOWER(a3.profile_slug) = LOWER(tasks.assigned_to)
+			  AND a3.status = 'active'
+		  ) = 1`)
+	if err != nil {
+		return 0, fmt.Errorf("reconcile assignee sole-agent: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	return int(n), nil
+}

--- a/internal/db/referential_reconcile_test.go
+++ b/internal/db/referential_reconcile_test.go
@@ -1,0 +1,119 @@
+package db
+
+import (
+	"os"
+	"testing"
+)
+
+// taskAssignee reads a task's current assigned_to (empty string when NULL).
+func taskAssignee(t *testing.T, d *DB, id string) string {
+	t.Helper()
+	var a *string
+	if err := d.conn.QueryRow(`SELECT assigned_to FROM tasks WHERE id = ?`, id).Scan(&a); err != nil {
+		t.Fatalf("read assignee %s: %v", id, err)
+	}
+	if a == nil {
+		return ""
+	}
+	return *a
+}
+
+// TestReconcileResolvesSoleAgentAssignee proves Rule B: an orphan assigned_to that
+// is a profile slug with EXACTLY ONE active agent of that profile resolves to that
+// agent's name; the run is snapshot-backed, marker-guarded, and idempotent.
+func TestReconcileResolvesSoleAgentAssignee(t *testing.T) {
+	d := testDB(t)
+	c := d.conn
+	seedProject(t, c, "p1")
+	seedProfile(t, c, "p1", "backend")
+	// exactly one ACTIVE agent runs the 'backend' profile
+	seedAgent(t, c, "p1", "worker-1", "active", "backend", "", 0)
+
+	// task assigned to the SLUG 'backend' (no agent literally named 'backend')
+	seedTask(t, c, "t-slug", "p1", "in-progress", "worker-1", "backend", "", "backend", "", "", false)
+
+	d.maybeReconcileOrphans()
+
+	if got := taskAssignee(t, d, "t-slug"); got != "worker-1" {
+		t.Errorf("assigned_to = %q, want worker-1 (resolved to the sole live agent)", got)
+	}
+	// snapshot was taken before the mutation
+	if _, err := os.Stat(d.path + reconcileSnapshotSuffix); err != nil {
+		t.Errorf("pre-reconcile snapshot not found: %v", err)
+	}
+	// marker set → one-shot
+	if d.GetSetting(reconcileOrphansMarker) != "done" {
+		t.Error("reconcile marker not set after run")
+	}
+	// the healed assignee ref is stamped resolved in the quarantine table (audit
+	// trail — not deleted).
+	if openCount(t, c, "orphan_assignee") != 0 {
+		t.Error("resolved assignee should drop out of the open orphan count")
+	}
+
+	// Idempotent: a second run is a marker-guarded no-op and changes nothing.
+	before := taskAssignee(t, d, "t-slug")
+	d.maybeReconcileOrphans()
+	if after := taskAssignee(t, d, "t-slug"); after != before {
+		t.Errorf("second reconcile mutated data: %q -> %q", before, after)
+	}
+}
+
+// TestReconcileLeavesAmbiguousAndUnresolvable proves the conservative half of the
+// ruling: ambiguous slugs (>1 candidate), non-slug dead-agent names, dispatched_by
+// orphans, and limbo are all LEFT ALONE (marked, never mutated, never rerouted).
+func TestReconcileLeavesAmbiguousAndUnresolvable(t *testing.T) {
+	d := testDB(t)
+	c := d.conn
+	seedProject(t, c, "p1")
+	seedProfile(t, c, "p1", "backend")
+	seedProfile(t, c, "p1", "frontend")
+	// TWO active agents run 'backend' → ambiguous, must not resolve
+	seedAgent(t, c, "p1", "be-1", "active", "backend", "", 0)
+	seedAgent(t, c, "p1", "be-2", "active", "backend", "", 0)
+	// one live 'frontend' agent, plus a DEAD one for the limbo case
+	seedAgent(t, c, "p1", "fe-1", "active", "frontend", "", 0)
+	seedAgent(t, c, "p1", "fe-dead", "deleted", "frontend", "", 0)
+
+	seedTask(t, c, "t-ambig", "p1", "pending", "fe-1", "backend", "", "frontend", "", "", false)     // assigned_to slug 'backend' → 2 candidates → NOT resolved
+	seedTask(t, c, "t-ghost", "p1", "pending", "fe-1", "ghost-agent", "", "frontend", "", "", false) // not a slug, no agent → NOT resolved
+	seedTask(t, c, "t-limbo", "p1", "in-progress", "fe-1", "fe-dead", "", "frontend", "", "", false) // dead assignee → limbo, must not reroute
+
+	d.maybeReconcileOrphans()
+
+	if got := taskAssignee(t, d, "t-ambig"); got != "backend" {
+		t.Errorf("ambiguous assignee mutated to %q, want unchanged 'backend'", got)
+	}
+	if got := taskAssignee(t, d, "t-ghost"); got != "ghost-agent" {
+		t.Errorf("non-resolvable assignee mutated to %q, want unchanged 'ghost-agent'", got)
+	}
+	if got := taskAssignee(t, d, "t-limbo"); got != "fe-dead" {
+		t.Errorf("limbo task was REROUTED to %q — ruling forbids rerouting; want unchanged 'fe-dead'", got)
+	}
+	// The limbo row is still marked (surfaced for triage), not silently healed.
+	if !quarantineRowExists(t, c, "limbo", "t-limbo") {
+		t.Error("limbo task must remain quarantined for triage")
+	}
+}
+
+// TestReconcileSyncsProfileSlug covers Rule A: a task whose profile_slug is stale
+// relative to its live assignee's own profile is synced (reused T3 rule).
+func TestReconcileSyncsProfileSlug(t *testing.T) {
+	d := testDB(t)
+	c := d.conn
+	seedProject(t, c, "p1")
+	seedProfile(t, c, "p1", "backend")
+	seedAgent(t, c, "p1", "worker-1", "active", "backend", "", 0)
+	// task's stored profile_slug ('stale') differs from its live assignee's ('backend')
+	seedTask(t, c, "t-sync", "p1", "in-progress", "worker-1", "worker-1", "", "stale", "", "", false)
+
+	d.maybeReconcileOrphans()
+
+	var slug string
+	if err := c.QueryRow(`SELECT profile_slug FROM tasks WHERE id = 't-sync'`).Scan(&slug); err != nil {
+		t.Fatal(err)
+	}
+	if slug != "backend" {
+		t.Errorf("profile_slug = %q, want 'backend' (synced to the live assignee's profile)", slug)
+	}
+}


### PR DESCRIPTION
## Summary
Phase 1 of 0-2 (task 536ecc40, design §6, ruled by cto-tsukumo). Builds on the Phase 0 detection surface (`integrity_quarantine`, merged f2f48c0): it now **heals the mechanically-resolvable orphans and leaves the rest MARKED** — never deletes, never reroutes.

One-shot, settings-marker guarded (`reconcile_orphans_v1`), **snapshot-backed**. Runs from `New()` (post-`migrate()`, pre-serving) because the pre-mutation snapshot needs `*DB`.

### Two reconcile rules (nothing else auto-changed)
- **Rule A** — sync a stale `task.profile_slug` to its **live assignee's own profile** (reuses the existing, tested `backfillTaskProfileSlugs` T3 rule).
- **Rule B** — an **orphan** `task.assigned_to` whose value is a profile **slug** with **exactly one** active agent of that profile in the project → resolve to that agent's **name**. Fixes the name-vs-slug misroute (the audit's `analytics-lead` class) by making the task claimable by the one live agent that runs the profile. >1 candidate, or none → left unresolved.

### Left MARKED as unresolvable (per ruling)
- **Structural `profile_slug` orphans** — never rewritten to a name (ruling Q5: `profile_slug` is the profile-pool key).
- **`dispatched_by` / `claimed_by`** — a historical record; resolving them would fabricate provenance.
- **limbo** (non-terminal task whose assignee exists but is dead) — reassigning it is a **reroute**, forbidden; it stays surfaced for triage.
- **sentinels** `{linear,cron,user}`.

### Safety
- A dedicated **VACUUM INTO snapshot** (throwaway read-only conn, never the writer pool — `Backup()` discipline) is taken **before any mutation**. If it fails, nothing is mutated and the marker stays unset (retry next boot).
- Each rule is **independently idempotent** (its `WHERE` stops matching once the row is healed), so a crash mid-pass is safe.
- **Non-fatal**: a reconcile error never blocks the relay from booting.
- After the reconcile, a re-scan stamps the healed quarantine rows `resolved_at` (audit trail — not deleted).

## Constraint compliance
- Auto-migrate on startup, users do nothing ✓ (runs in `New()`, one-shot, marker-guarded)
- Snapshot-before ✓ (dedicated pre-reconcile VACUUM INTO; abort-if-fails)
- Idempotent, re-run-safe, zero data loss ✓ (marker + idempotent WHERE; no delete)
- Backward-compatible ✓ (**no schema change** — data + a settings marker on existing columns; older binary reads the healed data fine)
- KEEP name-as-key, no name→int FK ✓; `foreign_keys` unchanged, zero enforced FK ✓ (Phase 3 deferred)
- No `scanTask`/`scanAgent` lockstep touch ✓

## Test plan
- [x] `go build -tags fts5 ./...` / `go vet -tags fts5 ./...` / `gofmt -l .` clean
- [x] `go test -tags fts5 -race -count=1 ./...` — 642 passed (639 + 3 new), zero races
- [x] `golangci-lint run` (v2.12.2) — 0 issues
- [x] New tests: sole-agent assignee resolved + snapshot taken + marker set + idempotent re-run; ambiguous (>1 candidate) / non-slug / **limbo** all left untouched (limbo NOT rerouted, stays quarantined); profile_slug sync (Rule A)

## review-wraith verdict: SHIP
Scope: internal/db/referential_reconcile.go (new), internal/db/referential_reconcile_test.go (new), internal/db/db.go (+`maybeReconcileOrphans` call in `New()`)
Gate: build -tags fts5 OK / vet OK / gofmt OK / test -tags fts5 -race OK (642 passed) / golangci-lint OK (0 issues)

BLOCKERS: none
NITS: none — no schema change (data + settings marker only); no scan-lockstep touch; snapshot uses a dedicated RO conn (never the writer pool); one-shot pre-serving (no hot-path contention); limbo left un-rerouted; no delete anywhere.

Off current `origin/main` (f2f48c0, Phase 0). Data migration + boot-path change — not self-merging; PR-to-cto. Phase 2 (soft on-write validation + soft-cascade on deactivate/delete + periodic GC) follows as the last gated PR.