### PR TITLE
[relay] registry listings exclude status='deleted' rows (registry-tri #2)

### DIFF
--- a/features/relay-registry-listings-exclude-status-deleted-rows-registry-tri-2.md
+++ b/features/relay-registry-listings-exclude-status-deleted-rows-registry-tri-2.md
@@ -1,0 +1,49 @@
+# [relay] registry listings exclude status='deleted' rows (registry-tri #2)
+
+## Team : wraith-backend (niwa)
+## Branch : wraith-backend/registry-list-exclude-deleted (from main)
+## Relay task : c877a9db-ffb5-4673-8ca3-dfc9504f379d
+## Status : 🔵 SUBMITTED
+
+## 1. Product Brief
+
+### Acceptance Criteria
+- [ ] 1. AC1 list_agents excludes status='deleted' rows — named test with a mixed live/deleted fixture asserts only live rows returned
+- [ ] 2. AC2 every other registry listing surface excludes deleted rows — table-driven named test covering the enumerated surfaces; the enumeration is stated in the report
+- [ ] 3. AC3 deleted rows remain in the table untouched (no hard delete, audit trail intact) — named test asserts row still readable directly after being filtered from listings
+- [ ] 4. AC4 direct read of a deleted agent surfaces an explicit deleted state (loud), not a silent not-found — named test asserts the exact response/MESSAGE
+- [ ] 5. AC5 go build + go vet + go test green with fts5/CGO flags
+
+## 2. Root cause & decisions
+
+ROOT_CAUSE: Team-roster listing surfaces in internal/db/orgs.go (GetTeamMembers, GetTeamMemberNames, GetAllTeamMemberships, GetAgentTeams) joined team_members WITHOUT checking agents.status, so a soft-deleted agent (DeleteAgent sets status='deleted' and KEEPS both the agents row and the team_members row) kept leaking into every roster. Agent listings (ListAgents, GetAgentsByProfile, FindActiveAgentsBySkill, BuildOrgChart, web/projects) already excluded deleted via `status IN ('active','sleeping','inactive')` since 5a2791d — empirically list_agents(tsukumo) returns 0 of 280 deleted — so the residual leak was the roster join alone. Fix: add a conservative `NOT EXISTS (SELECT 1 FROM agents a WHERE a.name=<tm>.agent_name AND a.project=<tm>.project AND a.status='deleted')` guard to those four queries — filters only positively-deleted members, leaves the audit-trail row untouched and any bare/unregistered member unaffected. AC4 (loud direct read) needed no code: SenderEligibility already returns reason='deleted' (distinct from 'unregistered'); AC4 asserts that exact message via HandleIsEligible.
+
+## review-wraith verdict: SHIP-WITH-NITS
+Scope: internal/db/orgs.go (4 roster queries), internal/db/registry_listing_deleted_test.go (new), internal/relay/is_eligible_deleted_test.go (new)
+Gate: build -tags fts5 OK / vet OK / gofmt OK / test -tags fts5 OK (full ./internal/... green)
+
+BLOCKERS (must fix before merge):
+- none
+
+NITS (non-blocking):
+- internal/db/orgs.go:GetTeamMemberNames — feeds team-broadcast delivery, so a soft-deleted agent now stops receiving team messages. Intended (consistent with delete_agent's "no more messages" contract), flagged in the plan for sign-off; plan-lane silence window (600s) elapsed with no veto.
+- Guard is a correlated NOT EXISTS per row; team_members rosters are small and reads use the RO pool (d.ro()), so no hot-write-path or contention concern. CanMessage's team_members joins are permission checks (not listings) and are deliberately left unchanged — the send path already gates on SenderEligibility.
+
+## 3. Files changed
+
+```
+internal/db/orgs.go                          |  23 ++-
+ internal/db/registry_listing_deleted_test.go | 202 +++++++++++++++++++++++++++
+ internal/relay/is_eligible_deleted_test.go   |  46 ++++++
+ 3 files changed, 268 insertions(+), 3 deletions(-)
+```
+
+## 4. QA Log
+
+_(no review round yet)_
+
+## 5. Timeline
+
+
+---
+_Auto-assembled by the niwa scribe from the Q&A gate. Task `c877a9db-ffb5-4673-8ca3-dfc9504f379d`._

--- a/internal/db/orgs.go
+++ b/internal/db/orgs.go
@@ -235,10 +235,19 @@ func (d *DB) RemoveTeamMember(teamID, agentName string) error {
 	return nil
 }
 
+// GetTeamMembers returns a team's active members, excluding any whose agent row
+// has been soft-deleted (status='deleted'). The deleted agent's team_members row
+// is left in place (DeleteAgent keeps it, audit trail intact) — the NOT EXISTS
+// guard filters it out of the roster without touching it. A member with no
+// matching agent row at all is kept: the guard removes only positively-deleted
+// members, never a bare/unregistered one.
 func (d *DB) GetTeamMembers(teamID string) ([]models.TeamMember, error) {
 	rows, err := d.ro().Query(
 		`SELECT team_id, agent_name, project, role, joined_at, left_at
-		 FROM team_members WHERE team_id = ? AND left_at IS NULL ORDER BY role, agent_name`, teamID,
+		 FROM team_members WHERE team_id = ? AND left_at IS NULL
+		   AND NOT EXISTS (SELECT 1 FROM agents a
+		     WHERE a.name = team_members.agent_name AND a.project = team_members.project AND a.status = 'deleted')
+		 ORDER BY role, agent_name`, teamID,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("get team members: %w", err)
@@ -256,10 +265,14 @@ func (d *DB) GetTeamMembers(teamID string) ([]models.TeamMember, error) {
 	return members, rows.Err()
 }
 
-// GetTeamMemberNames returns active member names for a team.
+// GetTeamMemberNames returns active member names for a team, excluding soft-deleted
+// agents. This feeds team-broadcast delivery, so a deleted agent stops receiving
+// team messages — consistent with delete_agent's "no more messages" contract.
 func (d *DB) GetTeamMemberNames(teamID string) ([]string, error) {
 	rows, err := d.ro().Query(
-		`SELECT agent_name FROM team_members WHERE team_id = ? AND left_at IS NULL`, teamID,
+		`SELECT agent_name FROM team_members WHERE team_id = ? AND left_at IS NULL
+		   AND NOT EXISTS (SELECT 1 FROM agents a
+		     WHERE a.name = team_members.agent_name AND a.project = team_members.project AND a.status = 'deleted')`, teamID,
 	)
 	if err != nil {
 		return nil, err
@@ -284,6 +297,8 @@ func (d *DB) GetAgentTeams(project, agentName string) ([]models.Team, error) {
 		 FROM teams t
 		 JOIN team_members tm ON t.id = tm.team_id
 		 WHERE tm.agent_name = ? AND tm.project = ? AND tm.left_at IS NULL
+		   AND NOT EXISTS (SELECT 1 FROM agents a
+		     WHERE a.name = tm.agent_name AND a.project = tm.project AND a.status = 'deleted')
 		 ORDER BY t.name`,
 		agentName, project,
 	)
@@ -537,6 +552,8 @@ func (d *DB) GetAllTeamMemberships() ([]TeamMembershipInfo, error) {
 		 FROM team_members tm
 		 JOIN teams t ON tm.team_id = t.id
 		 WHERE tm.left_at IS NULL
+		   AND NOT EXISTS (SELECT 1 FROM agents a
+		     WHERE a.name = tm.agent_name AND a.project = tm.project AND a.status = 'deleted')
 		 ORDER BY tm.agent_name, t.name`,
 	)
 	if err != nil {

--- a/internal/db/registry_listing_deleted_test.go
+++ b/internal/db/registry_listing_deleted_test.go
@@ -1,0 +1,202 @@
+package db
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func contains(names []string, want string) bool {
+	for _, n := range names {
+		if n == want {
+			return true
+		}
+	}
+	return false
+}
+
+// AC1: list_agents excludes status='deleted' rows.
+func TestListAgents_ExcludesDeleted(t *testing.T) {
+	d, err := NewTestDB(filepath.Join(t.TempDir(), "t.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	const proj = "proj"
+	for _, name := range []string{"alice", "ghost"} {
+		if _, _, err := d.RegisterAgent(proj, name, "dev", "", nil, nil, false, nil, "[]", 0, RegisterOptions{}); err != nil {
+			t.Fatalf("register %s: %v", name, err)
+		}
+	}
+	if err := d.DeleteAgent(proj, "ghost"); err != nil {
+		t.Fatalf("delete ghost: %v", err)
+	}
+
+	agents, err := d.ListAgents(proj)
+	if err != nil {
+		t.Fatalf("list agents: %v", err)
+	}
+	var names []string
+	for _, a := range agents {
+		names = append(names, a.Name)
+	}
+	if !contains(names, "alice") {
+		t.Errorf("live agent alice missing from listing: %v", names)
+	}
+	if contains(names, "ghost") {
+		t.Errorf("deleted agent ghost leaked into listing: %v", names)
+	}
+}
+
+// AC2: every team-roster listing surface excludes a soft-deleted agent while
+// keeping live members. Table-driven over the enumerated roster surfaces in
+// orgs.go (GetTeamMembers, GetTeamMemberNames, GetAllTeamMemberships) plus an
+// explicit check of GetAgentTeams (which is keyed on the agent, not the team).
+func TestTeamRosterListings_ExcludeDeleted(t *testing.T) {
+	d, err := NewTestDB(filepath.Join(t.TempDir(), "t.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	const proj = "proj"
+	for _, name := range []string{"alice", "ghost"} {
+		if _, _, err := d.RegisterAgent(proj, name, "dev", "", nil, nil, false, nil, "[]", 0, RegisterOptions{}); err != nil {
+			t.Fatalf("register %s: %v", name, err)
+		}
+	}
+	team, err := d.CreateTeam("Backend", "backend", proj, "", "regular", nil, nil)
+	if err != nil {
+		t.Fatalf("create team: %v", err)
+	}
+	for _, name := range []string{"alice", "ghost"} {
+		if err := d.AddTeamMember(team.ID, name, proj, "member"); err != nil {
+			t.Fatalf("add member %s: %v", name, err)
+		}
+	}
+	if err := d.DeleteAgent(proj, "ghost"); err != nil {
+		t.Fatalf("delete ghost: %v", err)
+	}
+
+	surfaces := []struct {
+		name    string
+		members func() ([]string, error)
+	}{
+		{"GetTeamMembers", func() ([]string, error) {
+			ms, err := d.GetTeamMembers(team.ID)
+			if err != nil {
+				return nil, err
+			}
+			var names []string
+			for _, m := range ms {
+				names = append(names, m.AgentName)
+			}
+			return names, nil
+		}},
+		{"GetTeamMemberNames", func() ([]string, error) {
+			return d.GetTeamMemberNames(team.ID)
+		}},
+		{"GetAllTeamMemberships", func() ([]string, error) {
+			ms, err := d.GetAllTeamMemberships()
+			if err != nil {
+				return nil, err
+			}
+			var names []string
+			for _, m := range ms {
+				names = append(names, m.AgentName)
+			}
+			return names, nil
+		}},
+	}
+	for _, s := range surfaces {
+		t.Run(s.name, func(t *testing.T) {
+			names, err := s.members()
+			if err != nil {
+				t.Fatalf("%s: %v", s.name, err)
+			}
+			if !contains(names, "alice") {
+				t.Errorf("%s: live member alice missing: %v", s.name, names)
+			}
+			if contains(names, "ghost") {
+				t.Errorf("%s: deleted member ghost leaked: %v", s.name, names)
+			}
+		})
+	}
+
+	t.Run("GetAgentTeams", func(t *testing.T) {
+		// A live agent still sees its team.
+		aliceTeams, err := d.GetAgentTeams(proj, "alice")
+		if err != nil {
+			t.Fatalf("GetAgentTeams alice: %v", err)
+		}
+		if len(aliceTeams) != 1 {
+			t.Errorf("live agent alice: want 1 team, got %d", len(aliceTeams))
+		}
+		// A deleted agent lists no teams.
+		ghostTeams, err := d.GetAgentTeams(proj, "ghost")
+		if err != nil {
+			t.Fatalf("GetAgentTeams ghost: %v", err)
+		}
+		if len(ghostTeams) != 0 {
+			t.Errorf("deleted agent ghost: want 0 teams, got %d", len(ghostTeams))
+		}
+	})
+}
+
+// AC3: a soft-deleted row is filtered from listings but remains in the table,
+// readable directly (audit trail intact) with an explicit status='deleted'.
+func TestDeletedAgentRowRemainsReadable(t *testing.T) {
+	d, err := NewTestDB(filepath.Join(t.TempDir(), "t.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	const proj = "proj"
+	if _, _, err := d.RegisterAgent(proj, "ghost", "dev", "", nil, nil, false, nil, "[]", 0, RegisterOptions{}); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	if err := d.DeleteAgent(proj, "ghost"); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+
+	a, err := d.GetAgent(proj, "ghost")
+	if err != nil {
+		t.Fatalf("get agent: %v", err)
+	}
+	if a == nil {
+		t.Fatal("deleted agent row was hard-deleted; audit trail lost")
+	}
+	if a.Status != "deleted" {
+		t.Errorf("deleted agent status = %q, want %q", a.Status, "deleted")
+	}
+}
+
+// AC5 (extra coverage): the profile-based listing surface also excludes deleted
+// rows. GetAgentsByProfile resolves dispatch fan-out; a deleted agent must not
+// appear as a delivery target.
+func TestOtherRegistryListings_ExcludeDeleted(t *testing.T) {
+	d, err := NewTestDB(filepath.Join(t.TempDir(), "t.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	const proj = "proj"
+	slug := "backend-dev"
+	for _, name := range []string{"alice", "ghost"} {
+		if _, _, err := d.RegisterAgent(proj, name, "dev", "", nil, &slug, false, nil, "[]", 0, RegisterOptions{ProfileSlugSet: true}); err != nil {
+			t.Fatalf("register %s: %v", name, err)
+		}
+	}
+	if err := d.DeleteAgent(proj, "ghost"); err != nil {
+		t.Fatalf("delete ghost: %v", err)
+	}
+
+	agents, err := d.GetAgentsByProfile(proj, slug)
+	if err != nil {
+		t.Fatalf("get agents by profile: %v", err)
+	}
+	var names []string
+	for _, a := range agents {
+		names = append(names, a.Name)
+	}
+	if !contains(names, "alice") {
+		t.Errorf("live agent alice missing from profile listing: %v", names)
+	}
+	if contains(names, "ghost") {
+		t.Errorf("deleted agent ghost leaked into profile listing: %v", names)
+	}
+}

--- a/internal/relay/is_eligible_deleted_test.go
+++ b/internal/relay/is_eligible_deleted_test.go
@@ -1,0 +1,46 @@
+package relay
+
+import (
+	"testing"
+
+	"agent-relay/internal/db"
+)
+
+// AC4: a direct eligibility read of a soft-deleted agent surfaces an explicit
+// "deleted" state (loud), never a silent not-found ambiguity. The reason must be
+// distinct from "unregistered" so a client can tell a killed agent apart from a
+// never-existed one and PARK rather than hot-loop.
+func TestIsEligible_DeletedAgentLoudReason(t *testing.T) {
+	h := testHandlers(t)
+	const proj = "test-proj"
+
+	if _, _, err := h.db.RegisterAgent(proj, "ghost", "dev", "", nil, nil, false, nil, "[]", 0, db.RegisterOptions{}); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	if err := h.db.DeleteAgent(proj, "ghost"); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+
+	res, err := h.HandleIsEligible(ctx, call(map[string]any{"project": proj, "agent": "ghost"}))
+	if err != nil {
+		t.Fatalf("is_eligible: %v", err)
+	}
+	data := parseJSON(t, res)
+	if data["eligible"] != false {
+		t.Errorf("deleted agent eligible = %v, want false", data["eligible"])
+	}
+	if data["reason"] != "deleted" {
+		t.Errorf("deleted agent reason = %q, want loud %q", data["reason"], "deleted")
+	}
+
+	// A never-registered name reports "unregistered" — proving "deleted" is a
+	// distinct, non-silent verdict, not collapsed into a generic not-found.
+	res2, err := h.HandleIsEligible(ctx, call(map[string]any{"project": proj, "agent": "nobody"}))
+	if err != nil {
+		t.Fatalf("is_eligible nobody: %v", err)
+	}
+	data2 := parseJSON(t, res2)
+	if data2["reason"] != "unregistered" {
+		t.Errorf("unregistered agent reason = %q, want %q", data2["reason"], "unregistered")
+	}
+}


### PR DESCRIPTION
### niwa Q&A gate

An adversarial reviewer is reading this diff right now. Its verdict lands on this PR as a review (or a comment when the gate and the author share one GitHub account), and the merge waits for this repository's own checks to go green.

*Opened automatically — a rejected round comes back to the author, who pushes fixes to the same branch.*

## What & why

- **docs(scribe): provenance for relay-registry-listings-exclude-status-deleted-rows-registry-tri-2**
- **fix(relay): exclude soft-deleted agents from team-roster listings**
  <details><summary>details</summary>

  Team-roster surfaces in orgs.go (GetTeamMembers, GetTeamMemberNames,
  GetAllTeamMemberships, GetAgentTeams) joined team_members without checking
  agents.status, leaking soft-deleted agents into every roster. DeleteAgent
  sets status='deleted' but keeps both the agents row and the team_members
  row (audit trail), and agent listings already filter deleted since 5a2791d,
  so the roster join was the residual leak.
  
  Add a conservative NOT EXISTS (agents.status='deleted') guard to the four
  roster queries — filters only positively-deleted members, leaves the
  audit-trail row untouched and bare/unregistered members unaffected. Direct
  reads stay loud: SenderEligibility already returns reason='deleted' distinct
  from 'unregistered'.
  
  Tests: TestListAgents_ExcludesDeleted, TestTeamRosterListings_ExcludeDeleted
  (table-driven over the roster surfaces + GetAgentTeams),
  TestDeletedAgentRowRemainsReadable, TestOtherRegistryListings_ExcludeDeleted,
  TestIsEligible_DeletedAgentLoudReason.
  
  Task: c877a9db-ffb5-4673-8ca3-dfc9504f379d
  
  Claude-Session: https://claude.ai/code/session_01C3hsyCeR5poTZTLmaWuyTf

  </details>

## Changes

<details><summary>Files changed (git diff --stat)</summary>

```
...s-exclude-status-deleted-rows-registry-tri-2.md |  49 +++++
 internal/db/orgs.go                                |  23 ++-
 internal/db/registry_listing_deleted_test.go       | 202 +++++++++++++++++++++
 internal/relay/is_eligible_deleted_test.go         |  46 +++++
 4 files changed, 317 insertions(+), 3 deletions(-)
```

</details>

## Acceptance criteria

- [ ] AC1 list_agents excludes status='deleted' rows — named test with a mixed live/deleted fixture asserts only live rows returned
- [ ] AC2 every other registry listing surface excludes deleted rows — table-driven named test covering the enumerated surfaces; the enumeration is stated in the report
- [ ] AC3 deleted rows remain in the table untouched (no hard delete, audit trail intact) — named test asserts row still readable directly after being filtered from listings
- [ ] AC4 direct read of a deleted agent surfaces an explicit deleted state (loud), not a silent not-found — named test asserts the exact response/MESSAGE
- [ ] AC5 go build + go vet + go test green with fts5/CGO flags

## Provenance

📄 [Root cause, decisions &amp; QA log — `features/relay-registry-listings-exclude-status-deleted-rows-registry-tri-2.md`](https://github.com/TsukumoHQ/WRAI.TH/blob/wraith-backend/registry-list-exclude-deleted/features/relay-registry-listings-exclude-status-deleted-rows-registry-tri-2.md)

## Self-review

## review-wraith verdict: SHIP-WITH-NITS
Scope: internal/db/orgs.go (4 roster queries), internal/db/registry_listing_deleted_test.go (new), internal/relay/is_eligible_deleted_test.go (new)
Gate: build -tags fts5 OK / vet OK / gofmt OK / test -tags fts5 OK (full ./internal/... green)

BLOCKERS (must fix before merge):
- none

NITS (non-blocking):
- internal/db/orgs.go:GetTeamMemberNames — feeds team-broadcast delivery, so a soft-deleted agent now stops receiving team messages. Intended (consistent with delete_agent's "no more messages" contract), flagged in the plan for sign-off; plan-lane silence window (600s) elapsed with no veto.
- Guard is a correlated NOT EXISTS per row; team_members rosters are small and reads use the RO pool (d.ro()), so no hot-write-path or contention concern. CanMessage's team_members joins are permission checks (not listings) and are deliberately left unchanged — the send path already gates on SenderEligibility.

---
<sub>Authored by agent `wraith-backend` · branch `wraith-backend/registry-list-exclude-deleted` → `main` · reviewed by niwa-gate and merged when this repo's checks pass.</sub>