### PR TITLE
[wraith/relay][split] orphan_profile class redefinition per DEC-wraith-orphan-profile-burndown-1: pool-key resolver + terminal exclusion

### DIFF
--- a/features/wraith-relay-split-orphan-profile-class-redefinition-per-dec-wraith-orphan-profi.md
+++ b/features/wraith-relay-split-orphan-profile-class-redefinition-per-dec-wraith-orphan-profi.md
@@ -1,0 +1,56 @@
+# [wraith/relay][split] orphan_profile class redefinition per DEC-wraith-orphan-profile-burndown-1: pool-key resolver + terminal exclusion
+
+## Team : wraith-backend (tsukumo)
+## Branch : wraith-backend/orphan-profile-redef (from main)
+## Relay task : 96eb1fa3-6f77-4f6c-8773-1fa716003316
+## Status : 🔵 SUBMITTED
+
+## 1. Product Brief
+
+### Acceptance Criteria
+- [ ] 1. AC1 task whose slug matches NO profiles row but an in-project agents.profile_slug (case-insensitive) is NOT flagged — fixture test
+- [ ] 2. AC2 done/cancelled task with fully-dead slug NOT flagged; non-terminal fully-dead slug STILL flagged — fixture tests both directions
+- [ ] 3. AC3 previously-quarantined row whose condition cleared under the new definition gets resolved_at stamped on re-scan (heal path) — test
+- [ ] 4. AC4 all OTHER class counts unchanged on the existing master fixture — existing count assertions stay green unmodified except orphan_profile expectations
+- [ ] 5. AC5 go build ./..., go vet ./..., go test -tags fts5 ./... green (count cited); ≤2 non-test source files
+
+## 2. Root cause & decisions
+
+# .niwa-decision — 96eb1fa3 orphan_profile class redefinition
+
+ROOT_CAUSE: the orphan_profile integrity class (internal/db/referential_integrity.go) flagged a task's profile_slug as orphan whenever no profiles row matched — but the profiles table is sparse; the real agent registry is the agents pool. So every live slug carried only by an agent (not a profiles row) was a false positive, and dead slugs on already-finished (done/cancelled) tasks were counted as live limbo noise. Open ledger stood at 936, almost all false.
+
+DECISION (per DEC-wraith-orphan-profile-burndown-1, ruling on design doc trovex 94e27a349b6a4b97a0080da357e68ac5, Q1+Q2 — class-definition change only, NO data rewrite, NO quarantine-table change):
+- Q1 SECOND resolver: a slug is live when a profiles row matches OR any in-project agent carries it. Added `AND NOT EXISTS (SELECT 1 FROM agents a WHERE a.project = t.project AND LOWER(a.profile_slug) = LOWER(t.profile_slug))`. Project-scoped, case-insensitive (LOWER both sides), agents pool = real registry (phase3 Q5).
+- Q2 terminal exclusion: added `AND t.status NOT IN ('done', 'cancelled')` (limbo-class precedent :123) — a dead slug on a finished task is noise, not limbo.
+- Class comment updated to name both resolvers + the terminal exclusion.
+- Reversibility: the existing heal path (:328-357) auto-resolves rows whose condition cleared on the next scan and re-opens regressed rows; a revert simply reopens the rows. No migration, no quarantine schema change.
+
+EXPECTED LIVE EFFECT (cite): open ledger 936 → ~37 true-dead after the next startup scan.
+
+FIXTURE COUNTS: master fixture TestReferentialScanDetectsOrphanClasses orphan_profile stays exactly 1 (t-oprofile: pending, slug 'no-such-profile' carried by no agent) — all other class counts byte-for-byte unchanged. New tests: pool-resolved slug → 0 flagged; fully-dead slug → 1; done+cancelled dead slug → 0; non-terminal dead slug → 1; cross-project agent → does NOT resolve; heal path stamps resolved_at (row kept, not deleted).
+
+## review-wraith verdict: SHIP
+Scope: internal/db/referential_integrity.go (class SQL + comment) + internal/db/referential_integrity_test.go (4 new tests). 1 non-test source file (≤2), tests excluded.
+Gate: gofmt clean / go build -tags fts5 OK / go vet OK / go test -tags fts5 -count=1 ./... green.
+Tests (one per AC): AC1 TestOrphanProfilePoolResolver (+ TestOrphanProfilePoolCaseInsensitive), AC2 TestOrphanProfileTerminalExclusion, AC3 TestOrphanProfileHealPath, AC4 TestReferentialScanDetectsOrphanClasses (existing, unmodified — other classes unchanged), AC5 full suite green + ≤2 non-test files.
+BLOCKERS: none.
+NITS: none. Other integrity classes byte-for-byte untouched; zero schema change; zero MCP tool change.
+
+## 3. Files changed
+
+```
+internal/db/referential_integrity.go      |  10 ++-
+ internal/db/referential_integrity_test.go | 116 ++++++++++++++++++++++++++++++
+ 2 files changed, 124 insertions(+), 2 deletions(-)
+```
+
+## 4. QA Log
+
+_(no review round yet)_
+
+## 5. Timeline
+
+
+---
+_Auto-assembled by the niwa scribe from the Q&A gate. Task `96eb1fa3-6f77-4f6c-8773-1fa716003316`._

