### PR TITLE
[wraith/relay] typed validation for routing params: mistyped as/project/task_id refuses — never silently coerces to default identity/project

### DIFF
--- a/features/wraith-relay-typed-validation-for-routing-params-mistyped-as-project-task-id-ref.md
+++ b/features/wraith-relay-typed-validation-for-routing-params-mistyped-as-project-task-id-ref.md
@@ -1,0 +1,52 @@
+# [wraith/relay] typed validation for routing params: mistyped as/project/task_id refuses — never silently coerces to default identity/project
+
+## Team : wraith-backend (tsukumo)
+## Branch : fix/routing-param-typed-validation (from main)
+## Relay task : 2540e596-354b-459a-9125-592301f9b8b8
+## Status : 🔵 SUBMITTED
+
+## 1. Product Brief
+
+### Acceptance Criteria
+- [ ] 1. AC1 named test: a tool call with `as` present as a non-string refuses INVALID_ARGUMENT naming 'as'; nothing executes (no row written, no message sent)
+- [ ] 2. AC2 named test: `project` present as a non-string refuses identically — the call never resolves to the default project namespace
+- [ ] 3. AC3 named test: absent as/project keep today's default-resolution behavior byte-identical (regression guard)
+- [ ] 4. AC4 named test: task_id present as a non-string on a task tool refuses naming 'task_id' instead of a NOT_FOUND or empty-id lookup
+
+## 2. Root cause & decisions
+
+# Decision — task 2540e596 typed validation for routing params
+
+ROOT_CAUSE: resolveAgent (handlers.go) and resolveProject (project_ns.go) read `as`/`project` via mcp GetString, and every task handler reads `task_id` the same way. GetString silently folds a present-but-non-string value (a native array, a number, a JSON null) to "". For these three routing params that "" then resolves to the DEFAULT identity/project (context or single-registration fallback) or an empty task lookup — so a mistyped `as`/`project` made the call EXECUTE under the wrong identity or in the wrong project namespace (silent misroute / potential cross-project write), and a mistyped `task_id` degraded into a NOT_FOUND. Same silent-coercion family as 88510cb5 (content fields) but with a worse blast radius.
+
+FIX: a single shared seam. `guardRoutingParamTypes` wraps every toolRegistry handler OUTERMOST — applied after the guardIdentity loop so it runs BEFORE guardIdentity and any resolveProject/resolveAgent/resolveTaskID call. A present-but-non-string `as`/`project`/`task_id` is refused with INVALID_ARGUMENT (CategoryValidation, non-retryable) naming the param, before any write. An ABSENT param is untouched (given == false), so context/registration default-resolution is byte-identical to before. Applied to EVERY tool (reads route namespace/identity too); call_tool/discover_tools are registered separately and carry no routing params at their top level, and call_tool's inner dispatch runs through these same wrapped handlers, so nested calls are covered.
+
+## review-wraith verdict: SHIP
+Scope: internal/relay/toolset.go (guardRoutingParamTypes + wiring in toolRegistry), internal/relay/routing_param_types_test.go (4 tests)
+Gate: build -tags fts5 OK / vet -tags fts5 OK / gofmt OK / test -tags fts5 OK (836 passed)
+
+BLOCKERS (must fix before merge):
+- none
+
+NITS (non-blocking):
+- none
+
+Notes on the shared-backbone invariants: no DB write added (pure pre-dispatch type check) — single-writer + lock discipline untouched; no schema/migration change (agentColumns↔scanAgent untouched); no task-transition change (no TOCTOU surface); inbox stays non-destructive — AC1 asserts a refused send writes no row (recipient inbox empty); middleware order / auth untouched (guard sits at the tool-handler layer, after auth); MCP tool set still sourced from the single registry and does not bypass resolveProject/resolveAgent (it runs ahead of them and only refuses malformed input, else delegates).
+
+## 3. Files changed
+
+```
+internal/relay/routing_param_types_test.go | 138 +++++++++++++++++++++++++++++
+ internal/relay/toolset.go                  |  39 ++++++++
+ 2 files changed, 177 insertions(+)
+```
+
+## 4. QA Log
+
+_(no review round yet)_
+
+## 5. Timeline
+
+
+---
+_Auto-assembled by the niwa scribe from the Q&A gate. Task `2540e596-354b-459a-9125-592301f9b8b8`._

