### PR TITLE
[wraith/relay] delete_memory loud-fail: targeted delete matching no row returns error naming key+author

### DIFF
--- a/features/wraith-relay-delete-memory-loud-fail-targeted-delete-matching-no-row-returns-err.md
+++ b/features/wraith-relay-delete-memory-loud-fail-targeted-delete-matching-no-row-returns-err.md
@@ -1,0 +1,44 @@
+# [wraith/relay] delete_memory loud-fail: targeted delete matching no row returns error naming key+author
+
+## Team : wraith-backend (tsukumo)
+## Branch : wraith-backend/delete-memory-loud-fail (from main)
+## Relay task : 7d0629c7-f983-4ae6-9f22-99779dbbc228
+## Status : 🔵 SUBMITTED
+
+## 1. Product Brief
+
+### Acceptance Criteria
+- [ ] 1. AC1 named test: delete_memory with explicit `agent` param matching no row (wrong author or missing key) returns an error whose message names both the key and the target author
+- [ ] 2. AC2 named test: self-delete (no `agent` param) of a missing key keeps current lenient behavior, unchanged
+
+## 2. Root cause & decisions
+
+ROOT_CAUSE: DeleteMemoryAs (internal/db/memories.go) returned a single generic "memory not found: <key> (scope=<scope>)" error on RowsAffected==0 for BOTH self-delete and the targeted cross-author admin/janitor arm. When an operator targets a specific author via the explicit `agent` param and the assumed author is wrong (live incident: frontend-lead-resume was authored by anonymous, DEV-checkpoint by dev), the no-op error did not name the author, so the operator could not tell WHICH target matched nothing and believed the purge done. FIX: in the n==0 branch, when the delete is a targeted cross-author agent-scope delete (scope=='agent' && !EqualFold(targetAuthor, actingAgent)), return an error naming BOTH the key and the target author. The self-delete path (targetAuthor==actingAgent, including no `agent` param) keeps the exact prior message — byte-identical, no behavior change.
+
+## review-wraith verdict: SHIP
+Scope: internal/db/memories.go (DeleteMemoryAs n==0 branch), internal/db/delete_memory_loud_fail_test.go (new)
+Gate: build -tags fts5 OK / vet OK / gofmt OK / test -tags fts5 OK (829 pass, full ./...)
+
+BLOCKERS (must fix before merge):
+- none
+
+NITS (non-blocking):
+- No schema/migration, no new writer (reuses the existing single UPDATE via writerExec), single-writer + WAL untouched. Backward-compatible: the successful-delete path and the self-delete not-found message are unchanged; only the cross-author no-op error text is enriched. No caller parses the error string (handler wraps it as toolResultError), so the message change is safe. Failure-is-loud satisfied: AC1 asserts the exact message names key + author.
+
+## 3. Files changed
+
+```
+internal/db/delete_memory_loud_fail_test.go | 68 +++++++++++++++++++++++++++++
+ internal/db/memories.go                     | 11 +++++
+ 2 files changed, 79 insertions(+)
+```
+
+## 4. QA Log
+
+_(no review round yet)_
+
+## 5. Timeline
+
+
+---
+_Auto-assembled by the niwa scribe from the Q&A gate. Task `7d0629c7-f983-4ae6-9f22-99779dbbc228`._

--- a/internal/db/delete_memory_loud_fail_test.go
+++ b/internal/db/delete_memory_loud_fail_test.go
@@ -1,0 +1,68 @@
+package db
+
+import (
+	"strings"
+	"testing"
+)
+
+// AC1: a targeted cross-author delete (explicit `agent` target distinct from the
+// caller, agent scope) that matches no row fails LOUDLY, naming both the key and
+// the target author — the founder failure-is-loud fix for the live incident where
+// an assumed author differed and a silent no-op left the purge believed-done.
+func TestDeleteMemoryAs_TargetedNoRowNamesKeyAndAuthor(t *testing.T) {
+	d := testDB(t)
+
+	// A real agent-scope memory exists, but authored by "alice". Targeting a
+	// DIFFERENT author ("ghost") for the same key matches no row.
+	if _, err := d.SetMemory("p1", "alice", "secret", "v", "[]", "agent", "stated", "behavior"); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	err := d.DeleteMemoryAs("p1", "admin", "ghost", "secret", "agent", "purge")
+	if err == nil {
+		t.Fatal("expected a loud error on a targeted delete that matched no row, got nil")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "secret") {
+		t.Errorf("error must name the key: %q", msg)
+	}
+	if !strings.Contains(msg, "ghost") {
+		t.Errorf("error must name the target author: %q", msg)
+	}
+
+	// The seeded row (alice's) is untouched — the wrong-author delete archived
+	// nothing.
+	live, _ := d.GetMemory("p1", "alice", "secret", "agent")
+	if len(live) != 1 {
+		t.Errorf("alice's memory should be untouched by the wrong-author delete, got %d live rows", len(live))
+	}
+}
+
+// AC2: a self-delete (no `agent` target — actingAgent == targetAuthor) of a
+// missing key keeps its current lenient behavior UNCHANGED: the plain
+// "memory not found: <key> (scope=<scope>)" message, with no target-author phrasing.
+func TestDeleteMemory_SelfMissingKeyLenientUnchanged(t *testing.T) {
+	d := testDB(t)
+
+	err := d.DeleteMemory("p1", "bob", "missing", "project", "cleanup")
+	if err == nil {
+		t.Fatal("expected the existing not-found error, got nil")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "memory not found: missing (scope=project)") {
+		t.Errorf("self-delete message changed; want the plain not-found form, got %q", msg)
+	}
+	if strings.Contains(msg, "authored by") {
+		t.Errorf("self-delete must NOT use the targeted author-naming message: %q", msg)
+	}
+
+	// Same for an agent-scope self-delete (targetAuthor resolves to the caller):
+	// still the plain message, no author naming.
+	errAgent := d.DeleteMemoryAs("p1", "bob", "bob", "missing", "agent", "cleanup")
+	if errAgent == nil {
+		t.Fatal("expected the existing not-found error for agent self-delete, got nil")
+	}
+	if strings.Contains(errAgent.Error(), "authored by") {
+		t.Errorf("agent-scope self-delete must NOT name a target author: %q", errAgent.Error())
+	}
+}

