### PR TITLE
[wraith/relay] project-lifecycle executive arm: archive/unarchive/delete_project by an executive registered elsewhere — unblocks archiving the retired 'default' project

### DIFF
--- a/.niwa-decision.md
+++ b/.niwa-decision.md
@@ -1,0 +1,40 @@
+# [wraith/relay] project-lifecycle executive arm
+
+Task: 05936947-cfad-4509-9860-527d35157a03
+
+ROOT_CAUSE: `archive_project`/`unarchive_project`/`delete_project` are gated by `guardIdentity`, which resolves the project from the SAME `project` arg the tool uses as its TARGET, then requires the caller to be registered in that project (toolset.go, "agent %q is not registered in project %q"). The retired 'default' catch-all refuses registration by design (`anonymousRefusedError`), so no one can ever be registered there — making 'default' (and any zero-agent shell) permanently unarchivable. Deadlock: the only tool that could retire the project cannot be called against it by anyone.
+
+DECISION: Add a narrow executive arm at the `agent == nil` seam in `guardIdentity`. `projectLifecycleTools = {archive_project, unarchive_project, delete_project}`. When the tool is one of these AND the caller is not registered in the target project, `callerIsActiveExecutive(from)` looks the caller up across projects (reusing `ProjectsOfAgent` + `GetAgent`, both read-pool; no new query, no wide-table column touched); if ANY row for `from` is `status='active'` and `is_executive`, the call is allowed and a `RecordAudit{Action:'project.lifecycle.admin', Actor:from, Project:targetProject, Reason:'executive arm from project <home>'}` row is written, then it flows to the handler. Every other unregistered caller — including a non-executive — falls through to today's unchanged refusal. A caller registered in the target project never takes the new path (byte-identical behavior). `create_project` is intentionally absent (bootstrap tool, never wrapped). `anonymousRefusedError` and `refuseIfArchived` untouched, per the founder directive (no anonymous agents) and DEC-wraith-archive-project-1.
+
+Scope: `internal/relay/toolset.go` + one new test file `internal/relay/project_lifecycle_exec_test.go`.
+
+Verification: `go build -tags fts5 ./...` OK, `go vet -tags fts5 ./internal/relay` OK, `gofmt -l` clean, `go test -tags fts5 ./...` green.
+- AC1: TestLifecycleArm_RemoteExecutiveArchives — exec in 'home' archives 'target-b' (unregistered there), audit row names actor+target+home. TestLifecycleArm_RemoteExecutiveArchivesDefault — target may be 'default'.
+- AC1 revert-check: neutering the `projectLifecycleTools` branch (`if false && …`) turns TestLifecycleArm_RemoteExecutiveArchives red with the exact "is not registered in project" refusal; restored → green.
+- AC2: TestLifecycleArm_NonExecutiveRefused — non-exec refused with unchanged text, no audit row.
+- AC3: TestLifecycleArm_RegisteredCallerUnchanged — caller registered in target archives as today, arm does not fire (no arm audit); existing archived_project_test.go stays green.
+- AC4: TestLifecycleArm_UnarchiveAndDelete — remote exec unarchives; delete purges an archived target but still refuses a non-archived one ("archive_project it first", enforced by the handler after the guard passes).
+
+Out of scope: the actual archive of 'default' (cto-tsukumo runs it after redeploy).
+
+GOTCHA recorded: a Go test file named `*_arm_test.go` is silently EXCLUDED from the build on non-arm GOARCH — go reads the `_arm` segment as an implicit `GOARCH=arm` build constraint (we build arm64). The file's tests never compile and `go test -run` reports "no tests to run" with no error. Original name `project_lifecycle_arm_test.go` hit this; renamed to `project_lifecycle_exec_test.go`. Avoid GOOS/GOARCH tokens (arm, amd64, arm64, linux, darwin, windows, …) as trailing filename segments before `_test.go`.
+
+Rejected alternatives:
+- New DB method `FindExecutiveAgentByName` in internal/db/agents.go: would push the diff to a 3rd file (triggering [split]) for no gain — `ProjectsOfAgent` + `GetAgent` already give the cross-project-by-name lookup using the read pool.
+- Exempting 'default' from anonymousRefusedError so an agent could register there and archive it: rejected — founder directive is no anonymous/default registrations; the arm keeps that refusal intact.
+- Checking is_executive in the handler instead of the guard: the guard is the single seam that already refuses unregistered callers; the handler has no identity context and adding it there duplicates resolution.
+
+Security note (for the reviewer): the arm skips the best-effort session-binding anti-theft check (it early-returns `next`), but that check only proves impersonation when the connection is bound to a different agent IN THE TARGET project — a cross-project caller is never bound there, so the check is inapplicable and skipping it changes nothing. The arm trusts the `as` identity exactly as the existing model already does for every registered call (session binding is documented fail-open). No new attack-surface class; the arm is is_executive-gated and audited.
+
+## review-wraith verdict: SHIP-WITH-NITS
+Scope: internal/relay/toolset.go (guardIdentity seam + two helpers) + internal/relay/project_lifecycle_exec_test.go (new)
+Gate: build -tags fts5 OK / vet OK / gofmt OK / test -tags fts5 OK (full ./... green; internal/relay 9.9s)
+
+BLOCKERS (must fix before merge):
+- none
+
+NITS (non-blocking):
+- The arm early-returns `next(ctx, req)`, skipping the session-binding anti-theft check for lifecycle tools. As analysed above this is inapplicable cross-project (the caller is never session-bound in the target project), so behaviour is unchanged — noted only so the reviewer sees the skip is deliberate, not an oversight.
+- callerIsActiveExecutive is O(projects-of-caller) read-pool lookups; lifecycle tools are rare admin ops so this is not a hot path. No caching added on purpose (staleness would be worse than a few RO reads).
+
+Invariants checked: single-writer intact (only the existing best-effort RecordAudit writer path is used; lookups are read-pool). agentColumns/scanAgent untouched. No schema/migration. refuseIfArchived + anonymousRefusedError byte-identical. No new MCP tool; registry unchanged. Existing archived_project_test.go green.

