### PR TITLE
[wraith/relay] update_task typed-field validation: native-array acceptance_criteria coerced, wrong types refused loudly (silent drop today)

### DIFF
--- a/features/wraith-relay-update-task-typed-field-validation-native-array-acceptance-criteria.md
+++ b/features/wraith-relay-update-task-typed-field-validation-native-array-acceptance-criteria.md
@@ -1,0 +1,46 @@
+# [wraith/relay] update_task typed-field validation: native-array acceptance_criteria coerced, wrong types refused loudly (silent drop today)
+
+## Team : wraith-backend (tsukumo)
+## Branch : wraith-backend/update-task-typed-fields (from main)
+## Relay task : 88510cb5-309d-478c-b60e-b8311aee2eb9
+## Status : 🔵 SUBMITTED
+
+## 1. Product Brief
+
+### Acceptance Criteria
+- [ ] 1. AC1 named test: update_task with acceptance_criteria as a native array of strings applies — stored value equals the canonical JSON-string form, and a progress_note in the same call is applied too (the 3ad80aae repro shape)
+- [ ] 2. AC2 named test: update_task with a wrong-typed value on a string field refuses INVALID_ARGUMENT naming the field and expected type; no field from that request is applied (atomic refusal, last_activity_at unchanged)
+- [ ] 3. AC3 named test: acceptance_criteria as an array containing a non-string element refuses INVALID_ARGUMENT naming the field — not coerced, not dropped
+
+## 2. Root cause & decisions
+
+ROOT_CAUSE: HandleUpdateTask (internal/relay/handlers_tasks.go) read every field via req.GetString, which silently falls back to "" when an arg is present but the wrong JSON type. A native-array acceptance_criteria therefore resolved to "" -> optionalString -> nil and was DROPPED with a 200 + bumped last_activity_at, no error (live repro 3ad80aae); a mistyped value on any other string field was likewise dropped. batch_dispatch_tasks accepts real arrays for the same field, making the asymmetry a trap. FIX: a typed-field validation pass right after the unknown-key check, BEFORE any DB write — (1) every string field present with a non-string value is refused INVALID_ARGUMENT naming the field + expected type; (2) acceptance_criteria additionally accepts a native []string, coerced to its canonical JSON-string form (json.Marshal) for batch_dispatch parity; (3) an AC array with a non-string element is refused, not coerced/dropped. Validation precedes UpdateTaskFields/reassign/AddProgressNote, so a refusal is atomic (no partial apply, last_activity_at unchanged).
+
+## review-wraith verdict: SHIP
+Scope: internal/relay/handlers_tasks.go (HandleUpdateTask typed-field pass), internal/relay/update_task_typed_fields_test.go (new)
+Gate: build -tags fts5 OK / vet OK / gofmt OK / test -tags fts5 -count=1 OK (832 pass, full ./...)
+
+BLOCKERS (must fix before merge):
+- none
+
+NITS (non-blocking):
+- No schema/migration, no new writer, no new tool/route — validation-only in an existing handler; middleware/auth/permission model untouched. Backward-compatible: a JSON-string acceptance_criteria keeps the existing json.Unmarshal array validation (existing TestUpdateTask_DispatcherRescopesContract_Audited still green). Atomicity proven by AC2 (sibling valid field + last_activity_at unchanged on refusal). Failure-is-loud satisfied: AC2/AC3 assert the refusal message names the field.
+- DoD note: after the next agent-relay redeploy, the niwa memory key `niwa-update-task-ac-must-be-json-string` (the string-only workaround) is obsolete and should be retired by the dispatcher.
+
+## 3. Files changed
+
+```
+internal/relay/handlers_tasks.go                |  50 ++++++++-
+ internal/relay/update_task_typed_fields_test.go | 130 ++++++++++++++++++++++++
+ 2 files changed, 179 insertions(+), 1 deletion(-)
+```
+
+## 4. QA Log
+
+_(no review round yet)_
+
+## 5. Timeline
+
+
+---
+_Auto-assembled by the niwa scribe from the Q&A gate. Task `88510cb5-309d-478c-b60e-b8311aee2eb9`._

--- a/internal/relay/handlers_tasks.go
+++ b/internal/relay/handlers_tasks.go
@@ -892,6 +892,51 @@ func (h *Handlers) HandleUpdateTask(ctx context.Context, req mcp.CallToolRequest
 		}
 	}
 
