### PR TITLE
[wraith/relay][split] ack_delivery returns NOT_FOUND on nonexistent message_id (silent-success bug)

### DIFF
--- a/features/wraith-relay-split-ack-delivery-returns-not-found-on-nonexistent-message-id-sile.md
+++ b/features/wraith-relay-split-ack-delivery-returns-not-found-on-nonexistent-message-id-sile.md
@@ -1,0 +1,48 @@
+# [wraith/relay][split] ack_delivery returns NOT_FOUND on nonexistent message_id (silent-success bug)
+
+## Team : wraith-backend (tsukumo)
+## Branch : wraith-backend/ack-notfound (from main)
+## Relay task : 12512c6e-0817-4a65-ad2a-c061c740595d
+## Status : 🔵 SUBMITTED
+
+## 1. Product Brief
+
+### Acceptance Criteria
+- [ ] 1. AC1 ack_delivery with a message_id matching no delivery and no message returns a typed NOT_FOUND error naming the id — test
+- [ ] 2. AC2 ack_delivery with a valid unread message_id still acknowledges and returns the same success shape as before — existing tests green unmodified
+- [ ] 3. AC3 cross-project id (message exists in another project) also refuses — test
+- [ ] 4. AC4 go build ./..., go vet ./..., go test -tags fts5 ./... green (count cited); ≤2 non-test source files; TestToolSchemaBudget total unchanged
+
+## 2. Root cause & decisions
+
+ROOT_CAUSE: ack_delivery's message_id fallback (handlers_messaging.go HandleAckDelivery) called db.AcknowledgeDeliveryByMessage, which runs an UPDATE ... WHERE message_id=? AND to_agent=? AND project=? AND state IN ('queued','surfaced'). A bogus id matches zero rows, but writerExec returns nil error on a 0-row UPDATE, so the handler echoed {acknowledged_message_id: <bogus>} — a silent success. Live repro 2026-09-05 22:35Z: acked 'ffbf98ef-2c3a-4bfe-95cf-c3e43d72ac7f' (no such message), relay reported success, the real unread stayed unread, the caller believed the inbox drained (founder silent-failure theme).
+FIX: AcknowledgeDeliveryByMessage now checks RowsAffected; on 0 it runs a project-scoped EXISTS over deliveries+messages to distinguish a real id whose delivery is already acked (idempotent success) from an id that resolves NOTHING in the caller's project (bogus, or a message only in another project) — returning a typed *db.MessageNotFoundError. The handler maps that to validationError(CodeNotFound, ...) naming the id. Valid ack path (RowsAffected>0) is byte-for-byte unchanged; no schema/tool-schema change (TestToolSchemaBudget still 51647 B).
+
+## review-wraith verdict: SHIP
+Scope: internal/db/deliveries.go (AcknowledgeDeliveryByMessage: 0-row guard + typed MessageNotFoundError), internal/relay/handlers_messaging.go (map to validationError NOT_FOUND, +errors import), internal/relay/ack_notfound_test.go (new, 3 handler tests). 2 non-test source files.
+Gate: build -tags fts5 OK / vet OK / gofmt OK / golangci-lint 0 issues / test -tags fts5 OK (811 passed, was 808 +3 new).
+
+BLOCKERS (must fix before merge):
+- none
+
+NITS (non-blocking):
+- none. Deliveries/inbox invariants (§5) preserved: non-destructive peek unchanged, valid ack path byte-identical, no second writer, no schema/PRAGMA/tool-schema change, existence check on the RO pool. The only behavior delta is refusing an id that resolves nothing — the intended fix.
+
+## 3. Files changed
+
+```
+internal/db/deliveries.go            |  43 +++++++++++++-
+ internal/relay/ack_notfound_test.go  | 107 +++++++++++++++++++++++++++++++++++
+ internal/relay/handlers_messaging.go |   8 +++
+ 3 files changed, 156 insertions(+), 2 deletions(-)
+```
+
+## 4. QA Log
+
+_(no review round yet)_
+
+## 5. Timeline
+
+
+---
+_Auto-assembled by the niwa scribe from the Q&A gate. Task `12512c6e-0817-4a65-ad2a-c061c740595d`._