--- a/features/wraith-relay-project-lifecycle-executive-arm-archive-unarchive-delete-project-by.md
+++ b/features/wraith-relay-project-lifecycle-executive-arm-archive-unarchive-delete-project-by.md
@@ -26,7 +26,7 @@ DECISION: Add a narrow executive arm at the `agent == nil` seam in `guardIdentit
 
 Scope: `internal/relay/toolset.go` + one new test file `internal/relay/project_lifecycle_exec_test.go`.
 
-Verification: `go build -tags fts5 ./...` OK, `go vet -tags fts5 ./internal/relay` OK, `gofmt -l` clean, `go test -tags fts5 ./...` green.
+Verification: `go build -tags fts5 ./...` OK, `go vet -tags fts5 ./internal/relay` OK, `gofmt -l` clean, `go test -tags fts5 ./...` green (rebased onto current main, full suite green).
 - AC1: TestLifecycleArm_RemoteExecutiveArchives — exec in 'home' archives 'target-b' (unregistered there), audit row names actor+target+home. TestLifecycleArm_RemoteExecutiveArchivesDefault — target may be 'default'.
 - AC1 revert-check: neutering the `projectLifecycleTools` branch (`if false && …`) turns TestLifecycleArm_RemoteExecutiveArchives red with the exact "is not registered in project" refusal; restored → green.
 - AC2: TestLifecycleArm_NonExecutiveRefused — non-exec refused with unchanged text, no audit row.
@@ -46,7 +46,7 @@ Security note (for the reviewer): the arm skips the best-effort session-binding 
 
 ## review-wraith verdict: SHIP-WITH-NITS
 Scope: internal/relay/toolset.go (guardIdentity seam + two helpers) + internal/relay/project_lifecycle_exec_test.go (new)
-Gate: build -tags fts5 OK / vet OK / gofmt OK / test -tags fts5 OK (full ./... green; internal/relay 9.9s)
+Gate: build -tags fts5 OK / vet OK / gofmt OK / test -tags fts5 OK (full ./... green after rebase onto current main)
 
 BLOCKERS (must fix before merge):
 - none
@@ -60,18 +60,26 @@ Invariants checked: single-writer intact (only the existing best-effort RecordAu
 ## 3. Files changed
 
 ```