+	// Typed-field validation (silent-drop fix, task 88510cb5). GetString silently
+	// falls back to "" when an arg is present but the wrong JSON type, so a
+	// mistyped value used to be DROPPED with a 200 + bumped last_activity_at and
+	// no error (live repro 3ad80aae: acceptance_criteria as a native array kept
+	// the old ACs and dropped the progress_note in the same call). Refuse every
+	// string field that is present with a non-string value — atomically, BEFORE
+	// any write, naming the field and the expected type. acceptance_criteria
+	// additionally accepts a native array of strings, coerced to its canonical
+	// JSON-string form, for parity with batch_dispatch_tasks' ergonomics.
+	args := req.GetArguments()
+	for _, f := range []string{"title", "description", "priority", "board_id", "assigned_to", "profile_slug", "progress_note", "goal", "dod", "verify_cmd"} {
+		if raw, given := args[f]; given {
+			if _, ok := raw.(string); !ok {
+				return validationError(CodeInvalidArgument, fmt.Sprintf(
+					"%s must be a string (got %#v)", f, raw)), nil
+			}
+		}
+	}
+	var acOverride *string
+	if raw, given := args["acceptance_criteria"]; given {
+		switch v := raw.(type) {
+		case string:
+			// A JSON-string value keeps the existing JSON-array validation below.
+		case []any:
+			items := make([]string, 0, len(v))
+			for i, el := range v {
+				s, ok := el.(string)
+				if !ok {
+					return validationError(CodeInvalidArgument, fmt.Sprintf(
+						"acceptance_criteria[%d] must be a string (got %#v) — the array is neither coerced nor dropped", i, el)), nil
+				}
+				items = append(items, s)
+			}
+			canon, mErr := json.Marshal(items)
+			if mErr != nil {
+				return validationError(CodeInvalidArgument, fmt.Sprintf("acceptance_criteria could not be encoded: %v", mErr)), nil
+			}
+			s := string(canon)
+			acOverride = &s
+		default:
+			return validationError(CodeInvalidArgument, fmt.Sprintf(
+				"acceptance_criteria must be a JSON string or an array of strings (got %#v)", raw)), nil
+		}
+	}
+
 	assignedTo := optionalString(strings.TrimSpace(req.GetString("assigned_to", "")))
 	profileSlug := optionalString(strings.TrimSpace(req.GetString("profile_slug", "")))
 