--- a/internal/db/deliveries.go
+++ b/internal/db/deliveries.go
@@ -353,13 +353,52 @@ func (d *DB) DeliveryIDsForAgent(project, agent string, messageIDs []string) (ma
 
 // AcknowledgeDeliveryByMessage finds a delivery by message_id + agent and acknowledges it.
 // Used for backward compat with mark_read.
+// MessageNotFoundError is returned by AcknowledgeDeliveryByMessage when the
+// given message_id resolves to NEITHER an open delivery for the agent NOR any
+// message row in the caller's project — so ack_delivery can refuse loudly
+// instead of echoing a bogus success. The silent-success bug: acking a
+// nonexistent id used to return {acknowledged_message_id: <bogus>} while the
+// real unread message stayed unread, so the caller believed the inbox drained.
+type MessageNotFoundError struct{ MessageID string }
+
+func (e *MessageNotFoundError) Error() string {
+	return fmt.Sprintf("no message or delivery found for message_id %q in this project", e.MessageID)
+}
+
 func (d *DB) AcknowledgeDeliveryByMessage(messageID, agentName, project string) error {
 	now := time.Now().UTC().Format("2006-01-02T15:04:05.000000Z")
-	_, err := d.writerExec(
+	res, err := d.writerExec(
 		"UPDATE deliveries SET state = 'acknowledged', acknowledged_at = ? WHERE message_id = ? AND to_agent = ? AND project = ? AND state IN ('queued', 'surfaced')",
 		now, messageID, agentName, project,
 	)
-	return err
+	if err != nil {
+		return err
+	}
+	// An UPDATE that matched an open delivery acks it — the valid path, unchanged.
+	if n, err := res.RowsAffected(); err == nil && n > 0 {
+		return nil
+	}
+	// Zero rows acked: the UPDATE affects nothing both for a bogus id AND for a
+	// real message whose delivery is already acknowledged. Distinguish them so the
+	// idempotent re-ack of a real id stays a success while an id that resolves
+	// NOTHING in this project (bogus, or a message that only exists in another
+	// project) refuses loudly. Project-scoped by construction, so a cross-project
+	// id is treated as not-found here.
+	var exists bool
+	if err := d.ro().QueryRow(
+		`SELECT EXISTS(
+			SELECT 1 FROM deliveries WHERE message_id = ? AND to_agent = ? AND project = ?
+			UNION ALL
+			SELECT 1 FROM messages   WHERE id = ? AND project = ?
+		)`,
+		messageID, agentName, project, messageID, project,
+	).Scan(&exists); err != nil {
+		return err
+	}
+	if !exists {
+		return &MessageNotFoundError{MessageID: messageID}
+	}
+	return nil
 }
 
 // AcknowledgeConversationDeliveries acks every still-open delivery to an agent

--- a/internal/relay/ack_notfound_test.go
+++ b/internal/relay/ack_notfound_test.go
@@ -1,0 +1,107 @@
+package relay
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// expectNotFound asserts an error result carries the typed NOT_FOUND envelope
+// (structured JSON, not a bare string) so a caller can branch on the code and
+// know its ack did NOT land — the opposite of the silent-success bug.
+func expectNotFound(t *testing.T, res *mcp.CallToolResult) map[string]any {
+	t.Helper()
+	if res == nil || !res.IsError {
+		t.Fatal("expected a typed NOT_FOUND error result, got success/nil (silent-success regression)")
+	}
+	raw := res.Content[0].(mcp.TextContent).Text
+	var body map[string]any
+	if err := json.Unmarshal([]byte(raw), &body); err != nil {
+		t.Fatalf("refusal is not structured JSON (client can't branch on it): %v\nraw: %s", err, raw)
+	}
+	if body["code"] != "NOT_FOUND" {
+		t.Fatalf("want code NOT_FOUND, got %v\nraw: %s", body["code"], raw)
+	}
+	return body
+}
+
+// TestAckDelivery_BogusMessageIDRefusesNotFound (bf920f6c-class reproduction):
+// ack_delivery via message_id with an id that resolves NOTHING used to echo
+// {acknowledged_message_id: <bogus>} — a silent success while the real unread
+// stayed unread. It must now refuse loudly with a typed NOT_FOUND naming the id.
+func TestAckDelivery_BogusMessageIDRefusesNotFound(t *testing.T) {
+	h := testHandlers(t)
+	registerActive(t, h, "p1", "worker", nil)
+	ack := guardedHandler(t, h, "ack_delivery")
+
+	bogus := "ffbf98ef-2c3a-4bfe-95cf-c3e43d72ac7f" // the live-repro id
+	res, _ := ack(ctx, call(map[string]any{
+		"project": "p1", "as": "worker", "message_id": bogus,
+	}))
+	body := expectNotFound(t, res)
+	if msg, _ := body["message"].(string); !strings.Contains(msg, bogus) {
+		t.Fatalf("NOT_FOUND message must name the id %q, got %q", bogus, msg)
+	}
+}
+
+// TestAckDelivery_ValidMessageIDStillAcks: the valid path is byte-for-byte
+// behaviour — a real unread message_id acks and echoes acknowledged_message_id —
+// and a second ack of the SAME real id (delivery already acked) stays a success
+// (idempotent), never a false NOT_FOUND.
+func TestAckDelivery_ValidMessageIDStillAcks(t *testing.T) {
+	h := testHandlers(t)
+	registerActive(t, h, "p1", "sender", nil)
+	registerActive(t, h, "p1", "worker", nil)
+	m, _, err := h.db.InsertMessageWithDeliveries("p1", "sender", "worker", "notification", "hi", "body", "{}", "P2", 0, nil, nil, []string{"worker"}, "")
+	if err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	ack := guardedHandler(t, h, "ack_delivery")
+
+	res, _ := ack(ctx, call(map[string]any{
+		"project": "p1", "as": "worker", "message_id": m.ID,
+	}))
+	if res != nil && res.IsError {
+		t.Fatalf("valid ack should succeed: %s", res.Content[0].(mcp.TextContent).Text)
+	}
+	got := parseJSON(t, res)
+	if got["acknowledged_message_id"] != m.ID {
+		t.Fatalf("want acknowledged_message_id=%s, got %v", m.ID, got["acknowledged_message_id"])
+	}
+
+	// Idempotent re-ack of a REAL id must not be mistaken for a bogus one.
+	res2, _ := ack(ctx, call(map[string]any{
+		"project": "p1", "as": "worker", "message_id": m.ID,
+	}))
+	if res2 != nil && res2.IsError {
+		t.Fatalf("idempotent re-ack of a real id must not refuse: %s", res2.Content[0].(mcp.TextContent).Text)
+	}
+}
+
+// TestAckDelivery_CrossProjectIDRefusesNotFound: a message_id that exists only
+// in ANOTHER project resolves nothing in the caller's project, so it refuses
+// NOT_FOUND — no cross-project silent ack.
+func TestAckDelivery_CrossProjectIDRefusesNotFound(t *testing.T) {
+	h := testHandlers(t)
+	registerActive(t, h, "p2", "sender", nil)
+	registerActive(t, h, "p2", "worker", nil)
+	registerActive(t, h, "p1", "worker", nil)
+	m, _, err := h.db.InsertMessageWithDeliveries("p2", "sender", "worker", "notification", "hi", "body", "{}", "P2", 0, nil, nil, []string{"worker"}, "")
+	if err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	ack := guardedHandler(t, h, "ack_delivery")
+
+	// worker acting in p1 tries to ack a p2-scoped message id.
+	res, _ := ack(ctx, call(map[string]any{
+		"project": "p1", "as": "worker", "message_id": m.ID,
+	}))
+	_ = expectNotFound(t, res)
+
+	// The real p2 delivery stayed unread — the failed cross-project ack didn't drain it.
+	if err := h.db.AcknowledgeDeliveryByMessage(m.ID, "worker", "p2"); err != nil {
+		t.Fatalf("the genuine p2 ack must still land (delivery was never consumed): %v", err)
+	}
+}

--- a/internal/relay/handlers_messaging.go
+++ b/internal/relay/handlers_messaging.go
@@ -5,6 +5,7 @@ import (
 	"agent-relay/internal/models"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -505,6 +506,13 @@ func (h *Handlers) HandleAckDelivery(ctx context.Context, req mcp.CallToolReques
 			agent := resolveAgent(ctx, req)
 			project := h.resolveProject(ctx, req)
 			if err := h.db.AcknowledgeDeliveryByMessage(msgID, agent, project); err != nil {
+				// Refuse loudly on an id that resolves nothing in this project,
+				// instead of the old silent-success echo that left the real
+				// unread message unread while the caller believed it was drained.
+				var nf *db.MessageNotFoundError
+				if errors.As(err, &nf) {
+					return validationError(CodeNotFound, fmt.Sprintf("ack_delivery: no message or delivery found for message_id %q in project %q", msgID, project)), nil
+				}
 				return toolResultError(fmt.Sprintf("failed to acknowledge delivery by message: %v", err)), nil
 			}
 			return h.resultJSONTracked(project, agent, "ack_delivery", map[string]any{"acknowledged_message_id": msgID})


### PR DESCRIPTION
### niwa Q&A gate

An adversarial reviewer is reading this diff right now. Its verdict lands on this PR as a review (or a comment when the gate and the author share one GitHub account), and the merge waits for this repository's own checks to go green.

*Opened automatically — a rejected round comes back to the author, who pushes fixes to the same branch.*

## What & why

- **docs(scribe): provenance for wraith-relay-split-ack-delivery-returns-not-found-on-nonexistent-message-id-sile**
- **fix: [wraith/relay][split] ack_delivery refuses loudly on unknown message_id (was silent-success)**
  <details><summary>details</summary>

  ack_delivery's message_id fallback echoed {acknowledged_message_id: <id>} for
  ANY id: db.AcknowledgeDeliveryByMessage ran a 0-row UPDATE on a bogus id and
  writerExec returned nil, so the handler reported success while the real unread
  stayed unread — the caller believed the inbox drained (live repro
  ffbf98ef-..., founder silent-failure theme).
  
  AcknowledgeDeliveryByMessage now checks RowsAffected; on 0 it runs a
  project-scoped EXISTS over deliveries+messages to tell a real id whose delivery
  is already acked (idempotent success) from an id resolving nothing in the
  caller's project (bogus, or cross-project) — returning a typed
  *db.MessageNotFoundError. The handler maps it to validationError(NOT_FOUND)
  naming the id. Valid ack path byte-for-byte unchanged; no schema/tool-schema
  change (TestToolSchemaBudget 51647 B unchanged).
  
  Tests: TestAckDelivery_BogusMessageIDRefusesNotFound (bf920f6c-class repro),
  TestAckDelivery_ValidMessageIDStillAcks (valid + idempotent re-ack),
  TestAckDelivery_CrossProjectIDRefusesNotFound.
  
  Claude-Session: https://claude.ai/code/session_01C3hsyCeR5poTZTLmaWuyTf

  </details>

## Changes

<details><summary>Files changed (git diff --stat)</summary>

```
...rns-not-found-on-nonexistent-message-id-sile.md |  48 +++++++++
 internal/db/deliveries.go                          |  43 ++++++++-
 internal/relay/ack_notfound_test.go                | 107 +++++++++++++++++++++
 internal/relay/handlers_messaging.go               |   8 ++
 4 files changed, 204 insertions(+), 2 deletions(-)
```

</details>

## Acceptance criteria

- [ ] AC1 ack_delivery with a message_id matching no delivery and no message returns a typed NOT_FOUND error naming the id — test
- [ ] AC2 ack_delivery with a valid unread message_id still acknowledges and returns the same success shape as before — existing tests green unmodified
- [ ] AC3 cross-project id (message exists in another project) also refuses — test
- [ ] AC4 go build ./..., go vet ./..., go test -tags fts5 ./... green (count cited); ≤2 non-test source files; TestToolSchemaBudget total unchanged

## Provenance

📄 [Root cause, decisions &amp; QA log — `features/wraith-relay-split-ack-delivery-returns-not-found-on-nonexistent-message-id-sile.md`](https://github.com/TsukumoHQ/WRAI.TH/blob/wraith-backend/ack-notfound/features/wraith-relay-split-ack-delivery-returns-not-found-on-nonexistent-message-id-sile.md)

## Self-review

## review-wraith verdict: SHIP
Scope: internal/db/deliveries.go (AcknowledgeDeliveryByMessage: 0-row guard + typed MessageNotFoundError), internal/relay/handlers_messaging.go (map to validationError NOT_FOUND, +errors import), internal/relay/ack_notfound_test.go (new, 3 handler tests). 2 non-test source files.
Gate: build -tags fts5 OK / vet OK / gofmt OK / golangci-lint 0 issues / test -tags fts5 OK (811 passed, was 808 +3 new).

BLOCKERS (must fix before merge):
- none

NITS (non-blocking):
- none. Deliveries/inbox invariants (§5) preserved: non-destructive peek unchanged, valid ack path byte-identical, no second writer, no schema/PRAGMA/tool-schema change, existence check on the RO pool. The only behavior delta is refusing an id that resolves nothing — the intended fix.

---
<sub>Authored by agent `wraith-backend` · branch `wraith-backend/ack-notfound` → `main` · reviewed by niwa-gate and merged when this repo's checks pass.</sub>