-.niwa-decision.md                             |  40 ++++++
- internal/relay/project_lifecycle_exec_test.go | 180 ++++++++++++++++++++++++++
- internal/relay/toolset.go                     |  52 ++++++++
- 3 files changed, 272 insertions(+)
+...tive-arm-archive-unarchive-delete-project-by.md |  77 +++++++++
+ internal/relay/project_lifecycle_exec_test.go      | 180 +++++++++++++++++++++
+ internal/relay/toolset.go                          |  52 ++++++
+ 3 files changed, 309 insertions(+)
 ```
 
 ## 4. QA Log
 
-_(no review round yet)_
+### Round 1 — ✅ APPROVED by review-05936947-cfad-4509-9860-527d35157a03 @ `562342a89`
+- 🟢 AC1: AC1 audit row inspected via lifecycleAdminAudit helper, asserts actor=chief, project=target-b, reason contains home — evidence: internal/relay/toolset.go:445-455 adds projectLifecycleTools arm; testLogsTestLifecycleArm_RemoteExecutiveArchivesDefault PASS in 0.02s; revert-check: neutering `if projectLifecycleTools` to `if false && projectLifecycleTools` in /tmp copy turns the test red with exact `agent "chief" is not registered in project "target-b" — call register_agent first.` — test: TestLifecycleArm_RemoteExecutiveArchives + TestLifecycleArm_RemoteExecutiveArchivesDefault internal/relay/project_lifecycle_exec_test.go:38-89
+- 🟢 AC2: non-executive (worker) refused exactly as before, no arm audit, no archive side-effect — evidence: internal/relay/toolset.go:456 unchanged refusal text `agent %q is not registered in project %q — call register_agent first.`; expectNotRegistered helper asserts containment; archive NOT called (IsProjectArchived false) and zero arm audit rows — test: TestLifecycleArm_NonExecutiveRefused internal/relay/project_lifecycle_exec_test.go:91-105
+- 🟢 AC3: regression guard green; registered-caller path byte-identical (arm never fires) — evidence: TestLifecycleArm_RegisteredCallerUnchanged: caller registered in target takes agent!=nil path, archives successfully, zero arm audit rows; existing TestArchiveTaskRESTSuccessThenConflict + TestArchivedProjectRefusesRegisterDispatchSendClaim + TestArchiveBoard* + TestArchiveTasks all PASS pre-existing on main and still PASS in branch — test: TestLifecycleArm_RegisteredCallerUnchanged internal/relay/project_lifecycle_exec_test.go:108-124 + existing TestArchiveTaskREST* / TestArchivedProject* / TestArchiveBoard* / TestArchiveTasks internal/relay
+- 🟢 AC4: unarchive+delete take same arm; delete handler still enforces archived-first — evidence: TestLifecycleArm_UnarchiveAndDelete verifies all three: remote exec unarchives target-u (was archived), deletes archived target-d (purges), refuses delete on non-archived target-active with exact `archive_project it first` text — test: TestLifecycleArm_UnarchiveAndDelete internal/relay/project_lifecycle_exec_test.go:127-178
+- 🟢 AC5: scope contained; refusal paths byte-identical — evidence: git diff origin/main..fix/project-lifecycle-exec-arm --name-only: only internal/relay/toolset.go + internal/relay/project_lifecycle_exec_test.go (plus .niwa-decision.md + features/*.md scribe artifacts, non-code); grep confirms anonymousRefusedError at line 36 and refuseIfArchived at line 113/418 unchanged vs origin/main; TestRegisterRefusesAnonymousAndDefault PASS + all TestArchivedProject* PASS — test: TestRegisterRefusesAnonymousAndDefault + TestArchivedProject* internal/relay
 
 ## 5. Timeline
 
+- round 1 → **approve** (review-05936947-cfad-4509-9860-527d35157a03)
+
+**Approve-with-findings (follow-up):** go test -tags fts5 ./... 841 ok; TestLifecycleArm 5/5 ok; revert-check (arm neutered in /tmp copy) makes TestLifecycleArm_RemoteExecutiveArchives fail with exact 'is not registered in project' refusal; TestRegisterRefusesAnonymousAndDefault + archived-project suite green; scope toolset.go + 1 test file; anonymousRefusedError+refuseIfArchived untouched
 
 ---
 _Auto-assembled by the niwa scribe from the Q&A gate. Task `05936947-cfad-4509-9860-527d35157a03`._

--- a/features/wraith-relay-project-lifecycle-executive-arm-archive-unarchive-delete-project-by.md
+++ b/features/wraith-relay-project-lifecycle-executive-arm-archive-unarchive-delete-project-by.md
@@ -1,3 +1,21 @@
+# [wraith/relay] project-lifecycle executive arm: archive/unarchive/delete_project by an executive registered elsewhere — unblocks archiving the retired 'default' project
+
+## Team : wraith-backend (tsukumo)
+## Branch : fix/project-lifecycle-exec-arm (from main)
+## Relay task : 05936947-cfad-4509-9860-527d35157a03
+## Status : 🔵 SUBMITTED
+
+## 1. Product Brief
+
+### Acceptance Criteria
+- [ ] 1. AC1 named test: an is_executive agent registered only in project A calls archive_project project=B (no registration in B, B may be 'default') -> result archived:true, and an audit_log row Action='project.lifecycle.admin' names actor + target project + home project; revert-check: removing the executive arm makes the test fail with the 'is not registered in project' refusal
+- [ ] 2. AC2 named test: a NON-executive agent registered only in A calling archive_project project=B is refused with the existing 'is not registered in project' text — refusal text unchanged
+- [ ] 3. AC3 named test: caller registered in the target project archives as today (regression guard, path unchanged); existing archived_project_test.go + projects_archive_test.go stay green
+- [ ] 4. AC4 named test: unarchive_project and delete_project take the same arm (delete_project on an archived target by a remote executive succeeds; on a non-archived target still refuses 'archive_project it first')
+- [ ] 5. AC5 scope: diff touches internal/relay/toolset.go + one test file only; register_agent anonymous/default refusal and refuseIfArchived untouched
+
+## 2. Root cause & decisions
+
 # [wraith/relay] project-lifecycle executive arm
 
 Task: 05936947-cfad-4509-9860-527d35157a03
@@ -38,3 +56,22 @@ NITS (non-blocking):
 - callerIsActiveExecutive is O(projects-of-caller) read-pool lookups; lifecycle tools are rare admin ops so this is not a hot path. No caching added on purpose (staleness would be worse than a few RO reads).
 
 Invariants checked: single-writer intact (only the existing best-effort RecordAudit writer path is used; lookups are read-pool). agentColumns/scanAgent untouched. No schema/migration. refuseIfArchived + anonymousRefusedError byte-identical. No new MCP tool; registry unchanged. Existing archived_project_test.go green.
+
+## 3. Files changed
+
+```
+.niwa-decision.md                             |  40 ++++++
+ internal/relay/project_lifecycle_exec_test.go | 180 ++++++++++++++++++++++++++
+ internal/relay/toolset.go                     |  52 ++++++++
+ 3 files changed, 272 insertions(+)
+```
+
+## 4. QA Log
+
+_(no review round yet)_
+
+## 5. Timeline
+
+
+---
+_Auto-assembled by the niwa scribe from the Q&A gate. Task `05936947-cfad-4509-9860-527d35157a03`._

--- a/internal/relay/project_lifecycle_exec_test.go
+++ b/internal/relay/project_lifecycle_exec_test.go
@@ -1,0 +1,180 @@
+package relay
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// The project-lifecycle executive arm (task 05936947): archive/unarchive/
+// delete_project act ON a target project the caller need not be registered in.
+// guardIdentity's default rule (caller must be registered in the resolved ==
+// target project) makes a retired catch-all like 'default' — where registration
+// is refused by design — unarchivable forever. An ACTIVE executive registered
+// anywhere may run these three, audited; every other unregistered caller is
+// refused exactly as before.
+
+// expectNotRegistered asserts the unchanged bare-string refusal a caller not
+// registered in the target project gets.
+func expectNotRegistered(t *testing.T, res *mcp.CallToolResult) {
+	t.Helper()
+	msg := expectError(t, res)
+	if want := "is not registered in project"; !strings.Contains(msg, want) {
+		t.Fatalf("want %q refusal, got: %s", want, msg)
+	}
+}
+
+// lifecycleAdminAudit returns the project.lifecycle.admin audit rows recorded
+// against the target project (ResourceID is empty for these).
+func lifecycleAdminAudit(t *testing.T, h *Handlers, project string) []struct{ actor, proj, reason string } {
+	t.Helper()
+	rows, err := h.db.ListAudit(project, "", 50)
+	if err != nil {
+		t.Fatalf("ListAudit(%s): %v", project, err)
+	}
+	var out []struct{ actor, proj, reason string }
+	for _, e := range rows {
+		if e.Action == "project.lifecycle.admin" {
+			out = append(out, struct{ actor, proj, reason string }{e.Actor, e.Project, e.Reason})
+		}
+	}
+	return out
+}
+
+// TestLifecycleArm_RemoteExecutiveArchives (AC1): an is_executive agent
+// registered only in project A archives project B (no registration in B) and
+// an audit_log row Action=project.lifecycle.admin names actor + target + home.
+// Revert-check: deleting the projectLifecycleTools branch in guardIdentity turns
+// this red with the 'is not registered in project' refusal.
+func TestLifecycleArm_RemoteExecutiveArchives(t *testing.T) {
+	h := testHandlers(t)
+	registerActive(t, h, "home", "chief", map[string]any{"is_executive": true})
+	h.db.EnsureProject("target-b")
+
+	archive := guardedHandler(t, h, "archive_project")
+	res, _ := archive(ctx, call(map[string]any{"project": "target-b", "as": "chief"}))
+	if res.IsError {
+		t.Fatalf("remote executive must archive an unregistered project: %s", expectError(t, res))
+	}
+	if got := parseJSON(t, res)["archived"]; got != true {
+		t.Fatalf("archived != true: %v", got)
+	}
+	if !h.db.IsProjectArchived("target-b") {
+		t.Fatal("target-b should be archived")
+	}
+
+	audits := lifecycleAdminAudit(t, h, "target-b")
+	if len(audits) != 1 {
+		t.Fatalf("want exactly one project.lifecycle.admin audit row, got %d", len(audits))
+	}
+	a := audits[0]
+	if a.actor != "chief" || a.proj != "target-b" {
+		t.Fatalf("audit row must name actor=chief target=target-b, got actor=%q project=%q", a.actor, a.proj)
+	}
+	if !strings.Contains(a.reason, "home") {
+		t.Fatalf("audit reason must name the home project, got: %q", a.reason)
+	}
+}
+
+// TestLifecycleArm_RemoteExecutiveArchivesDefault (AC1, default variant): the
+// target may be 'default' — the exact project registration refuses by design,
+// so the arm is the only way to retire it.
+func TestLifecycleArm_RemoteExecutiveArchivesDefault(t *testing.T) {
+	h := testHandlers(t)
+	registerActive(t, h, "home", "chief", map[string]any{"is_executive": true})
+	h.db.EnsureProject("default")
+
+	archive := guardedHandler(t, h, "archive_project")
+	res, _ := archive(ctx, call(map[string]any{"project": "default", "as": "chief"}))
+	if res.IsError {
+		t.Fatalf("remote executive must archive 'default': %s", expectError(t, res))
+	}
+	if !h.db.IsProjectArchived("default") {
+		t.Fatal("default should be archived")
+	}
+}
+
+// TestLifecycleArm_NonExecutiveRefused (AC2): a NON-executive registered only in
+// A calling archive_project project=B is refused with the unchanged
+// 'is not registered in project' text, and no audit row is written.
+func TestLifecycleArm_NonExecutiveRefused(t *testing.T) {
+	h := testHandlers(t)
+	registerActive(t, h, "home", "worker", nil) // not executive
+	h.db.EnsureProject("target-b")
+
+	archive := guardedHandler(t, h, "archive_project")
+	res, _ := archive(ctx, call(map[string]any{"project": "target-b", "as": "worker"}))
+	expectNotRegistered(t, res)
+
+	if h.db.IsProjectArchived("target-b") {
+		t.Fatal("non-executive must not have archived target-b")
+	}
+	if n := len(lifecycleAdminAudit(t, h, "target-b")); n != 0 {
+		t.Fatalf("no arm audit expected for a refused non-executive, got %d", n)
+	}
+}
+
+// TestLifecycleArm_UnregisteredExecutiveOnlyPath: the arm is the ONLY new path.
+// An executive REGISTERED in the target project archives exactly as today (the
+// agent!=nil branch), and the executive arm does not fire (no arm audit row).
+func TestLifecycleArm_RegisteredCallerUnchanged(t *testing.T) {
+	h := testHandlers(t)
+	registerActive(t, h, "target-b", "chief", map[string]any{"is_executive": true})
+
+	archive := guardedHandler(t, h, "archive_project")
+	res, _ := archive(ctx, call(map[string]any{"project": "target-b", "as": "chief"}))
+	if res.IsError {
+		t.Fatalf("caller registered in the target archives as today: %s", expectError(t, res))
+	}
+	if !h.db.IsProjectArchived("target-b") {
+		t.Fatal("target-b should be archived")
+	}
+	if n := len(lifecycleAdminAudit(t, h, "target-b")); n != 0 {
+		t.Fatalf("registered-caller path must not take the executive arm (no arm audit), got %d", n)
+	}
+}
+
+// TestLifecycleArm_UnarchiveAndDelete (AC4): unarchive_project and delete_project
+// take the same arm. A remote executive unarchives an archived target; and
+// delete_project by a remote executive purges an archived target but still
+// refuses a non-archived one ('archive_project it first').
+func TestLifecycleArm_UnarchiveAndDelete(t *testing.T) {
+	h := testHandlers(t)
+	registerActive(t, h, "home", "chief", map[string]any{"is_executive": true})
+
+	// unarchive an archived target
+	h.db.EnsureProject("target-u")
+	if err := h.db.ArchiveProject("target-u"); err != nil {
+		t.Fatalf("archive target-u: %v", err)
+	}
+	unarchive := guardedHandler(t, h, "unarchive_project")
+	if r, _ := unarchive(ctx, call(map[string]any{"project": "target-u", "as": "chief"})); r.IsError {
+		t.Fatalf("remote executive must unarchive: %s", expectError(t, r))
+	}
+	if h.db.IsProjectArchived("target-u") {
+		t.Fatal("target-u should be unarchived")
+	}
+
+	// delete an archived target → purge
+	h.db.EnsureProject("target-d")
+	if err := h.db.ArchiveProject("target-d"); err != nil {
+		t.Fatalf("archive target-d: %v", err)
+	}
+	del := guardedHandler(t, h, "delete_project")
+	if r, _ := del(ctx, call(map[string]any{"project": "target-d", "as": "chief"})); r.IsError {
+		t.Fatalf("remote executive must delete an archived project: %s", expectError(t, r))
+	}
+	if h.db.IsProjectArchived("target-d") {
+		t.Fatal("target-d should be purged")
+	}
+
+	// delete a NON-archived target → the arm passes the guard but the handler
+	// still enforces archived-first.
+	h.db.EnsureProject("target-active")
+	res, _ := del(ctx, call(map[string]any{"project": "target-active", "as": "chief"}))
+	msg := expectError(t, res)
+	if !strings.Contains(msg, "archive_project it first") {
+		t.Fatalf("delete on a non-archived target must still refuse 'archive first', got: %s", msg)
+	}
+}

--- a/internal/relay/toolset.go
+++ b/internal/relay/toolset.go
@@ -60,6 +60,42 @@ var archivedRefusedTools = map[string]bool{
 	"claim_task":     true,
 }
 
+// projectLifecycleTools act ON a TARGET project the caller need not be
+// registered in (archive / unarchive / delete). guardIdentity's default rule —
+// the caller must be registered in the resolved (== target) project — makes a
+// retired catch-all like 'default' unarchivable forever, because registration
+// there is refused by design (anonymousRefusedError). These three take the
+// executive arm instead: an active executive registered ANYWHERE may run them,
+// audited. create_project is absent (it is the bootstrap tool, never wrapped).
+var projectLifecycleTools = map[string]bool{
+	"archive_project":   true,
+	"unarchive_project": true,
+	"delete_project":    true,
+}
+
+// callerIsActiveExecutive reports whether `from` holds an ACTIVE, is_executive
+// registration in ANY project, returning that home project. Cross-project
+// lookup by name reuses ProjectsOfAgent + GetAgent — no new query, no wide-table
+// column touched. Used only to grant the project-lifecycle arm to an executive
+// acting on a project they are not registered in; every other caller falls
+// through to guardIdentity's unchanged refusal.
+func (h *Handlers) callerIsActiveExecutive(from string) (string, bool) {
+	projects, err := h.db.ProjectsOfAgent(from)
+	if err != nil {
+		return "", false
+	}
+	for _, p := range projects {
+		a, err := h.db.GetAgent(p, from)
+		if err != nil || a == nil {
+			continue
+		}
+		if a.Status == "active" && a.IsExecutive {
+			return p, true
+		}
+	}
+	return "", false
+}
+
 // archivedProjectError is the TYPED refusal for a write into an archived
 // project. Permission-category, non-retryable: it stays archived until an
 // operator unarchives it, so the client must PARK, not hot-loop.
@@ -401,6 +437,22 @@ func (h *Handlers) guardIdentity(toolName string, next server.ToolHandlerFunc) s
 			}
 		}
 		if agent == nil {
+			// Project-lifecycle executive arm: archive/unarchive/delete_project act
+			// on a target project the caller need not live in, so an active executive
+			// registered elsewhere is allowed (audited). Every other unregistered
+			// caller — including a non-executive — falls through to the unchanged
+			// refusal below.
+			if projectLifecycleTools[toolName] {
+				if home, ok := h.callerIsActiveExecutive(from); ok {
+					_ = h.db.RecordAudit(models.AuditEntry{
+						Action:  "project.lifecycle.admin",
+						Actor:   from,
+						Project: project,
+						Reason:  "executive arm from project " + home,
+					})
+					return next(ctx, req)
+				}
+			}
 			return toolResultError(fmt.Sprintf("agent %q is not registered in project %q — call register_agent first.", from, project)), nil
 		}
 		// Identity binding (best-effort, fail-open): if this MCP connection's


### PR DESCRIPTION
### niwa Q&A gate

An adversarial reviewer is reading this diff right now. Its verdict lands on this PR as a review (or a comment when the gate and the author share one GitHub account), and the merge waits for this repository's own checks to go green.

*Opened automatically — a rejected round comes back to the author, who pushes fixes to the same branch.*

## What & why

- **docs(scribe): provenance for wraith-relay-project-lifecycle-executive-arm-archive-unarchive-delete-project-by**
- **feat: [wraith/relay] project-lifecycle executive arm in guardIdentity**
  <details><summary>details</summary>

  archive/unarchive/delete_project act on a TARGET project the caller need not
  live in, but guardIdentity required the caller to be registered in that
  (== target) project. The retired 'default' catch-all refuses registration by
  design (anonymousRefusedError), so it — and any zero-agent shell — was
  unarchivable forever. Deadlock.
  
  At the agent==nil seam, when the tool is archive/unarchive/delete_project and
  the caller is an ACTIVE is_executive registered in ANY project, allow the call
  and RecordAudit(action=project.lifecycle.admin, actor, target, home). Every
  other unregistered caller — including a non-executive — falls through to the
  unchanged "is not registered in project" refusal. A caller registered in the
  target project never takes the new path. Cross-project lookup reuses
  ProjectsOfAgent + GetAgent (read pool); no schema change, no new query,
  anonymousRefusedError + refuseIfArchived untouched.
  
  Task: 05936947-cfad-4509-9860-527d35157a03
  
  Claude-Session: https://claude.ai/code/session_01PCNkqC2fPW4ZssjNovwby4

  </details>

## Changes

<details><summary>Files changed (git diff --stat)</summary>

```
...tive-arm-archive-unarchive-delete-project-by.md |  77 +++++++++
 ...room-guard-testtoolschemabudget-fails-when-f.md |  62 -------
 internal/relay/project_lifecycle_exec_test.go      | 180 +++++++++++++++++++++
 internal/relay/toolset.go                          |  52 ++++++
 internal/relay/toolsize_test.go                    |  14 +-
 5 files changed, 310 insertions(+), 75 deletions(-)