--- a/internal/db/memories.go
+++ b/internal/db/memories.go
@@ -481,6 +481,17 @@ func (d *DB) DeleteMemoryAs(project, actingAgent, targetAuthor, key, scope strin
 	}
 	n, _ := res.RowsAffected()
 	if n == 0 {
+		// A targeted cross-author delete (the admin/janitor arm: an explicit
+		// `agent` target distinct from the caller, agent scope) that matches no
+		// row means the operator aimed at the WRONG author — the live incident
+		// where assumed authors differed (frontend-lead-resume was anonymous,
+		// DEV-checkpoint was dev) and a no-op would leave the operator believing
+		// the purge done. Fail loudly naming BOTH the key AND the target author
+		// (founder failure-is-loud). The self-delete path (targetAuthor ==
+		// actingAgent, incl. no `agent` param) keeps the plain message unchanged.
+		if scope == "agent" && !strings.EqualFold(targetAuthor, actingAgent) {
+			return fmt.Errorf("memory not found: no agent-scope memory %q authored by %q (scope=agent)", key, targetAuthor)
+		}
 		return fmt.Errorf("memory not found: %s (scope=%s)", key, scope)
 	}
 	return nil


### PR DESCRIPTION
### niwa Q&A gate

An adversarial reviewer is reading this diff right now. Its verdict lands on this PR as a review (or a comment when the gate and the author share one GitHub account), and the merge waits for this repository's own checks to go green.

*Opened automatically — a rejected round comes back to the author, who pushes fixes to the same branch.*

## What & why

- **docs(scribe): provenance for wraith-relay-delete-memory-loud-fail-targeted-delete-matching-no-row-returns-err**
- **fix(relay): delete_memory targeted no-row failure names key + target author**
  <details><summary>details</summary>

  DeleteMemoryAs returned a generic 'memory not found: <key> (scope=<scope>)'
  on RowsAffected==0 for both self-delete and the targeted cross-author
  admin/janitor arm. When an operator targets a specific author via the
  explicit `agent` param and the assumed author is wrong (live incident:
  frontend-lead-resume authored by anonymous, DEV-checkpoint by dev), the
  no-op error did not name the author, so the operator could not tell which
  target matched nothing and believed the purge done.
  
  Fix: in the n==0 branch, a targeted cross-author agent-scope delete
  (scope=='agent' && !EqualFold(targetAuthor, actingAgent)) now returns an
  error naming both the key and the target author (founder failure-is-loud).
  The self-delete path (targetAuthor==actingAgent, incl. no `agent` param)
  keeps the exact prior message unchanged — no behavior change.
  
  Tests: TestDeleteMemoryAs_TargetedNoRowNamesKeyAndAuthor,
  TestDeleteMemory_SelfMissingKeyLenientUnchanged.
  
  Task: 7d0629c7-f983-4ae6-9f22-99779dbbc228
  
  Claude-Session: https://claude.ai/code/session_01C3hsyCeR5poTZTLmaWuyTf

  </details>

## Changes

<details><summary>Files changed (git diff --stat)</summary>

```
...-targeted-delete-matching-no-row-returns-err.md | 44 ++++++++++++++
 internal/db/delete_memory_loud_fail_test.go        | 68 ++++++++++++++++++++++
 internal/db/memories.go                            | 11 ++++
 3 files changed, 123 insertions(+)
```

</details>

## Acceptance criteria

- [ ] AC1 named test: delete_memory with explicit `agent` param matching no row (wrong author or missing key) returns an error whose message names both the key and the target author
- [ ] AC2 named test: self-delete (no `agent` param) of a missing key keeps current lenient behavior, unchanged

## Provenance

📄 [Root cause, decisions &amp; QA log — `features/wraith-relay-delete-memory-loud-fail-targeted-delete-matching-no-row-returns-err.md`](https://github.com/TsukumoHQ/WRAI.TH/blob/wraith-backend/delete-memory-loud-fail/features/wraith-relay-delete-memory-loud-fail-targeted-delete-matching-no-row-returns-err.md)

## Self-review

## review-wraith verdict: SHIP
Scope: internal/db/memories.go (DeleteMemoryAs n==0 branch), internal/db/delete_memory_loud_fail_test.go (new)
Gate: build -tags fts5 OK / vet OK / gofmt OK / test -tags fts5 OK (829 pass, full ./...)

BLOCKERS (must fix before merge):
- none

NITS (non-blocking):
- No schema/migration, no new writer (reuses the existing single UPDATE via writerExec), single-writer + WAL untouched. Backward-compatible: the successful-delete path and the self-delete not-found message are unchanged; only the cross-author no-op error text is enriched. No caller parses the error string (handler wraps it as toolResultError), so the message change is safe. Failure-is-loud satisfied: AC1 asserts the exact message names key + author.

---
<sub>Authored by agent `wraith-backend` · branch `wraith-backend/delete-memory-loud-fail` → `main` · reviewed by niwa-gate and merged when this repo's checks pass.</sub>