--- a/features/wraith-relay-split-orphan-profile-class-redefinition-per-dec-wraith-orphan-profi.md
+++ b/features/wraith-relay-split-orphan-profile-class-redefinition-per-dec-wraith-orphan-profi.md
@@ -40,17 +40,26 @@ NITS: none. Other integrity classes byte-for-byte untouched; zero schema change;
 ## 3. Files changed
 
 ```
-internal/db/referential_integrity.go      |  10 ++-
- internal/db/referential_integrity_test.go | 116 ++++++++++++++++++++++++++++++
- 2 files changed, 124 insertions(+), 2 deletions(-)
+...ass-redefinition-per-dec-wraith-orphan-profi.md |  56 ++++++++++
+ internal/db/referential_integrity.go               |  10 +-
+ internal/db/referential_integrity_test.go          | 116 +++++++++++++++++++++
+ 3 files changed, 180 insertions(+), 2 deletions(-)
 ```
 
 ## 4. QA Log
 
-_(no review round yet)_
+### Round 1 — ✅ APPROVED by review-96eb1fa3-6f77-4f6c-8773-1fa716003316 @ `70cad0f0a`
+- 🟢 AC1: pool resolver verified: t-pool resolves via agent wb-agent; t-dead still flags; case-insensitive + project-scoped confirmed — evidence: referential_integrity.go:144 adds AND NOT EXISTS agents pool resolver (LOWER both sides, project-scoped) — test: TestOrphanProfilePoolResolver referential_integrity_test.go:501 + TestOrphanProfilePoolCaseInsensitive :529
+- 🟢 AC2: terminal exclusion verified: t-done/t-cancelled NOT flagged, t-open (in-progress) still flags — openCount=1 — evidence: referential_integrity.go:142 adds AND t.status NOT IN ('done','cancelled') — test: TestOrphanProfileTerminalExclusion referential_integrity_test.go:555
+- 🟢 AC3: heal path verified: scan 1 flags t-heal; seedAgent newcomer carrying slug; scan 2 resolves — openCount=0 AND resolved_at IS NOT NULL row count=1 (resolved, not deleted) — evidence: referential_integrity.go:140-144 new orphanSQL re-evaluated each scan via existing runReferentialScan heal path — test: TestOrphanProfileHealPath referential_integrity_test.go:582
+- 🟢 AC4: master fixture unmodified; AC4 hold verified: other class counts byte-for-byte unchanged; orphan_profile=1 matches new pool resolver (t-oprofile='no-such-profile' carried by no agent) — evidence: referential_integrity_test.go:217-233 want map untouched in diff (0 deleted lines); all 14 non-orphan_profile counts=1, orphan_profile=1 — test: TestReferentialScanDetectsOrphanClasses referential_integrity_test.go:163
+- 🟢 AC5: AC5 green: build/vet/test all green; 1 non-test source file (limit ≤2) — evidence: go build EXIT=0; go vet -tags fts5 EXIT=0; go test -tags fts5 ./... all pkgs ok; only internal/db/referential_integrity.go non-test file — test: go test -tags fts5 -count=1 ./... exit 0; 9 pkgs ok / 4 no-test
 
 ## 5. Timeline
 