```

</details>

## Module graph

```mermaid
graph TD
  n0["(root)"]
  n1["features/wraith-relay-project-lifecycle-executive-arm-archive-unarchive-delete-project-by.md"]
  n2["internal/relay"]
  n0 --- n2
```

## Acceptance criteria

- [x] AC1 named test: an is_executive agent registered only in project A calls archive_project project=B (no registration in B, B may be 'default') -> result archived:true, and an audit_log row Action='project.lifecycle.admin' names actor + target project + home project; revert-check: removing the executive arm makes the test fail with the 'is not registered in project' refusal
- [x] AC2 named test: a NON-executive agent registered only in A calling archive_project project=B is refused with the existing 'is not registered in project' text — refusal text unchanged
- [x] AC3 named test: caller registered in the target project archives as today (regression guard, path unchanged); existing archived_project_test.go + projects_archive_test.go stay green
- [x] AC4 named test: unarchive_project and delete_project take the same arm (delete_project on an archived target by a remote executive succeeds; on a non-archived target still refuses 'archive_project it first')
- [x] AC5 scope: diff touches internal/relay/toolset.go + one test file only; register_agent anonymous/default refusal and refuseIfArchived untouched
## Provenance

📄 [Root cause, decisions &amp; QA log — `features/wraith-relay-project-lifecycle-executive-arm-archive-unarchive-delete-project-by.md`](https://github.com/TsukumoHQ/WRAI.TH/blob/fix/project-lifecycle-exec-arm/features/wraith-relay-project-lifecycle-executive-arm-archive-unarchive-delete-project-by.md)

## Gate verdict

**✅ APPROVED** · round 2 · reviewer `review-05936947-cfad-4509-9860-527d35157a03`

## review-wraith verdict: SHIP-WITH-NITS
Scope: internal/relay/toolset.go (guardIdentity seam + two helpers) + internal/relay/project_lifecycle_exec_test.go (new)
Gate: build -tags fts5 OK / vet OK / gofmt OK / test -tags fts5 OK (full ./... green after rebase onto current main)

BLOCKERS (must fix before merge):
- none

NITS (non-blocking):
- The arm early-returns `next(ctx, req)`, skipping the session-binding anti-theft check for lifecycle tools. As analysed above this is inapplicable cross-project (the caller is never session-bound in the target project), so behaviour is unchanged — noted only so the reviewer sees the skip is deliberate, not an oversight.
- callerIsActiveExecutive is O(projects-of-caller) read-pool lookups; lifecycle tools are rare admin ops so this is not a hot path. No caching added on purpose (staleness would be worse than a few RO reads).

Invariants checked: single-writer intact (only the existing best-effort RecordAudit writer path is used; lookups are read-pool). agentColumns/scanAgent untouched. No schema/migration. refuseIfArchived + anonymousRefusedError byte-identical. No new MCP tool; registry unchanged. Existing archived_project_test.go green.
## review-wraith verdict: SHIP-WITH-NITS
Scope: internal/relay/toolset.go (guardIdentity seam + two helpers) + internal/relay/project_lifecycle_exec_test.go (new)
Gate: build -tags fts5 OK / vet OK / gofmt OK / test -tags fts5 OK (full ./... green; internal/relay 9.9s)

BLOCKERS (must fix before merge):
- none

NITS (non-blocking):
- The arm early-returns `next(ctx, req)`, skipping the session-binding anti-theft check for lifecycle tools. As analysed above this is inapplicable cross-project (the caller is never session-bound in the target project), so behaviour is unchanged — noted only so the reviewer sees the skip is deliberate, not an oversight.
- callerIsActiveExecutive is O(projects-of-caller) read-pool lookups; lifecycle tools are rare admin ops so this is not a hot path. No caching added on purpose (staleness would be worse than a few RO reads).

Invariants checked: single-writer intact (only the existing best-effort RecordAudit writer path is used; lookups are read-pool). agentColumns/scanAgent untouched. No schema/migration. refuseIfArchived + anonymousRefusedError byte-identical. No new MCP tool; registry unchanged. Existing archived_project_test.go green.
## review-wraith verdict: SHIP-WITH-NITS
Scope: internal/relay/toolset.go (guardIdentity seam + two helpers) + internal/relay/project_lifecycle_exec_test.go (new)
Gate: build -tags fts5 OK / vet OK / gofmt OK / test -tags fts5 OK (full ./... green; internal/relay 9.9s)

BLOCKERS (must fix before merge):
- none

NITS (non-blocking):
- The arm early-returns `next(ctx, req)`, skipping the session-binding anti-theft check for lifecycle tools. As analysed above this is inapplicable cross-project (the caller is never session-bound in the target project), so behaviour is unchanged — noted only so the reviewer sees the skip is deliberate, not an oversight.
- callerIsActiveExecutive is O(projects-of-caller) read-pool lookups; lifecycle tools are rare admin ops so this is not a hot path. No caching added on purpose (staleness would be worse than a few RO reads).

Invariants checked: single-writer intact (only the existing best-effort RecordAudit writer path is used; lookups are read-pool). agentColumns/scanAgent untouched. No schema/migration. refuseIfArchived + anonymousRefusedError byte-identical. No new MCP tool; registry unchanged. Existing archived_project_test.go green.

---
<sub>Authored by agent `wraith-backend` · branch `fix/project-lifecycle-exec-arm` → `main` · reviewed by niwa-gate and merged when this repo's checks pass.</sub>