--- a/features/wraith-relay-typed-validation-for-routing-params-mistyped-as-project-task-id-ref.md
+++ b/features/wraith-relay-typed-validation-for-routing-params-mistyped-as-project-task-id-ref.md
@@ -21,6 +21,22 @@ ROOT_CAUSE: resolveAgent (handlers.go) and resolveProject (project_ns.go) read `
 
 FIX: a single shared seam. `guardRoutingParamTypes` wraps every toolRegistry handler OUTERMOST — applied after the guardIdentity loop so it runs BEFORE guardIdentity and any resolveProject/resolveAgent/resolveTaskID call. A present-but-non-string `as`/`project`/`task_id` is refused with INVALID_ARGUMENT (CategoryValidation, non-retryable) naming the param, before any write. An ABSENT param is untouched (given == false), so context/registration default-resolution is byte-identical to before. Applied to EVERY tool (reads route namespace/identity too); call_tool/discover_tools are registered separately and carry no routing params at their top level, and call_tool's inner dispatch runs through these same wrapped handlers, so nested calls are covered.
 
+## Round 2 — AC4 test strengthened (reviewer finding, r1 REJECTED)
+r1 marked AC1/AC2/AC3 green; AC4 partial. Finding: every task handler already
+short-circuits an empty task_id ("task_id is required" → INVALID_ARGUMENT, no
+lookup), so TestRoutingParams_TaskIDNonStringRefused passed on pre-fix code and
+pinned nothing (rule (e)). Reviewer offered two fixes: strengthen the assertion,
+or drop task_id from the guard as redundant.
+Chosen: KEEP task_id + strengthen. task_id is an explicit ticket AC (AC4 names a
+task_id test), and the guard is a genuine improvement — for a value that WAS
+supplied but wrong-typed, "task_id is required" is a misleading error, the exact
+silent-coercion family this ticket fixes; the guard reports the accurate
+"task_id must be a string" uniformly at one seam (also covering any future
+task_id-reading tool, not just today's 15 handlers). The test now asserts the
+guard's distinctive "must be a string" message; revert-check confirmed: removing
+task_id from routingParamKeys FAILS the test (routing_param_types_test.go:150).
+No production code changed round 2 — test-only strengthening; 836 pass.
+
 ## review-wraith verdict: SHIP
 Scope: internal/relay/toolset.go (guardRoutingParamTypes + wiring in toolRegistry), internal/relay/routing_param_types_test.go (4 tests)
 Gate: build -tags fts5 OK / vet -tags fts5 OK / gofmt OK / test -tags fts5 OK (836 passed)
@@ -36,17 +52,23 @@ Notes on the shared-backbone invariants: no DB write added (pure pre-dispatch ty
 ## 3. Files changed
 
 ```