@@ -901,7 +946,10 @@ func (h *Handlers) HandleUpdateTask(ctx context.Context, req mcp.CallToolRequest
 	boardID := optionalString(req.GetString("board_id", ""))
 	progressNote := req.GetString("progress_note", "")
 	goal := optionalString(req.GetString("goal", ""))
-	acceptanceCriteria := optionalString(req.GetString("acceptance_criteria", ""))
+	acceptanceCriteria := acOverride
+	if acceptanceCriteria == nil {
+		acceptanceCriteria = optionalString(req.GetString("acceptance_criteria", ""))
+	}
 	dod := optionalString(req.GetString("dod", ""))
 	verifyCmd := optionalString(req.GetString("verify_cmd", ""))
 

--- a/internal/relay/update_task_typed_fields_test.go
+++ b/internal/relay/update_task_typed_fields_test.go
@@ -1,0 +1,130 @@
+package relay
+
+import (
+	"strings"
+	"testing"
+)
+
+// dispatchForTypedFieldTest dispatches a task as "cto" (so cto is the dispatcher
+// and may edit the contract) and returns its id.
+func dispatchForTypedFieldTest(t *testing.T, h *Handlers, title string) string {
+	t.Helper()
+	_, _ = h.HandleRegisterAgent(ctx, call(map[string]any{"project": "p1", "name": "cto", "role": "lead"}))
+	_, _ = h.HandleRegisterAgent(ctx, call(map[string]any{"project": "p1", "name": "dev-a", "role": "dev"}))
+	dispatchRes, _ := h.HandleDispatchTask(ctx, call(map[string]any{
+		"project": "p1", "as": "cto", "profile": "dev", "title": title,
+		"goal": "orig goal", "acceptance_criteria": `["orig ac"]`, "dod": "orig dod",
+	}))
+	if dispatchRes.IsError {
+		t.Fatalf("dispatch: %s", expectError(t, dispatchRes))
+	}
+	return parseJSON(t, dispatchRes)["task"].(map[string]any)["id"].(string)
+}
+
+// AC1: acceptance_criteria passed as a NATIVE array of strings is coerced to its
+// canonical JSON-string form and applied — and a progress_note in the SAME call
+// is applied too (the 3ad80aae repro shape that used to 200 + silently drop both).
+func TestUpdateTask_NativeArrayACCoercedWithProgressNote(t *testing.T) {
+	h := testHandlers(t)
+	taskID := dispatchForTypedFieldTest(t, h, "native array ac")
+
+	res, _ := h.HandleUpdateTask(ctx, call(map[string]any{
+		"project": "p1", "as": "cto", "task_id": taskID,
+		"acceptance_criteria": []any{"AC one thing", "AC two thing"},
+		"progress_note":       "made progress",
+	}))
+	if res.IsError {
+		t.Fatalf("native-array AC + progress_note should apply, got: %s", expectError(t, res))
+	}
+	const wantCanonical = `["AC one thing","AC two thing"]`
+	if got := parseJSON(t, res)["acceptance_criteria"]; got != wantCanonical {
+		t.Errorf("acceptance_criteria = %v, want canonical JSON-string %q", got, wantCanonical)
+	}
+
+	// The stored value (read back) is the canonical JSON string, not dropped.
+	getRes, _ := h.HandleGetTask(ctx, call(map[string]any{"project": "p1", "task_id": taskID}))
+	if got := parseJSON(t, getRes)["acceptance_criteria"]; got != wantCanonical {
+		t.Errorf("stored acceptance_criteria = %v, want %q", got, wantCanonical)
+	}
+
+	// The progress_note in the same call was applied, not dropped.
+	notes, err := h.db.GetProgressNotes(taskID, "p1")
+	if err != nil {
+		t.Fatalf("GetProgressNotes: %v", err)
+	}
+	found := false
+	for _, n := range notes {
+		if n.Note == "made progress" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("progress_note dropped: notes=%+v", notes)
+	}
+}
+
+// AC2: a wrong-typed value on a string field refuses INVALID_ARGUMENT naming the
+// field and the expected type, and NO field from the request is applied — atomic
+// refusal, last_activity_at unchanged (the valid sibling field does not land).
+func TestUpdateTask_WrongTypedStringFieldRefusedAtomically(t *testing.T) {
+	h := testHandlers(t)
+	taskID := dispatchForTypedFieldTest(t, h, "atomic refusal")
+
+	before, _ := h.db.GetTask(taskID, "p1")
+	beforeLA := ""
+	if before.LastActivityAt != nil {
+		beforeLA = *before.LastActivityAt
+	}
+
+	// title is the wrong type (a number); description is a valid sibling edit that
+	// must NOT be applied because the whole request is refused atomically.
+	res, _ := h.HandleUpdateTask(ctx, call(map[string]any{
+		"project": "p1", "as": "cto", "task_id": taskID,
+		"title":       42,
+		"description": "should not be applied",
+	}))
+	msg := expectError(t, res)
+	if !strings.Contains(msg, "title") {
+		t.Errorf("refusal must name the field 'title', got: %s", msg)
+	}
+	if !strings.Contains(msg, "string") {
+		t.Errorf("refusal must name the expected type 'string', got: %s", msg)
+	}
+
+	after, _ := h.db.GetTask(taskID, "p1")
+	if after.Description == "should not be applied" {
+		t.Error("the valid sibling field was applied despite the atomic refusal")
+	}
+	if after.Title != before.Title {
+		t.Errorf("title changed on a refused request: %q -> %q", before.Title, after.Title)
+	}
+	afterLA := ""
+	if after.LastActivityAt != nil {
+		afterLA = *after.LastActivityAt
+	}
+	if afterLA != beforeLA {
+		t.Errorf("last_activity_at changed on a refused request: %q -> %q", beforeLA, afterLA)
+	}
+}
+
+// AC3: acceptance_criteria as an array containing a non-string element is refused
+// INVALID_ARGUMENT naming the field — neither coerced nor dropped.
+func TestUpdateTask_ACArrayWithNonStringRefused(t *testing.T) {
+	h := testHandlers(t)
+	taskID := dispatchForTypedFieldTest(t, h, "ac non-string element")
+
+	res, _ := h.HandleUpdateTask(ctx, call(map[string]any{
+		"project": "p1", "as": "cto", "task_id": taskID,
+		"acceptance_criteria": []any{"ok item", 5},
+	}))
+	msg := expectError(t, res)
+	if !strings.Contains(msg, "acceptance_criteria") {
+		t.Errorf("refusal must name 'acceptance_criteria', got: %s", msg)
+	}
+
+	// Untouched: the original contract stands (not coerced to a partial, not dropped).
+	getRes, _ := h.HandleGetTask(ctx, call(map[string]any{"project": "p1", "task_id": taskID}))
+	if got := parseJSON(t, getRes)["acceptance_criteria"]; got != `["orig ac"]` {
+		t.Errorf("acceptance_criteria must be unchanged after refusal, got: %v", got)
+	}
+}


### PR DESCRIPTION
### niwa Q&A gate

An adversarial reviewer is reading this diff right now. Its verdict lands on this PR as a review (or a comment when the gate and the author share one GitHub account), and the merge waits for this repository's own checks to go green.

*Opened automatically — a rejected round comes back to the author, who pushes fixes to the same branch.*

## What & why

- **docs(scribe): provenance for wraith-relay-update-task-typed-field-validation-native-array-acceptance-criteria**
- **fix(relay): update_task typed-field validation (no silent drop)**
  <details><summary>details</summary>

  HandleUpdateTask read every field via req.GetString, which silently falls
  back to "" when an arg is present but the wrong JSON type. A native-array
  acceptance_criteria resolved to "" -> nil and was dropped with a 200 +
  bumped last_activity_at and no error (live repro 3ad80aae); a mistyped
  value on any string field was likewise dropped. batch_dispatch_tasks
  accepts real arrays for the same field, making the asymmetry a trap.
  
  Add a typed-field validation pass before any write:
  - every string field present with a non-string value is refused
    INVALID_ARGUMENT naming the field + expected type;
  - acceptance_criteria additionally accepts a native array of strings,
    coerced to its canonical JSON-string form (batch_dispatch parity);
  - an AC array with a non-string element is refused, not coerced/dropped.
  Validation precedes UpdateTaskFields/reassign/AddProgressNote, so a
  refusal is atomic (no partial apply, last_activity_at unchanged).
  
  Tests: TestUpdateTask_NativeArrayACCoercedWithProgressNote,
  TestUpdateTask_WrongTypedStringFieldRefusedAtomically,
  TestUpdateTask_ACArrayWithNonStringRefused.
  
  Task: 88510cb5-309d-478c-b60e-b8311aee2eb9
  
  Claude-Session: https://claude.ai/code/session_01C3hsyCeR5poTZTLmaWuyTf

  </details>

## Changes

<details><summary>Files changed (git diff --stat)</summary>

```
...-validation-native-array-acceptance-criteria.md |  46 ++++++++
 internal/relay/handlers_tasks.go                   |  50 +++++++-
 internal/relay/update_task_typed_fields_test.go    | 130 +++++++++++++++++++++
 3 files changed, 225 insertions(+), 1 deletion(-)
```

</details>

## Acceptance criteria

- [ ] AC1 named test: update_task with acceptance_criteria as a native array of strings applies — stored value equals the canonical JSON-string form, and a progress_note in the same call is applied too (the 3ad80aae repro shape)
- [ ] AC2 named test: update_task with a wrong-typed value on a string field refuses INVALID_ARGUMENT naming the field and expected type; no field from that request is applied (atomic refusal, last_activity_at unchanged)
- [ ] AC3 named test: acceptance_criteria as an array containing a non-string element refuses INVALID_ARGUMENT naming the field — not coerced, not dropped

## Provenance

📄 [Root cause, decisions &amp; QA log — `features/wraith-relay-update-task-typed-field-validation-native-array-acceptance-criteria.md`](https://github.com/TsukumoHQ/WRAI.TH/blob/wraith-backend/update-task-typed-fields/features/wraith-relay-update-task-typed-field-validation-native-array-acceptance-criteria.md)

## Self-review

## review-wraith verdict: SHIP
Scope: internal/relay/handlers_tasks.go (HandleUpdateTask typed-field pass), internal/relay/update_task_typed_fields_test.go (new)
Gate: build -tags fts5 OK / vet OK / gofmt OK / test -tags fts5 -count=1 OK (832 pass, full ./...)

BLOCKERS (must fix before merge):
- none

NITS (non-blocking):
- No schema/migration, no new writer, no new tool/route — validation-only in an existing handler; middleware/auth/permission model untouched. Backward-compatible: a JSON-string acceptance_criteria keeps the existing json.Unmarshal array validation (existing TestUpdateTask_DispatcherRescopesContract_Audited still green). Atomicity proven by AC2 (sibling valid field + last_activity_at unchanged on refusal). Failure-is-loud satisfied: AC2/AC3 assert the refusal message names the field.
- DoD note: after the next agent-relay redeploy, the niwa memory key `niwa-update-task-ac-must-be-json-string` (the string-only workaround) is obsolete and should be retired by the dispatcher.

---
<sub>Authored by agent `wraith-backend` · branch `wraith-backend/update-task-typed-fields` → `main` · reviewed by niwa-gate and merged when this repo's checks pass.</sub>