+- round 1 → **approve** (review-96eb1fa3-6f77-4f6c-8773-1fa716003316)
+
+**Approve-with-findings (follow-up):** build/vet/test green; 4 new tests + master fixture all pass; pool resolver + terminal exclusion match plan; 1 non-test source file; no bar weakening
 
 ---
 _Auto-assembled by the niwa scribe from the Q&A gate. Task `96eb1fa3-6f77-4f6c-8773-1fa716003316`._

--- a/internal/db/referential_integrity.go
+++ b/internal/db/referential_integrity.go
@@ -128,14 +128,20 @@ func refChecks() []refCheck {
 		},
 		// --- task profile_slug: STRUCTURAL orphan (sparse profiles table).
 		// Tolerated + marked, never rewritten. Empty slug (Linear mirror inserts '')
-		// is not an orphan.
+		// is not an orphan. TWO resolvers: a slug is live when a profiles row matches
+		// OR any in-project agent carries it (the agents pool is the real registry —
+		// DEC-wraith-orphan-profile-burndown-1 Q1, phase3 Q5). Terminal tasks
+		// (done/cancelled) are excluded — a dead slug on a finished task is noise, not
+		// a limbo (limbo-class precedent above) — DEC-wraith-orphan-profile-burndown-1 Q2.
 		{
 			class: "orphan_profile", table: "tasks", refCol: "profile_slug",
 			orphanSQL: `SELECT t.id AS row_id, t.profile_slug AS ref_value, t.project AS project
 				FROM tasks t
 				WHERE t.profile_slug IS NOT NULL AND t.profile_slug <> ''
 				  AND t.archived_at IS NULL
-				  AND NOT EXISTS (SELECT 1 FROM profiles p WHERE p.project = t.project AND LOWER(p.slug) = LOWER(t.profile_slug))`,
+				  AND t.status NOT IN ('done', 'cancelled')
+				  AND NOT EXISTS (SELECT 1 FROM profiles p WHERE p.project = t.project AND LOWER(p.slug) = LOWER(t.profile_slug))
+				  AND NOT EXISTS (SELECT 1 FROM agents a WHERE a.project = t.project AND LOWER(a.profile_slug) = LOWER(t.profile_slug))`,
 		},
 		// --- task id references (uuid) ---
 		{

--- a/internal/db/referential_integrity_test.go
+++ b/internal/db/referential_integrity_test.go
@@ -494,3 +494,119 @@ func TestLogReferentialCountsKeepsSummaryLine(t *testing.T) {
 		t.Fatalf("summary line changed/dropped.\nwant: %q\ngot:\n%s", want, out)
 	}
 }
+
+// TestOrphanProfilePoolResolver (DEC-wraith-orphan-profile-burndown-1 Q1): a slug
+// with NO profiles row is NOT an orphan when any in-project agent carries it (the
+// agents pool is the real registry). A slug matched by neither still flags.
+func TestOrphanProfilePoolResolver(t *testing.T) {
+	d := testDB(t)
+	c := d.conn
+	seedProject(t, c, "p1")
+	// Agent carries 'wraith-backend' as its profile_slug; no profiles row exists.
+	seedAgent(t, c, "p1", "wb-agent", "active", "wraith-backend", "", 0)
+	// Task slug resolves via the agents pool → NOT orphan.
+	seedTask(t, c, "t-pool", "p1", "pending", "linear", "", "", "wraith-backend", "", "", false)
+	// Task slug matches neither profiles nor agents → orphan.
+	seedTask(t, c, "t-dead", "p1", "pending", "linear", "", "", "no-such-slug", "", "", false)
+
+	if _, err := runReferentialScan(c); err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if got := openCount(t, c, "orphan_profile"); got != 1 {
+		t.Errorf("orphan_profile: got %d open, want 1 (only the fully-dead slug)", got)
+	}
+	if quarantineRowExists(t, c, "orphan_profile", "t-pool") {
+		t.Error("slug carried by an in-project agent must resolve via the pool, not flag")
+	}
+	if !quarantineRowExists(t, c, "orphan_profile", "t-dead") {
+		t.Error("fully-dead slug (no profile, no agent) must still flag")
+	}
+}
+
+// TestOrphanProfilePoolCaseInsensitive: the pool resolver matches on LOWER() both
+// sides, so a case difference between the task slug and the agent's profile_slug
+// still resolves.
+func TestOrphanProfilePoolCaseInsensitive(t *testing.T) {
+	d := testDB(t)
+	c := d.conn
+	seedProject(t, c, "p1")
+	seedAgent(t, c, "p1", "wb-agent", "active", "Wraith-Backend", "", 0) // mixed case
+	seedTask(t, c, "t-ci", "p1", "pending", "linear", "", "", "wraith-backend", "", "", false)
+	// An agent in a DIFFERENT project carrying the slug must NOT resolve it.
+	seedProject(t, c, "p2")
+	seedAgent(t, c, "p2", "other", "active", "cross-slug", "", 0)
+	seedTask(t, c, "t-xproj", "p1", "pending", "linear", "", "", "cross-slug", "", "", false)
+
+	if _, err := runReferentialScan(c); err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if quarantineRowExists(t, c, "orphan_profile", "t-ci") {
+		t.Error("pool resolver must be case-insensitive (LOWER on both sides)")
+	}
+	if !quarantineRowExists(t, c, "orphan_profile", "t-xproj") {
+		t.Error("an agent carrying the slug in another project must not resolve it (project-scoped)")
+	}
+}
+
+// TestOrphanProfileTerminalExclusion (DEC-wraith-orphan-profile-burndown-1 Q2):
+// done/cancelled tasks are excluded from orphan_profile — a dead slug on a
+// finished task is noise, not limbo. The same dead slug on a non-terminal task
+// still flags.
+func TestOrphanProfileTerminalExclusion(t *testing.T) {
+	d := testDB(t)
+	c := d.conn
+	seedProject(t, c, "p1")
+	// Same fully-dead slug on terminal tasks → NOT flagged.
+	seedTask(t, c, "t-done", "p1", "done", "linear", "", "", "dead-slug", "", "", false)
+	seedTask(t, c, "t-cancelled", "p1", "cancelled", "linear", "", "", "dead-slug", "", "", false)
+	// ...and on a non-terminal task → STILL flagged.
+	seedTask(t, c, "t-open", "p1", "in-progress", "linear", "", "", "dead-slug", "", "", false)
+
+	if _, err := runReferentialScan(c); err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if got := openCount(t, c, "orphan_profile"); got != 1 {
+		t.Errorf("orphan_profile: got %d open, want 1 (only the non-terminal task)", got)
+	}
+	if quarantineRowExists(t, c, "orphan_profile", "t-done") || quarantineRowExists(t, c, "orphan_profile", "t-cancelled") {
+		t.Error("terminal (done/cancelled) tasks must be excluded from orphan_profile")
+	}
+	if !quarantineRowExists(t, c, "orphan_profile", "t-open") {
+		t.Error("non-terminal fully-dead slug must still flag")
+	}
+}
+
+// TestOrphanProfileHealPath (AC3): a row flagged under the new definition is
+// auto-resolved (resolved_at stamped, row kept) on the next scan once an agent
+// joins the pool carrying the slug — the existing heal path, no data rewrite.
+func TestOrphanProfileHealPath(t *testing.T) {
+	d := testDB(t)
+	c := d.conn
+	seedProject(t, c, "p1")
+	seedTask(t, c, "t-heal", "p1", "pending", "linear", "", "", "joins-later", "", "", false)
+
+	// Scan 1: no profile, no agent → flagged.
+	if _, err := runReferentialScan(c); err != nil {
+		t.Fatalf("scan 1: %v", err)
+	}
+	if !quarantineRowExists(t, c, "orphan_profile", "t-heal") {
+		t.Fatal("expected orphan_profile flagged before the agent joins the pool")
+	}
+
+	// An agent now carries the slug → the condition clears.
+	seedAgent(t, c, "p1", "newcomer", "active", "joins-later", "", 0)
+	if _, err := runReferentialScan(c); err != nil {
+		t.Fatalf("scan 2: %v", err)
+	}
+	if openCount(t, c, "orphan_profile") != 0 {
+		t.Error("healed orphan_profile must drop out of the open count")
+	}
+	// Resolved, not deleted (audit trail preserved).
+	var resolved int
+	if err := c.QueryRow(`SELECT COUNT(*) FROM integrity_quarantine WHERE class='orphan_profile' AND row_id='t-heal' AND resolved_at IS NOT NULL`).Scan(&resolved); err != nil {
+		t.Fatal(err)
+	}
+	if resolved != 1 {
+		t.Errorf("healed quarantine row must be stamped resolved (not deleted): got %d", resolved)
+	}
+}


### PR DESCRIPTION
### niwa Q&A gate

An adversarial reviewer is reading this diff right now. Its verdict lands on this PR as a review (or a comment when the gate and the author share one GitHub account), and the merge waits for this repository's own checks to go green.

*Opened automatically — a rejected round comes back to the author, who pushes fixes to the same branch.*

## What & why

- **docs(scribe): provenance for wraith-relay-split-orphan-profile-class-redefinition-per-dec-wraith-orphan-profi**
- **feat(db): orphan_profile class redefinition (DEC-wraith-orphan-profile-burndown-1)**
  <details><summary>details</summary>

  Q1 second resolver: a task profile_slug is live when a profiles row
  matches OR any in-project agent carries it (agents pool = real registry,
  project-scoped, case-insensitive). Q2: exclude terminal (done/cancelled)
  tasks. Class-definition change only — no data rewrite, no quarantine
  schema change; the existing heal path auto-resolves cleared rows on the
  next scan. Expected live effect: open ledger 936 -> ~37 true-dead.
  
  Tests: TestOrphanProfilePoolResolver, TestOrphanProfilePoolCaseInsensitive,
  TestOrphanProfileTerminalExclusion, TestOrphanProfileHealPath. Master
  fixture orphan_profile stays 1; other class counts unchanged.
  
  Claude-Session: https://claude.ai/code/session_01C3hsyCeR5poTZTLmaWuyTf

  </details>

## Changes

<details><summary>Files changed (git diff --stat)</summary>

```
...ass-redefinition-per-dec-wraith-orphan-profi.md |  56 ++++++++++
 internal/db/referential_integrity.go               |  10 +-
 internal/db/referential_integrity_test.go          | 116 +++++++++++++++++++++
 3 files changed, 180 insertions(+), 2 deletions(-)
```

</details>

## Acceptance criteria

- [ ] AC1 task whose slug matches NO profiles row but an in-project agents.profile_slug (case-insensitive) is NOT flagged — fixture test
- [ ] AC2 done/cancelled task with fully-dead slug NOT flagged; non-terminal fully-dead slug STILL flagged — fixture tests both directions
- [ ] AC3 previously-quarantined row whose condition cleared under the new definition gets resolved_at stamped on re-scan (heal path) — test
- [ ] AC4 all OTHER class counts unchanged on the existing master fixture — existing count assertions stay green unmodified except orphan_profile expectations
- [ ] AC5 go build ./..., go vet ./..., go test -tags fts5 ./... green (count cited); ≤2 non-test source files

## Provenance

📄 [Root cause, decisions &amp; QA log — `features/wraith-relay-split-orphan-profile-class-redefinition-per-dec-wraith-orphan-profi.md`](https://github.com/TsukumoHQ/WRAI.TH/blob/wraith-backend/orphan-profile-redef/features/wraith-relay-split-orphan-profile-class-redefinition-per-dec-wraith-orphan-profi.md)

## Self-review

## review-wraith verdict: SHIP
Scope: internal/db/referential_integrity.go (class SQL + comment) + internal/db/referential_integrity_test.go (4 new tests). 1 non-test source file (≤2), tests excluded.
Gate: gofmt clean / go build -tags fts5 OK / go vet OK / go test -tags fts5 -count=1 ./... green.
Tests (one per AC): AC1 TestOrphanProfilePoolResolver (+ TestOrphanProfilePoolCaseInsensitive), AC2 TestOrphanProfileTerminalExclusion, AC3 TestOrphanProfileHealPath, AC4 TestReferentialScanDetectsOrphanClasses (existing, unmodified — other classes unchanged), AC5 full suite green + ≤2 non-test files.
BLOCKERS: none.
NITS: none. Other integrity classes byte-for-byte untouched; zero schema change; zero MCP tool change.

---
<sub>Authored by agent `wraith-backend` · branch `wraith-backend/orphan-profile-redef` → `main` · reviewed by niwa-gate and merged when this repo's checks pass.</sub>