-internal/relay/routing_param_types_test.go | 138 +++++++++++++++++++++++++++++
- internal/relay/toolset.go                  |  39 ++++++++
- 2 files changed, 177 insertions(+)
+...uting-params-mistyped-as-project-task-id-ref.md |  52 +++++++
+ internal/relay/routing_param_types_test.go         | 152 +++++++++++++++++++++
+ internal/relay/toolset.go                          |  39 ++++++
+ 3 files changed, 243 insertions(+)
 ```
 
 ## 4. QA Log
 
-_(no review round yet)_
+### Round 1 — ❌ REJECTED by review-2540e596-354b-459a-9125-592301f9b8b8 @ `840505940`
+- 🟢 AC1: test exercises the registry-wrapped send_message handler with as:[]any{"sender"}; refusal message names as and carries CodeInvalidArgument; recipient inbox asserted empty (no row written) — evidence: internal/relay/toolset.go:230-232 wraps every handler with guardRoutingParamTypes; removing the guard wrap makes TestRoutingParams_AsNonStringRefusedNothingSent fail with INTERNAL instead of INVALID_ARGUMENT — test: TestRoutingParams_AsNonStringRefusedNothingSent internal/relay/routing_param_types_test.go:28
+- 🟢 AC2: test sends project:42; without guard the call resolves to sender sole registration and executes; with guard refused INVALID_ARGUMENT naming project before any resolution — evidence: internal/relay/toolset.go:230-232 + project_ns.go:33 (resolveProject falls through to single-registration default when GetString folds project:42 to ""); removing the guard makes TestRoutingParams_ProjectNonStringRefused fail with success (silent misroute to default project) — test: TestRoutingParams_ProjectNonStringRefused internal/relay/routing_param_types_test.go:60
+- 🟢 AC3: regression guard: absent keys untouched (given==false), valid string keys pass through; default-resolution byte-identical to pre-fix — evidence: internal/relay/toolset.go:248-261 guardRoutingParamTypes skips keys where given==false; TestRoutingParams_AbsentAndValidUnchanged asserts valid string params pass and absent project falls through to sender sole registration (2 messages delivered) — test: TestRoutingParams_AbsentAndValidUnchanged internal/relay/routing_param_types_test.go:84
+- 🔴 AC4: [partial] AC behavior (refuse INVALID_ARGUMENT naming task_id, not NOT_FOUND, no DB lookup) was already met by pre-fix `if taskID == "" { return toolResultError("task_id is required") }` in every task handler (handlers_tasks.go:15 sites); fix adds a redundant guard whose specific "must be a string" message is not exercised by any test — per rule (e) a test green before the fix pins nothing — evidence: internal/relay/toolset.go:242 lists task_id in routingParamKeys; TestRoutingParams_TaskIDNonStringRefused passes even when task_id is removed from the list — the test pins the AC observable behavior but not the new code path — test: TestRoutingParams_TaskIDNonStringRefused internal/relay/routing_param_types_test.go:118
 
 ## 5. Timeline
 
+- round 1 → **reject** (review-2540e596-354b-459a-9125-592301f9b8b8)
 
 ---
 _Auto-assembled by the niwa scribe from the Q&A gate. Task `2540e596-354b-459a-9125-592301f9b8b8`._

--- a/internal/relay/routing_param_types_test.go
+++ b/internal/relay/routing_param_types_test.go
@@ -115,6 +115,15 @@ func TestRoutingParams_AbsentAndValidUnchanged(t *testing.T) {
 // AC4: task_id present as a non-string on a task tool refuses naming 'task_id'
 // instead of degrading into a NOT_FOUND / empty-id lookup (GetString would coerce
 // it to "" and the handler would report task_id required or not found).
+//
+// The task handlers already short-circuit an EMPTY task_id ("task_id is
+// required"), so asserting only INVALID_ARGUMENT + names-task_id would pass on
+// pre-fix code and pin nothing (round-1 reviewer finding). The distinguishing
+// assertion is the GUARD's own message, "must be a string": pre-fix a coerced ""
+// yields "task_id is required" (the misleading required-error for a value that
+// WAS supplied, just wrong-typed); only guardRoutingParamTypes reports the type.
+// Removing task_id from routingParamKeys therefore fails THIS test — it pins the
+// new code path, not the pre-existing empty-check.
 func TestRoutingParams_TaskIDNonStringRefused(t *testing.T) {
 	h := testHandlers(t)
 	_, _ = h.HandleRegisterAgent(ctx, call(map[string]any{"project": "p1", "name": "dev-a", "role": "dev"}))
@@ -134,5 +143,10 @@ func TestRoutingParams_TaskIDNonStringRefused(t *testing.T) {
 	}
 	if strings.Contains(msg, CodeNotFound) {
 		t.Errorf("a non-string task_id must refuse before the lookup, not report %s: %s", CodeNotFound, msg)
+	}
+	// Pins the guard specifically: the type-refusal message, not the handler's
+	// pre-existing "task_id is required" empty-check (which a coerced "" would hit).
+	if !strings.Contains(msg, "must be a string") {
+		t.Errorf("refusal must be the routing-param type guard (\"must be a string\"), not the pre-existing empty-check, got: %s", msg)
 	}
 }

--- a/internal/relay/routing_param_types_test.go
+++ b/internal/relay/routing_param_types_test.go
@@ -1,0 +1,138 @@
+package relay
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/server"
+)
+
+// wrappedTool returns the toolRegistry handler for name — the SAME wrapped
+// handler the MCP server dispatches to in production (guardRoutingParamTypes
+// applied). Calling a handler method directly (h.HandleSendMessage) would bypass
+// the wrapper, so the routing-param guard must be exercised through this seam.
+func wrappedTool(t *testing.T, h *Handlers, name string) server.ToolHandlerFunc {
+	t.Helper()
+	for _, rt := range h.toolRegistry() {
+		if rt.Tool.Name == name {
+			return rt.Handler
+		}
+	}
+	t.Fatalf("tool %q not found in registry", name)
+	return nil
+}
+
+// AC1: a tool call with `as` present as a non-string refuses INVALID_ARGUMENT
+// naming 'as'; nothing executes — no message is sent (the refusal is before any
+// write, so the intended recipient's inbox stays empty).
+func TestRoutingParams_AsNonStringRefusedNothingSent(t *testing.T) {
+	h := testHandlers(t)
+	_, _ = h.HandleRegisterAgent(ctx, call(map[string]any{"project": "p1", "name": "sender", "role": "dev"}))
+	_, _ = h.HandleRegisterAgent(ctx, call(map[string]any{"project": "p1", "name": "recipient", "role": "dev"}))
+
+	send := wrappedTool(t, h, "send_message")
+	res, _ := send(ctx, call(map[string]any{
+		"project": "p1",
+		"as":      []any{"sender"}, // present but a native array, not a string
+		"to":      "recipient",
+		"content": "should never be delivered",
+	}))
+	msg := expectError(t, res)
+	if !strings.Contains(msg, "as") {
+		t.Errorf("refusal must name the param 'as', got: %s", msg)
+	}
+	if !strings.Contains(msg, CodeInvalidArgument) {
+		t.Errorf("refusal must carry %s, got: %s", CodeInvalidArgument, msg)
+	}
+
+	// Nothing executed: the recipient's inbox is empty (no row written).
+	inbox := wrappedTool(t, h, "get_inbox")
+	inboxRes, _ := inbox(ctx, call(map[string]any{"project": "p1", "as": "recipient", "format": "json"}))
+	got := parseJSON(t, inboxRes)
+	if msgs, ok := got["messages"].([]any); ok && len(msgs) != 0 {
+		t.Errorf("no message should have been sent, inbox has %d", len(msgs))
+	}
+}
+
+// AC2: `project` present as a non-string refuses identically — the call never
+// resolves to the default project namespace (GetString would coerce it to "" and
+// resolveProject would fall through to the context/registration default).
+func TestRoutingParams_ProjectNonStringRefused(t *testing.T) {
+	h := testHandlers(t)
+	_, _ = h.HandleRegisterAgent(ctx, call(map[string]any{"project": "p1", "name": "sender", "role": "dev"}))
+
+	send := wrappedTool(t, h, "send_message")
+	res, _ := send(ctx, call(map[string]any{
+		"project": 42, // present but a number, not a string
+		"as":      "sender",
+		"to":      "recipient",
+		"content": "misrouted?",
+	}))
+	msg := expectError(t, res)
+	if !strings.Contains(msg, "project") {
+		t.Errorf("refusal must name the param 'project', got: %s", msg)
+	}
+	if !strings.Contains(msg, CodeInvalidArgument) {
+		t.Errorf("refusal must carry %s, got: %s", CodeInvalidArgument, msg)
+	}
+}
+
+// AC3: absent as/project keep today's default-resolution behavior byte-identical
+// — the guard only fires on a PRESENT non-string. A well-formed string as/project
+// still reaches the handler and executes; omitting project entirely still lets
+// resolveProject fall through to the caller's single-project registration.
+func TestRoutingParams_AbsentAndValidUnchanged(t *testing.T) {
+	h := testHandlers(t)
+	_, _ = h.HandleRegisterAgent(ctx, call(map[string]any{"project": "p1", "name": "sender", "role": "dev"}))
+	_, _ = h.HandleRegisterAgent(ctx, call(map[string]any{"project": "p1", "name": "recipient", "role": "dev"}))
+
+	send := wrappedTool(t, h, "send_message")
+
+	// Valid string as/project: passes the guard and delivers.
+	res, _ := send(ctx, call(map[string]any{
+		"project": "p1", "as": "sender", "to": "recipient", "content": "hello",
+	}))
+	if res.IsError {
+		t.Fatalf("valid string routing params must pass the guard, got: %s", expectError(t, res))
+	}
+
+	// project ABSENT: resolveProject falls through to sender's sole registration
+	// (p1) exactly as before — the guard must not refuse an absent param.
+	res2, _ := send(ctx, call(map[string]any{
+		"as": "sender", "to": "recipient", "content": "hello again",
+	}))
+	if res2.IsError {
+		t.Fatalf("absent project must keep default-resolution, got: %s", expectError(t, res2))
+	}
+	inbox := wrappedTool(t, h, "get_inbox")
+	inboxRes, _ := inbox(ctx, call(map[string]any{"project": "p1", "as": "recipient", "format": "json"}))
+	got := parseJSON(t, inboxRes)
+	if msgs, ok := got["messages"].([]any); !ok || len(msgs) != 2 {
+		t.Errorf("both valid + absent-project sends should deliver (want 2), got: %v", got["messages"])
+	}
+}
+
+// AC4: task_id present as a non-string on a task tool refuses naming 'task_id'
+// instead of degrading into a NOT_FOUND / empty-id lookup (GetString would coerce
+// it to "" and the handler would report task_id required or not found).
+func TestRoutingParams_TaskIDNonStringRefused(t *testing.T) {
+	h := testHandlers(t)
+	_, _ = h.HandleRegisterAgent(ctx, call(map[string]any{"project": "p1", "name": "dev-a", "role": "dev"}))
+
+	get := wrappedTool(t, h, "get_task")
+	res, _ := get(ctx, call(map[string]any{
+		"project": "p1",
+		"as":      "dev-a",
+		"task_id": []any{"abc123"}, // present but a native array, not a string
+	}))
+	msg := expectError(t, res)
+	if !strings.Contains(msg, "task_id") {
+		t.Errorf("refusal must name the param 'task_id', got: %s", msg)
+	}
+	if !strings.Contains(msg, CodeInvalidArgument) {
+		t.Errorf("refusal must carry %s (not NOT_FOUND / empty-id), got: %s", CodeInvalidArgument, msg)
+	}
+	if strings.Contains(msg, CodeNotFound) {
+		t.Errorf("a non-string task_id must refuse before the lookup, not report %s: %s", CodeNotFound, msg)
+	}
+}

--- a/internal/relay/toolset.go
+++ b/internal/relay/toolset.go
@@ -218,7 +218,46 @@ func (h *Handlers) toolRegistry() []registeredTool {
 			tools[i].Handler = h.guardIdentity(tools[i].Tool.Name, tools[i].Handler)
 		}
 	}
+	// Routing-param type guard (task 2540e596, sibling of 88510cb5). Wrapped
+	// OUTERMOST — before guardIdentity and every handler — so it runs before any
+	// project/agent/task resolution: a present-but-non-string as/project/task_id
+	// is refused, never GetString-coerced to "" and silently routed to the DEFAULT
+	// identity/project (or an empty task lookup). Applied to EVERY tool: project
+	// steers a read's namespace and `as` its inbox identity just as they steer a
+	// write's. call_tool/discover_tools are registered separately (relay.New) and
+	// carry no routing params at their top level; call_tool's INNER dispatch runs
+	// through these same wrapped handlers, so nested calls are covered.
+	for i := range tools {
+		tools[i].Handler = guardRoutingParamTypes(tools[i].Handler)
+	}
 	return tools
+}
+
+// routingParamKeys steer a call's identity, project namespace, and task target.
+// GetString silently folds a present-but-non-string value (an array, a number, a
+// JSON null) to "", which for these three would resolve the call to the DEFAULT
+// identity/project or an empty task lookup — a silent misroute, a worse failure
+// than the dropped-field family fixed in 88510cb5 because the call would then
+// EXECUTE under the wrong identity or in the wrong project namespace.
+var routingParamKeys = []string{"as", "project", "task_id"}
+
+// guardRoutingParamTypes refuses a present-but-non-string as/project/task_id with
+// INVALID_ARGUMENT naming the param, BEFORE the wrapped handler runs any
+// resolution or write. An ABSENT param is untouched (given == false), so
+// context/registration default-resolution is byte-identical to before.
+func guardRoutingParamTypes(next server.ToolHandlerFunc) server.ToolHandlerFunc {
+	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		args := req.GetArguments()
+		for _, k := range routingParamKeys {
+			if raw, given := args[k]; given {
+				if _, ok := raw.(string); !ok {
+					return validationError(CodeInvalidArgument, fmt.Sprintf(
+						"%s must be a string (got %#v) — it steers identity/project/task routing and is never coerced to a default", k, raw)), nil
+				}
+			}
+		}
+		return next(ctx, req)
+	}
 }
 
 // livenessGatedTools carry the T2 sender-liveness gate: a non-service sender


### PR DESCRIPTION
### niwa Q&A gate

An adversarial reviewer is reading this diff right now. Its verdict lands on this PR as a review (or a comment when the gate and the author share one GitHub account), and the merge waits for this repository's own checks to go green.

*Opened automatically — a rejected round comes back to the author, who pushes fixes to the same branch.*

## What & why

- **docs(scribe): provenance for wraith-relay-typed-validation-for-routing-params-mistyped-as-project-task-id-ref**
- **fix: [wraith/relay] typed validation for routing params as/project/task_id**
  <details><summary>details</summary>

  Refuse a present-but-non-string as/project/task_id with INVALID_ARGUMENT
  naming the param, at a single shared seam wrapping every toolRegistry
  handler outermost — before guardIdentity and any resolveProject/
  resolveAgent/resolveTaskID call. GetString silently folds a non-string
  (array/number/null) to "", which for these three routing params resolved
  the call to the default identity/project or an empty task lookup: a silent
  misroute, sibling of 88510cb5's dropped-field family but with a worse blast
  radius (the call would execute under the wrong identity or in the wrong
  project namespace).
  
  An absent param is untouched, so default-resolution stays byte-identical.
  call_tool's inner dispatch runs through the same wrapped handlers, so nested
  calls are covered.
  
  Tests (go test -tags fts5 ./..., 836 pass):
  - TestRoutingParams_AsNonStringRefusedNothingSent
  - TestRoutingParams_ProjectNonStringRefused
  - TestRoutingParams_AbsentAndValidUnchanged
  - TestRoutingParams_TaskIDNonStringRefused
  
  Claude-Session: https://claude.ai/code/session_01C3hsyCeR5poTZTLmaWuyTf

  </details>

## Changes

<details><summary>Files changed (git diff --stat)</summary>

```
...uting-params-mistyped-as-project-task-id-ref.md |  52 ++++++++
 internal/relay/routing_param_types_test.go         | 138 +++++++++++++++++++++
 internal/relay/toolset.go                          |  39 ++++++
 3 files changed, 229 insertions(+)
```

</details>

## Acceptance criteria

- [ ] AC1 named test: a tool call with `as` present as a non-string refuses INVALID_ARGUMENT naming 'as'; nothing executes (no row written, no message sent)
- [ ] AC2 named test: `project` present as a non-string refuses identically — the call never resolves to the default project namespace
- [ ] AC3 named test: absent as/project keep today's default-resolution behavior byte-identical (regression guard)
- [ ] AC4 named test: task_id present as a non-string on a task tool refuses naming 'task_id' instead of a NOT_FOUND or empty-id lookup

## Provenance

📄 [Root cause, decisions &amp; QA log — `features/wraith-relay-typed-validation-for-routing-params-mistyped-as-project-task-id-ref.md`](https://github.com/TsukumoHQ/WRAI.TH/blob/fix/routing-param-typed-validation/features/wraith-relay-typed-validation-for-routing-params-mistyped-as-project-task-id-ref.md)

## Self-review

## review-wraith verdict: SHIP
Scope: internal/relay/toolset.go (guardRoutingParamTypes + wiring in toolRegistry), internal/relay/routing_param_types_test.go (4 tests)
Gate: build -tags fts5 OK / vet -tags fts5 OK / gofmt OK / test -tags fts5 OK (836 passed)

BLOCKERS (must fix before merge):
- none

NITS (non-blocking):
- none

Notes on the shared-backbone invariants: no DB write added (pure pre-dispatch type check) — single-writer + lock discipline untouched; no schema/migration change (agentColumns↔scanAgent untouched); no task-transition change (no TOCTOU surface); inbox stays non-destructive — AC1 asserts a refused send writes no row (recipient inbox empty); middleware order / auth untouched (guard sits at the tool-handler layer, after auth); MCP tool set still sourced from the single registry and does not bypass resolveProject/resolveAgent (it runs ahead of them and only refuses malformed input, else delegates).

---
<sub>Authored by agent `wraith-backend` · branch `fix/routing-param-typed-validation` → `main` · reviewed by niwa-gate and merged when this repo's checks pass.</sub>