### PR TITLE
[wraith/db] referential scan must not hold the single writer: read phase on the reader pool, one short apply tx by row_id lists

### DIFF
--- a/features/wraith-db-referential-scan-must-not-hold-the-single-writer-read-phase-on-the-rea.md
+++ b/features/wraith-db-referential-scan-must-not-hold-the-single-writer-read-phase-on-the-rea.md
@@ -63,17 +63,28 @@ NITS: two test-only package vars (refScanReadHook/refScanBetweenHook) live in th
 ## 3. Files changed
 
 ```
-internal/db/referential_integrity.go      | 426 ++++++++++++++++++++++--------
- internal/db/referential_integrity_test.go | 312 +++++++++++++++++++++-
- 2 files changed, 620 insertions(+), 118 deletions(-)
+...hold-the-single-writer-read-phase-on-the-rea.md |  79 ++++
+ internal/db/referential_integrity.go               | 426 ++++++++++++++++-----
+ internal/db/referential_integrity_test.go          | 312 ++++++++++++++-
+ 3 files changed, 699 insertions(+), 118 deletions(-)
 ```
 
 ## 4. QA Log
 
-_(no review round yet)_
+### Round 1 — ✅ APPROVED by review-1ac2ce6e-40b6-41d8-a2ab-d282a14e267d @ `85a8406f0`
+- 🟢 AC1: readParked hook parks the read phase; concurrent writerExec completes within 100ms — scan does not hold the writer during reads; revert path (read on tx inside d.conn) provably blocked per the HoldGuard control — evidence: internal/db/referential_integrity.go: RunReferentialScan calls readRefDeltas(rctx, d.ro()) — read on reader pool, apply via d.beginWriterTx — test: TestReadPhaseDoesNotHoldWriter (referential_integrity_test.go:625); control TestReadPhaseHoldGuard (test.go:674) confirms 100ms bound is meaningful
+- 🟢 AC2: all 16 classes covered; pool-key OR-clause behavior preserved (orphan_profile resolves via profiles OR agents LOWER match, case-insensitive, project-scoped); no LOWER change — evidence: internal/db/referential_integrity.go: orphanSQL block unchanged; awk extraction byte-identical to pre-split (verified by file diff) — test: TestReferentialScanDetectsOrphanClasses (test.go:167) seeds one representative per class incl. orphan_profile pool resolver; TestBootScanMatchesSplit (test.go:872) proves boot single-tx == split open counts
+- 🟢 AC3: accepted one-tick race documented and pinned by behavioral test, not just by a code comment — evidence: internal/db/referential_integrity.go: refScanBetweenHook fires AFTER readRefDeltas returns, BEFORE beginWriterTx — test: TestScanHealBetweenReadAndApply (test.go:703) seeds ghost agent in the between hook → asserts scan 2 leaves row open, scan 3 resolves it
+- 🟢 AC4: both behavioral (recordingExecer captures real statements) and source-grep verifications in place; writerTimeout bound preserved by the beginWriterTx path — evidence: internal/db/referential_integrity.go applyRefDeltas runs only INSERT OR IGNORE INTO integrity_quarantine VALUES (...) and UPDATE integrity_quarantine SET ... WHERE row_id IN (chunked); called from RunReferentialScan via d.beginWriterTx (writerTimeout-bounded) — test: TestApplyPhaseRunsOnlyRowIDWrites (test.go:757) wraps the apply surface in recordingExecer and asserts every captured statement is INSERT OR IGNORE or UPDATE row_id IN; TestLiveScanUsesReaderAndWriterTx (test.go:822) is the grep-able source assertion for read phase=d.ro() + apply=beginWriterTx
+- 🟢 AC5: scope bounded to the listed code files; sibling scribe provenance commit (features/wraith-db-...) is outside implementation scope and not a runtime change — evidence: git diff 373e328..HEAD --name-only shows internal/db/referential_integrity.go + referential_integrity_test.go only (db.go untouched); orphanSQL byte-identical via awk extraction diff — test: go test -tags fts5 -race ./internal/db/... 307 passed (full suite, race-clean)
 
 ## 5. Timeline
 
+- round 1 → **approve** (review-1ac2ce6e-40b6-41d8-a2ab-d282a14e267d)
+
+**Approve-with-findings (follow-up):** go test -tags fts5 -race ./internal/db/... 307 ok; orphanSQL byte-identical; AC1-4 named tests pass; AC5 implementation scope = 2 code files (db.go not touched, fine).
+
+- **notice** `features/wraith-db-referential-scan-must-not-hold-the-single-writer-read-phase-on-the-rea.md:1` — sibling scribe provenance commit, separate from cff126d — not in the implementation scope but listed in the branch diff (AC5 "at most" lists 3 files)
 
 ---
 _Auto-assembled by the niwa scribe from the Q&A gate. Task `1ac2ce6e-40b6-41d8-a2ab-d282a14e267d`._

--- a/features/wraith-db-referential-scan-must-not-hold-the-single-writer-read-phase-on-the-rea.md
+++ b/features/wraith-db-referential-scan-must-not-hold-the-single-writer-read-phase-on-the-rea.md
@@ -1,0 +1,79 @@
+# [wraith/db] referential scan must not hold the single writer: read phase on the reader pool, one short apply tx by row_id lists
+
+## Team : wraith-backend-2 (tsukumo)
+## Branch : wraith-backend-2/db-refscan-writer-split (from main)
+## Relay task : 1ac2ce6e-40b6-41d8-a2ab-d282a14e267d
+## Status : 🔵 SUBMITTED
+
+## 1. Product Brief
+
+### Acceptance Criteria
+- [ ] 1. AC1 named test: while a scan's read phase is in progress (fixture with a slow orphanSQL or a hook that pauses between classes), a concurrent writerExec from another goroutine completes within 100ms — the scan does not hold the writer during reads; revert-check: running the read phase on d.conn inside a tx makes the concurrent write wait
+- [ ] 2. AC2 named test: on the existing 13 referential_integrity_test.go fixtures the scan output is byte-identical to today's: per-class open counts, the detect/heal/reopen row sets, and the emitted log lines — including the orphan_profile pool-key OR-clause behavior (DEC-wraith-orphan-profile-burndown-1)
+- [ ] 3. AC3 named test: a ref healed between the read phase and the apply tx is NOT resolved in that scan and IS resolved by the next scan (documents the accepted one-tick race)
+- [ ] 4. AC4 in-diff: the apply tx contains no orphanSQL text — a named test or a grep-able assertion that the only statements executed on the writer are INSERT OR IGNORE / UPDATE ... WHERE row_id IN (...) against integrity_quarantine; the apply tx is opened via beginWriterTx (writerTimeout-bounded)
+- [ ] 5. AC5 scope: diff touches at most internal/db/referential_integrity.go, internal/db/referential_integrity_test.go, internal/db/db.go; every orphanSQL string byte-identical (no LOWER() change); go test -tags fts5 ./internal/db/... green
+
+## 2. Root cause & decisions
+
+# Decision — referential scan off the single writer (task 1ac2ce6e)
+
+ROOT_CAUSE: `runReferentialScan` ran all ~16 orphan classes' five statements — each embedding the class `orphanSQL` — inside ONE writer transaction on `d.conn` (the single writer, `SetMaxOpenConns(1)`), bounded by `referentialScanTimeout` (30s). That is > `writerTimeout` (15s), so under fleet load the 20–40s scan held the sole writer connection while every other write (send_message / claim_task / complete_task / token flush / expire) deadlined behind it — 91 `context deadline exceeded` lines since 09-02.
+
+## Decision
+Split the scan into a READ phase and an APPLY phase (the reader-scan-then-short-write shape already used by `dangling_board.go` and `limbo_sweep.go`):
+
+- **READ** (reader pool `d.ro()`, own `referentialScanTimeout` ctx): per class run the `orphanSQL` ONCE, load the open/resolved quarantine sets, compute in Go `newOrphans = orphan\open`, `reopen = resolved∩orphan`, `resolve = open\orphan`. Holds no writer.
+- **APPLY** (ONE `beginWriterTx`, `writerTimeout`-bounded): only `INSERT OR IGNORE` (explicit values) and `UPDATE … WHERE row_id IN (…)` against `integrity_quarantine`, IN-lists chunked at 500. No `orphanSQL` text runs on the writer, so it is held for the milliseconds the deltas need, not the length of the scan.
+
+`readRefDeltas` / `applyRefDeltas` are shared by the live split path (`(*DB).RunReferentialScan`) and the boot-time single-tx path (`runReferentialScan(conn)`), so the SQL and the delta arithmetic are one source.
+
+## Invariants held
+- Every `orphanSQL` string byte-identical (incl. the DEC-wraith-orphan-profile-burndown-1 pool-key OR-clause). **No `LOWER()` change — that is ticket B, explicitly out of scope here.**
+- Log lines (`integrity: detect …`, `integrity: heal …`) byte-identical, still emitted post-commit only.
+- Single-writer discipline: the ONLY writer use in this file is the apply tx. No new goroutines, no schema change.
+
+## Accepted race (ruled)
+A ref that heals between the read phase and the apply tx is NOT resolved in that scan; the next scan (2 min later) resolves it. Idempotent. Covered by `TestScanHealBetweenReadAndApply` (AC3).
+
+## Boot / reconcile path
+`runReferentialScan(conn)` (migrate `db.go:1339`, reconcile `referential_reconcile.go:87`) runs before the reader pool exists and under no fleet contention, so it keeps the single-tx shape — now built on the same shared helpers. Kept in scope-safe: those callers were NOT edited. `TestBootScanMatchesSplit` proves boot and split return identical counts.
+
+## Rejected alternatives
+- **Keep one tx but shrink the timeout** — would just move the guillotine, not stop the writer being held for the whole scan.
+- **Duplicate the whole scan for the live path** — rejected: two copies of the orphan detect/heal/apply orchestration would drift; instead the `orphanSQL` source (`refChecks`) and the delta/apply helpers are shared.
+
+## Scope
+`internal/db/referential_integrity.go` + `internal/db/referential_integrity_test.go` (2 of the 3 allowed files; `db.go` not needed).
+
+## Verify
+`go test -tags fts5 ./internal/db/...` green; full `go test -tags fts5 ./...` green; AC1/AC3/AC4 + parity tests green 3× under `-race`.
+
+## review-agent-runtime verdict: SHIP
+
+review-agent-runtime: PASS
+Scope: internal/db/referential_integrity.go + internal/db/referential_integrity_test.go (referential scan; read/apply phase split)
+BLOCKERS: none
+- §1 schema/scan lockstep: N/A — no agentColumns/scanAgent/schema/migration change.
+- §2 concurrency: apply uses guarded conditional UPDATEs (row_id IN explicit lists, resolved_at state guard) + idempotent INSERT OR IGNORE; single background sweeper (no concurrent scans); read↔apply gap is the ruled one-tick race (AC3). Explicit IN-lists are strictly safer than the old NOT IN (orphanSQL).
+- §3 single-writer/availability: writer now held only for the short apply tx via beginWriterTx; reads on d.ro(); strictly LESS writer contention (this is the fix). Fallible reads check rows.Err()+Close, no nil-deref, no new hot-path write.
+- §4 network/auth, §5 MCP surface, §6 lifecycle: untouched.
+NITS: two test-only package vars (refScanReadHook/refScanBetweenHook) live in the production file — standard Go test-seam pattern, nil in production, negligible nil-check on a 2-min background path.
+
+## 3. Files changed
+
+```
+internal/db/referential_integrity.go      | 426 ++++++++++++++++++++++--------
+ internal/db/referential_integrity_test.go | 312 +++++++++++++++++++++-
+ 2 files changed, 620 insertions(+), 118 deletions(-)
+```
+
+## 4. QA Log
+
+_(no review round yet)_
+
+## 5. Timeline
+
+
+---
+_Auto-assembled by the niwa scribe from the Q&A gate. Task `1ac2ce6e-40b6-41d8-a2ab-d282a14e267d`._

--- a/internal/db/referential_integrity.go
+++ b/internal/db/referential_integrity.go
@@ -246,17 +246,287 @@ func refChecks() []refCheck {
 // A var, not a const, so a test can shrink it.
 var referentialScanTimeout = 30 * time.Second
 
-// runReferentialScan runs every referential check inside one writer transaction
-// and upserts the results into integrity_quarantine. It returns the count of
-// currently-OPEN (unresolved) quarantine rows per class. Idempotent: re-running
-// on an unchanged DB inserts nothing and flips no marker. Backward-compatible:
-// only the side-table is written; no existing row is touched.
+// refScanReadHook and refScanBetweenHook are test-only seams (nil in production):
+// refScanReadHook fires once during the read phase (after the first class is read)
+// so a test can observe the writer is free while reads are in flight;
+// refScanBetweenHook fires in the live path AFTER the read phase and BEFORE the
+// apply tx so a test can mutate the DB and exercise the accepted read↔apply race.
+var (
+	refScanReadHook    func()
+	refScanBetweenHook func()
+)
+
+// --- scan orchestration -----------------------------------------------------
 //
-// Per check, three steps keep the lifecycle correct and re-run-safe:
-//  1. INSERT OR IGNORE the current orphans (new ones get detected_at; the UNIQUE
-//     key dedupes existing ones — first-seen detected_at is preserved).
-//  2. RE-OPEN any row that had been marked resolved but is orphan again.
-//  3. MARK RESOLVED any open row whose ref now resolves (no delete — audit trail).
+// The scan is split into a READ phase and an APPLY phase so it never holds the
+// single writer connection (db.go SetMaxOpenConns(1)) for longer than the
+// milliseconds its writes need. Root cause of the 2026-09-02 writer-starvation
+// window (task 1ac2ce6e): the previous implementation ran all ~16 classes' five
+// statements — each embedding the class orphanSQL — inside ONE writer tx bounded
+// by referentialScanTimeout (30s) > writerTimeout (15s), so under fleet load a
+// 20–40s scan deadlined every other write. Now the orphanSQL runs ONCE per class
+// on the reader pool (read phase), the deltas are computed in Go, and only short
+// INSERT/UPDATE-by-row_id statements touch the writer (apply phase, bounded by
+// writerTimeout via beginWriterTx). Pattern mirrors dangling_board.go and
+// limbo_sweep.go (reader scan, then a short writer tx).
+//
+// Accepted race (ruled): a ref that heals between the read and the apply is
+// resolved one tick (2 min) later, not in this scan. Idempotent.
+
+// orphanRow is one current offender: (row_id, ref_value, project) as the
+// orphanSQL aliases them.
+type orphanRow struct {
+	rowID    string
+	refValue string
+	project  string
+}
+
+// refDelta is the per-class change set computed by the read phase from the
+// current orphan set and the existing quarantine rows. The apply phase writes
+// exactly these — no orphanSQL text runs on the writer.
+type refDelta struct {
+	c          refCheck
+	newOrphans []orphanRow // orphan AND not currently open (brand-new or resolved-then-regressed)
+	reopenIDs  []string    // resolved rows that are orphan again → re-open
+	resolveIDs []string    // open rows whose ref now resolves → mark resolved
+}
+
+// roQueryer is the read surface the read phase needs: the reader pool in the
+// live path, the boot tx at startup. *sql.DB, *sql.Tx and *sql.Conn satisfy it.
+type roQueryer interface {
+	QueryContext(ctx context.Context, query string, args ...interface{}) (*sql.Rows, error)
+}
+
+// execer is the write surface the apply phase needs. *sql.Tx (boot) and the
+// embedded *sql.Tx of a writerTx (live) satisfy it.
+type execer interface {
+	Exec(query string, args ...interface{}) (sql.Result, error)
+}
+
+// readRefDeltas computes every class's change set with READ-ONLY queries on rq.
+// The orphanSQL runs ONCE per class here (never inside the writer tx). Set
+// arithmetic is done in Go: newOrphans = orphan \ open, reopen = resolved ∩
+// orphan, resolve = open \ orphan. Iteration order of the orphan/open queries is
+// preserved into the returned slices so the detect/heal log lines are stable.
+func readRefDeltas(ctx context.Context, rq roQueryer) ([]refDelta, error) {
+	out := make([]refDelta, 0, 16)
+	for i, c := range refChecks() {
+		if i == 0 && refScanReadHook != nil {
+			refScanReadHook()
+		}
+		var orphans []orphanRow
+		orphanIDs := map[string]bool{}
+		orows, err := rq.QueryContext(ctx, c.orphanSQL)
+		if err != nil {
+			return nil, fmt.Errorf("referential scan %s: orphan read: %w", c.class, err)
+		}
+		for orows.Next() {
+			var o orphanRow
+			if err := orows.Scan(&o.rowID, &o.refValue, &o.project); err != nil {
+				_ = orows.Close()
+				return nil, fmt.Errorf("referential scan %s: orphan scan: %w", c.class, err)
+			}
+			orphans = append(orphans, o)
+			orphanIDs[o.rowID] = true
+		}
+		if err := orows.Err(); err != nil {
+			_ = orows.Close()
+			return nil, fmt.Errorf("referential scan %s: orphan rows: %w", c.class, err)
+		}
+		_ = orows.Close()
+
+		open, err := readQuarantineIDs(ctx, rq, c.class, false)
+		if err != nil {
+			return nil, fmt.Errorf("referential scan %s: open read: %w", c.class, err)
+		}
+		resolved, err := readQuarantineIDs(ctx, rq, c.class, true)
+		if err != nil {
+			return nil, fmt.Errorf("referential scan %s: resolved read: %w", c.class, err)
+		}
+		openSet := idSet(open)
+
+		d := refDelta{c: c}
+		for _, o := range orphans {
+			if !openSet[o.rowID] {
+				d.newOrphans = append(d.newOrphans, o) // orphan \ open
+			}
+		}
+		for _, id := range resolved {
+			if orphanIDs[id] {
+				d.reopenIDs = append(d.reopenIDs, id) // resolved ∩ orphan
+			}
+		}
+		for _, id := range open {
+			if !orphanIDs[id] {
+				d.resolveIDs = append(d.resolveIDs, id) // open \ orphan
+			}
+		}
+		out = append(out, d)
+	}
+	return out, nil
+}
+
+// readQuarantineIDs returns the row_ids of the quarantine rows for a class,
+// either the OPEN set (resolved==false) or the RESOLVED set (resolved==true).
+func readQuarantineIDs(ctx context.Context, rq roQueryer, class string, resolved bool) ([]string, error) {
+	q := `SELECT row_id FROM integrity_quarantine WHERE class = ? AND resolved_at IS NULL`
+	if resolved {
+		q = `SELECT row_id FROM integrity_quarantine WHERE class = ? AND resolved_at IS NOT NULL`
+	}
+	rows, err := rq.QueryContext(ctx, q, class)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var ids []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		ids = append(ids, id)
+	}
+	return ids, rows.Err()
+}
+
+func idSet(ids []string) map[string]bool {
+	m := make(map[string]bool, len(ids))
+	for _, id := range ids {
+		m[id] = true
+	}
+	return m
+}
+
+// refApplyChunk bounds each UPDATE ... row_id IN (...) list. SQLite's default
+// bound-parameter limit is 999; 500 keeps each statement small and well under it.
+const refApplyChunk = 500
+
+// applyRefDeltas writes the change sets on the writer surface x. The ONLY
+// statements it runs are INSERT OR IGNORE (explicit values) and UPDATE ...
+// WHERE row_id IN (explicit list) against integrity_quarantine — no orphanSQL
+// text, so the writer holds the connection for milliseconds, not the length of a
+// 16-class scan. Order per class: insert, reopen, resolve (matches the pre-split
+// statement order so a mid-scan crash leaves the same intermediate state).
+func applyRefDeltas(x execer, deltas []refDelta, now string) error {
+	for _, d := range deltas {
+		c := d.c
+		for _, o := range d.newOrphans {
+			if _, err := x.Exec(
+				`INSERT OR IGNORE INTO integrity_quarantine
+				   (table_name, row_id, ref_col, ref_value, class, project, detected_at)
+				 VALUES (?, ?, ?, ?, ?, ?, ?)`,
+				c.table, o.rowID, c.refCol, o.refValue, c.class, o.project, now,
+			); err != nil {
+				return fmt.Errorf("referential scan %s: insert: %w", c.class, err)
+			}
+		}
+		for _, chunk := range chunkStrings(d.reopenIDs, refApplyChunk) {
+			ph, ids := inPlaceholders(chunk)
+			args := append([]interface{}{now, c.class}, ids...)
+			if _, err := x.Exec(
+				`UPDATE integrity_quarantine
+				 SET resolved_at = NULL, detected_at = ?
+				 WHERE class = ? AND resolved_at IS NOT NULL AND row_id IN (`+ph+`)`,
+				args...,
+			); err != nil {
+				return fmt.Errorf("referential scan %s: reopen: %w", c.class, err)
+			}
+		}
+		for _, chunk := range chunkStrings(d.resolveIDs, refApplyChunk) {
+			ph, ids := inPlaceholders(chunk)
+			args := append([]interface{}{now, c.class}, ids...)
+			if _, err := x.Exec(
+				`UPDATE integrity_quarantine
+				 SET resolved_at = ?
+				 WHERE class = ? AND resolved_at IS NULL AND row_id IN (`+ph+`)`,
+				args...,
+			); err != nil {
+				return fmt.Errorf("referential scan %s: resolve: %w", c.class, err)
+			}
+		}
+	}
+	return nil
+}
+
+// chunkStrings splits ids into slices of at most size (nil in → nil out).
+func chunkStrings(ids []string, size int) [][]string {
+	if len(ids) == 0 {
+		return nil
+	}
+	var out [][]string
+	for i := 0; i < len(ids); i += size {
+		j := i + size
+		if j > len(ids) {
+			j = len(ids)
+		}
+		out = append(out, ids[i:j])
+	}
+	return out
+}
+
+// inPlaceholders renders "?, ?, ..." and the matching arg slice for an IN list.
+func inPlaceholders(ids []string) (string, []interface{}) {
+	ph := make([]string, len(ids))
+	args := make([]interface{}, len(ids))
+	for i, id := range ids {
+		ph[i] = "?"
+		args[i] = id
+	}
+	return strings.Join(ph, ", "), args
+}
+
+// refScanLogLines builds the transition log lines from the deltas: one detect
+// line per newly-opening orphan (class order, then orphan-query order), then one
+// heal line per resolving row (class order, then open-query order). Byte-identical
+// to the pre-split lines; emitted post-commit by the callers.
+func refScanLogLines(deltas []refDelta, now string) (detect, heal []string) {
+	for _, d := range deltas {
+		ref := d.c.table + "." + d.c.refCol
+		for _, o := range d.newOrphans {
+			detect = append(detect, fmt.Sprintf(
+				"integrity: detect class=%s ref=%s value=%s row=%s", d.c.class, ref, o.refValue, o.rowID))
+		}
+	}
+	for _, d := range deltas {
+		for _, id := range d.resolveIDs {
+			heal = append(heal, fmt.Sprintf(
+				"integrity: heal class=%s row=%s action=ref_resolved resolved_at=%s", d.c.class, id, now))
+		}
+	}
+	return detect, heal
+}
+
+// openCountsByClass returns the open (unresolved) quarantine count per class,
+// the scan's return value.
+func openCountsByClass(ctx context.Context, rq roQueryer) (map[string]int, error) {
+	counts := map[string]int{}
+	rows, err := rq.QueryContext(ctx,
+		`SELECT class, COUNT(*) FROM integrity_quarantine WHERE resolved_at IS NULL GROUP BY class`)
+	if err != nil {
+		return nil, fmt.Errorf("referential scan: count: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var class string
+		var n int
+		if err := rows.Scan(&class, &n); err != nil {
+			return nil, fmt.Errorf("referential scan: count scan: %w", err)
+		}
+		counts[class] = n
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("referential scan: count rows: %w", err)
+	}
+	return counts, nil
+}
+
+// runReferentialScan runs the scan inside ONE transaction on conn (both read and
+// apply). Kept for the boot-time callers (migrate, reconcile) that run before the
+// reader pool exists and under no fleet contention — there the single-tx shape is
+// harmless. The live periodic path uses (*DB).RunReferentialScan, which splits
+// the phases across the reader pool and a short writer tx. Both share
+// readRefDeltas/applyRefDeltas, so the SQL and the delta arithmetic are one
+// source. Idempotent; only the side-table is written.
 func runReferentialScan(conn *sql.DB) (map[string]int, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), referentialScanTimeout)
 	defer cancel()
@@ -269,137 +539,81 @@ func runReferentialScan(conn *sql.DB) (map[string]int, error) {
 
 	now := time.Now().UTC().Format(memoryTimeFmt)
 
-	// Per-row transition logging (emitted post-commit, transition-only so a
-	// restart re-emits just the delta — not every open row — keeping the live
-	// log bounded). detect = a row about to open (a brand-new orphan, or a
-	// previously-resolved row regressing to orphan); heal = an open row whose
-	// ref now resolves. Captured BEFORE the mutations below so the "not yet
-	// open" / "still open" sets are the pre-scan state.
-	var detectLines, healLines []string
-
-	for _, c := range refChecks() {
-		ref := c.table + "." + c.refCol
-		drows, err := tx.QueryContext(ctx,
-			`SELECT o.row_id, o.ref_value FROM (`+c.orphanSQL+`) o
-			 WHERE o.row_id NOT IN (
-			   SELECT row_id FROM integrity_quarantine WHERE class = ? AND resolved_at IS NULL)`,
-			c.class)
-		if err != nil {
-			return nil, fmt.Errorf("referential scan %s: detect capture: %w", c.class, err)
-		}
-		for drows.Next() {
-			var rowID, refValue string
-			if err := drows.Scan(&rowID, &refValue); err != nil {
-				_ = drows.Close()
-				return nil, fmt.Errorf("referential scan %s: detect scan: %w", c.class, err)
-			}
-			detectLines = append(detectLines, fmt.Sprintf(
-				"integrity: detect class=%s ref=%s value=%s row=%s", c.class, ref, refValue, rowID))
-		}
-		if err := drows.Err(); err != nil {
-			_ = drows.Close()
-			return nil, fmt.Errorf("referential scan %s: detect rows: %w", c.class, err)
-		}
-		_ = drows.Close()
-
-		hrows, err := tx.QueryContext(ctx,
-			`SELECT row_id FROM integrity_quarantine
-			 WHERE class = ? AND resolved_at IS NULL
-			   AND row_id NOT IN (SELECT o.row_id FROM (`+c.orphanSQL+`) o)`,
-			c.class)
-		if err != nil {
-			return nil, fmt.Errorf("referential scan %s: heal capture: %w", c.class, err)
-		}
-		for hrows.Next() {
-			var rowID string
-			if err := hrows.Scan(&rowID); err != nil {
-				_ = hrows.Close()
-				return nil, fmt.Errorf("referential scan %s: heal scan: %w", c.class, err)
-			}
-			healLines = append(healLines, fmt.Sprintf(
-				"integrity: heal class=%s row=%s action=ref_resolved resolved_at=%s", c.class, rowID, now))
-		}
-		if err := hrows.Err(); err != nil {
-			_ = hrows.Close()
-			return nil, fmt.Errorf("referential scan %s: heal rows: %w", c.class, err)
-		}
-		_ = hrows.Close()
-
-		// 1. insert new orphans
-		if _, err := tx.ExecContext(ctx,
-			`INSERT OR IGNORE INTO integrity_quarantine
-			   (table_name, row_id, ref_col, ref_value, class, project, detected_at)
-			 SELECT ?, o.row_id, ?, o.ref_value, ?, o.project, ?
-			 FROM (`+c.orphanSQL+`) o`,
-			c.table, c.refCol, c.class, now,
-		); err != nil {
-			return nil, fmt.Errorf("referential scan %s: insert: %w", c.class, err)
-		}
-		// 2. re-open regressed rows (resolved before, orphan again)
-		if _, err := tx.ExecContext(ctx,
-			`UPDATE integrity_quarantine
-			 SET resolved_at = NULL, detected_at = ?
-			 WHERE class = ? AND resolved_at IS NOT NULL
-			   AND row_id IN (SELECT o.row_id FROM (`+c.orphanSQL+`) o)`,
-			now, c.class,
-		); err != nil {
-			return nil, fmt.Errorf("referential scan %s: reopen: %w", c.class, err)
-		}
-		// 3. mark healed rows resolved (ref now resolves) — never deleted
-		if _, err := tx.ExecContext(ctx,
-			`UPDATE integrity_quarantine
-			 SET resolved_at = ?
-			 WHERE class = ? AND resolved_at IS NULL
-			   AND row_id NOT IN (SELECT o.row_id FROM (`+c.orphanSQL+`) o)`,
-			now, c.class,
-		); err != nil {
-			return nil, fmt.Errorf("referential scan %s: resolve: %w", c.class, err)
-		}
-	}
-
-	counts := map[string]int{}
-	rows, err := tx.QueryContext(ctx,
-		`SELECT class, COUNT(*) FROM integrity_quarantine WHERE resolved_at IS NULL GROUP BY class`)
+	deltas, err := readRefDeltas(ctx, tx)
 	if err != nil {
-		return nil, fmt.Errorf("referential scan: count: %w", err)
+		return nil, err
 	}
-	for rows.Next() {
-		var class string
-		var n int
-		if err := rows.Scan(&class, &n); err != nil {
-			_ = rows.Close()
-			return nil, fmt.Errorf("referential scan: count scan: %w", err)
-		}
-		counts[class] = n
+	if err := applyRefDeltas(tx, deltas, now); err != nil {
+		return nil, err
 	}
-	if err := rows.Err(); err != nil {
-		_ = rows.Close()
-		return nil, fmt.Errorf("referential scan: count rows: %w", err)
+	counts, err := openCountsByClass(ctx, tx)
+	if err != nil {
+		return nil, err
 	}
-	_ = rows.Close()
-
 	if err := tx.Commit(); err != nil {
 		return nil, fmt.Errorf("referential scan: commit: %w", err)
 	}
-	// Emit per-row lines only after the tx commits, so a rolled-back scan logs
-	// nothing. Volume is the transition delta (see the capture note above).
-	for _, l := range detectLines {
+
+	detect, heal := refScanLogLines(deltas, now)
+	for _, l := range detect {
 		log.Print(l)
 	}
-	for _, l := range healLines {
+	for _, l := range heal {
 		log.Print(l)
 	}
 	return counts, nil
 }
 
-// RunReferentialScan runs the referential scan on the writer connection and
-// returns the per-class open-orphan counts. Phase 2 wires it onto the existing
-// 2-minute task-maintenance sweeper (the periodic GC deferred from Phase 0), so
-// orphans created during a long uptime — e.g. a task whose assignee is
-// deactivated between reboots — surface without a restart. It is idempotent, so a
-// clean sweep is a cheap near-no-op.
+// RunReferentialScan runs the referential scan on the LIVE relay: the read phase
+// (every class's orphanSQL) on the reader pool, then ONE short writer tx
+// (beginWriterTx, writerTimeout-bounded) that applies only the INSERT/UPDATE
+// deltas. The writer is therefore never held for the length of the scan, so a
+// slow scan under fleet load can no longer starve send_message/claim_task/
+// complete_task/flush/expire into writerTimeout (task 1ac2ce6e). Idempotent.
 func (d *DB) RunReferentialScan() (map[string]int, error) {
-	return runReferentialScan(d.conn)
+	// Read phase — reader pool, own ctx (referentialScanTimeout). Holds no writer.
+	rctx, rcancel := context.WithTimeout(context.Background(), referentialScanTimeout)
+	deltas, err := readRefDeltas(rctx, d.ro())
+	rcancel()
+	if err != nil {
+		return nil, err
+	}
+
+	if refScanBetweenHook != nil {
+		refScanBetweenHook()
+	}
+
+	now := time.Now().UTC().Format(memoryTimeFmt)
+
+	// Apply phase — one short writer tx, bounded by writerTimeout via beginWriterTx.
+	tx, err := d.beginWriterTx()
+	if err != nil {
+		return nil, fmt.Errorf("referential scan: begin writer: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }() // no-op after commit
+	if err := applyRefDeltas(tx.Tx, deltas, now); err != nil {
+		return nil, err
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("referential scan: commit: %w", err)
+	}
+
+	// Count phase — reader pool, post-commit (sees the committed apply).
+	cctx, ccancel := context.WithTimeout(context.Background(), referentialScanTimeout)
+	counts, err := openCountsByClass(cctx, d.ro())
+	ccancel()
+	if err != nil {
+		return nil, err
+	}
+
+	detect, heal := refScanLogLines(deltas, now)
+	for _, l := range detect {
+		log.Print(l)
+	}
+	for _, l := range heal {
+		log.Print(l)
+	}
+	return counts, nil
 }
 
 // MarkQuarantine upserts ONE referential-integrity quarantine row (the same

--- a/internal/db/referential_integrity_test.go
+++ b/internal/db/referential_integrity_test.go
@@ -4,8 +4,12 @@ import (
 	"bytes"
 	"database/sql"
 	"log"
+	"os"
+	"reflect"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 )
 
 // captureLog redirects the stdlib logger (what referential_integrity.go writes
@@ -209,7 +213,7 @@ func TestReferentialScanDetectsOrphanClasses(t *testing.T) {
 	seedCycle(t, c, "cy-clean", "p1")
 	seedCycle(t, c, "cy-oproject", "ghost-project")
 
-	counts, err := runReferentialScan(c)
+	counts, err := d.RunReferentialScan()
 	if err != nil {
 		t.Fatalf("scan: %v", err)
 	}
@@ -293,14 +297,14 @@ func TestReferentialScanIdempotent(t *testing.T) {
 	seedWorkflow(t, c, "wf-oproject", "ghost-project")
 	seedCycle(t, c, "cy-oproject", "ghost-project")
 
-	first, err := runReferentialScan(c)
+	first, err := d.RunReferentialScan()
 	if err != nil {
 		t.Fatalf("scan 1: %v", err)
 	}
 	var rowsAfter1 int
 	_ = c.QueryRow(`SELECT COUNT(*) FROM integrity_quarantine`).Scan(&rowsAfter1)
 
-	second, err := runReferentialScan(c)
+	second, err := d.RunReferentialScan()
 	if err != nil {
 		t.Fatalf("scan 2: %v", err)
 	}
@@ -330,7 +334,7 @@ func TestReferentialScanResolvesHealedRefs(t *testing.T) {
 	seedProfile(t, c, "p1", "backend")
 	seedTask(t, c, "t-odisp", "p1", "pending", "latecomer", "", "", "backend", "", "", false)
 
-	if _, err := runReferentialScan(c); err != nil {
+	if _, err := d.RunReferentialScan(); err != nil {
 		t.Fatalf("scan 1: %v", err)
 	}
 	if openCount(t, c, "orphan_dispatcher") != 1 {
@@ -340,7 +344,7 @@ func TestReferentialScanResolvesHealedRefs(t *testing.T) {
 	// The referenced agent now exists → the ref resolves.
 	seedAgent(t, c, "p1", "latecomer", "active", "backend", "", 0)
 
-	if _, err := runReferentialScan(c); err != nil {
+	if _, err := d.RunReferentialScan(); err != nil {
 		t.Fatalf("scan 2: %v", err)
 	}
 	if openCount(t, c, "orphan_dispatcher") != 0 {
@@ -368,7 +372,7 @@ func TestReferentialScanReopensRegressedRef(t *testing.T) {
 	seedTask(t, c, "t-odisp", "p1", "pending", "flaky", "", "", "backend", "", "", false)
 
 	// Scan 1: resolves (flaky exists) → no open orphan.
-	if _, err := runReferentialScan(c); err != nil {
+	if _, err := d.RunReferentialScan(); err != nil {
 		t.Fatalf("scan 1: %v", err)
 	}
 	if openCount(t, c, "orphan_dispatcher") != 0 {
@@ -380,7 +384,7 @@ func TestReferentialScanReopensRegressedRef(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, err := runReferentialScan(c); err != nil {
+	if _, err := d.RunReferentialScan(); err != nil {
 		t.Fatalf("scan 2: %v", err)
 	}
 	if openCount(t, c, "orphan_dispatcher") != 1 {
@@ -509,7 +513,7 @@ func TestOrphanProfilePoolResolver(t *testing.T) {
 	// Task slug matches neither profiles nor agents → orphan.
 	seedTask(t, c, "t-dead", "p1", "pending", "linear", "", "", "no-such-slug", "", "", false)
 
-	if _, err := runReferentialScan(c); err != nil {
+	if _, err := d.RunReferentialScan(); err != nil {
 		t.Fatalf("scan: %v", err)
 	}
 	if got := openCount(t, c, "orphan_profile"); got != 1 {
@@ -537,7 +541,7 @@ func TestOrphanProfilePoolCaseInsensitive(t *testing.T) {
 	seedAgent(t, c, "p2", "other", "active", "cross-slug", "", 0)
 	seedTask(t, c, "t-xproj", "p1", "pending", "linear", "", "", "cross-slug", "", "", false)
 
-	if _, err := runReferentialScan(c); err != nil {
+	if _, err := d.RunReferentialScan(); err != nil {
 		t.Fatalf("scan: %v", err)
 	}
 	if quarantineRowExists(t, c, "orphan_profile", "t-ci") {
@@ -562,7 +566,7 @@ func TestOrphanProfileTerminalExclusion(t *testing.T) {
 	// ...and on a non-terminal task → STILL flagged.
 	seedTask(t, c, "t-open", "p1", "in-progress", "linear", "", "", "dead-slug", "", "", false)
 
-	if _, err := runReferentialScan(c); err != nil {
+	if _, err := d.RunReferentialScan(); err != nil {
 		t.Fatalf("scan: %v", err)
 	}
 	if got := openCount(t, c, "orphan_profile"); got != 1 {
@@ -586,7 +590,7 @@ func TestOrphanProfileHealPath(t *testing.T) {
 	seedTask(t, c, "t-heal", "p1", "pending", "linear", "", "", "joins-later", "", "", false)
 
 	// Scan 1: no profile, no agent → flagged.
-	if _, err := runReferentialScan(c); err != nil {
+	if _, err := d.RunReferentialScan(); err != nil {
 		t.Fatalf("scan 1: %v", err)
 	}
 	if !quarantineRowExists(t, c, "orphan_profile", "t-heal") {
@@ -595,7 +599,7 @@ func TestOrphanProfileHealPath(t *testing.T) {
 
 	// An agent now carries the slug → the condition clears.
 	seedAgent(t, c, "p1", "newcomer", "active", "joins-later", "", 0)
-	if _, err := runReferentialScan(c); err != nil {
+	if _, err := d.RunReferentialScan(); err != nil {
 		t.Fatalf("scan 2: %v", err)
 	}
 	if openCount(t, c, "orphan_profile") != 0 {
@@ -608,5 +612,289 @@ func TestOrphanProfileHealPath(t *testing.T) {
 	}
 	if resolved != 1 {
 		t.Errorf("healed quarantine row must be stamped resolved (not deleted): got %d", resolved)
+	}
+}
+
+// --- task 1ac2ce6e: writer-starvation split (read phase off the writer) ------
+
+// TestReadPhaseDoesNotHoldWriter (AC1) parks a live scan inside its read phase
+// and proves a concurrent writerExec still completes fast — the scan holds no
+// writer while it reads. Revert-check: if the read phase ran on d.conn inside a
+// tx (the pre-split bug), the writer would be held and the concurrent write would
+// block past the 100ms bound, failing this test.
+func TestReadPhaseDoesNotHoldWriter(t *testing.T) {
+	d := testDB(t)
+	seedProject(t, d.conn, "p1")
+	seedTask(t, d.conn, "t-odisp", "p1", "pending", "ghost", "", "", "backend", "", "", false)
+
+	readParked := make(chan struct{})
+	release := make(chan struct{})
+	var once sync.Once
+	refScanReadHook = func() {
+		once.Do(func() { close(readParked) })
+		<-release
+	}
+	defer func() { refScanReadHook = nil }()
+
+	scanDone := make(chan error, 1)
+	go func() { _, err := d.RunReferentialScan(); scanDone <- err }()
+
+	<-readParked // scan is parked inside the read phase (no apply tx open yet)
+
+	writeDone := make(chan error, 1)
+	go func() {
+		_, err := d.writerExec(
+			`INSERT INTO settings (key, value) VALUES ('ac1_probe', '1')
+			 ON CONFLICT(key) DO UPDATE SET value = '1'`)
+		writeDone <- err
+	}()
+
+	select {
+	case err := <-writeDone:
+		if err != nil {
+			close(release)
+			t.Fatalf("concurrent writerExec errored during read phase: %v", err)
+		}
+	case <-time.After(100 * time.Millisecond):
+		close(release)
+		<-scanDone
+		t.Fatal("concurrent writerExec blocked >100ms while the scan read phase was in progress — the scan is holding the writer during reads")
+	}
+
+	close(release)
+	if err := <-scanDone; err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+}
+
+// TestReadPhaseHoldGuard is the positive control for AC1's 100ms discriminator:
+// while a writer tx is genuinely held, a concurrent writerExec MUST block past
+// 100ms. This proves the AC1 bound can actually catch a writer being held (so the
+// AC1 pass is meaningful, not vacuous).
+func TestReadPhaseHoldGuard(t *testing.T) {
+	d := testDB(t)
+	tx, err := d.beginWriterTx()
+	if err != nil {
+		t.Fatalf("begin writer: %v", err)
+	}
+	defer tx.Rollback()
+
+	writeDone := make(chan error, 1)
+	go func() {
+		_, err := d.writerExec(
+			`INSERT INTO settings (key, value) VALUES ('hold_probe', '1')
+			 ON CONFLICT(key) DO UPDATE SET value = '1'`)
+		writeDone <- err
+	}()
+
+	select {
+	case <-writeDone:
+		t.Fatal("writerExec completed while a writer tx was held — the 100ms guard would be vacuous")
+	case <-time.After(100 * time.Millisecond):
+		// expected: the held tx blocks the concurrent write
+	}
+	_ = tx.Rollback() // release so the parked write can drain
+	<-writeDone
+}
+
+// TestScanHealBetweenReadAndApply (AC3) proves the accepted one-tick race: a ref
+// that heals AFTER the read phase but BEFORE the apply tx is NOT resolved in that
+// scan (the read saw it still orphan) and IS resolved by the next scan.
+func TestScanHealBetweenReadAndApply(t *testing.T) {
+	d := testDB(t)
+	seedProject(t, d.conn, "p1")
+	seedTask(t, d.conn, "t-odisp", "p1", "pending", "ghost", "", "", "backend", "", "", false)
+
+	if _, err := d.RunReferentialScan(); err != nil {
+		t.Fatalf("scan 1: %v", err)
+	}
+	if openCount(t, d.conn, "orphan_dispatcher") != 1 {
+		t.Fatalf("expected 1 open orphan_dispatcher after scan 1")
+	}
+
+	// Heal the ref (register the missing agent) DURING the second scan, after its
+	// read phase has already snapshotted the ref as still-orphan.
+	var once sync.Once
+	refScanBetweenHook = func() {
+		once.Do(func() { seedAgent(t, d.conn, "p1", "ghost", "active", "backend", "", 0) })
+	}
+	if _, err := d.RunReferentialScan(); err != nil {
+		refScanBetweenHook = nil
+		t.Fatalf("scan 2: %v", err)
+	}
+	refScanBetweenHook = nil
+
+	// Scan 2 read the pre-heal state → the row stays OPEN this tick.
+	if got := openCount(t, d.conn, "orphan_dispatcher"); got != 1 {
+		t.Errorf("scan 2 (heal after read): got %d open, want 1 — the mid-scan heal must NOT resolve this tick", got)
+	}
+
+	// Next scan sees the agent → the ref resolves now.
+	if _, err := d.RunReferentialScan(); err != nil {
+		t.Fatalf("scan 3: %v", err)
+	}
+	if got := openCount(t, d.conn, "orphan_dispatcher"); got != 0 {
+		t.Errorf("scan 3: got %d open, want 0 — the healed ref must resolve on the next scan", got)
+	}
+}
+
+// recordingExecer captures every statement run on the writer during the apply
+// phase while forwarding it to a real tx.
+type recordingExecer struct {
+	x       execer
+	queries []string
+}
+
+func (r *recordingExecer) Exec(q string, args ...interface{}) (sql.Result, error) {
+	r.queries = append(r.queries, q)
+	return r.x.Exec(q, args...)
+}
+
+// TestApplyPhaseRunsOnlyRowIDWrites (AC4) proves the apply phase runs ONLY
+// INSERT OR IGNORE (explicit values) and UPDATE ... WHERE row_id IN (...) against
+// integrity_quarantine — no orphanSQL / SELECT / NOT EXISTS text touches the
+// writer — and that it works on a beginWriterTx-derived surface.
+func TestApplyPhaseRunsOnlyRowIDWrites(t *testing.T) {
+	d := testDB(t)
+	now := "2026-01-01T00:00:00Z"
+	// Pre-seed one resolved row (reopen target) and one open row (resolve target).
+	if _, err := d.conn.Exec(
+		`INSERT INTO integrity_quarantine (table_name,row_id,ref_col,ref_value,class,project,detected_at,resolved_at)
+		 VALUES ('tasks','r2','dispatched_by','ghost','orphan_dispatcher','p1',?,?)`, now, now); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := d.conn.Exec(
+		`INSERT INTO integrity_quarantine (table_name,row_id,ref_col,ref_value,class,project,detected_at)
+		 VALUES ('tasks','r3','dispatched_by','ghost','orphan_dispatcher','p1',?)`, now); err != nil {
+		t.Fatal(err)
+	}
+
+	deltas := []refDelta{{
+		c:          refCheck{class: "orphan_dispatcher", table: "tasks", refCol: "dispatched_by"},
+		newOrphans: []orphanRow{{rowID: "r1", refValue: "ghost", project: "p1"}},
+		reopenIDs:  []string{"r2"},
+		resolveIDs: []string{"r3"},
+	}}
+
+	tx, err := d.beginWriterTx()
+	if err != nil {
+		t.Fatalf("begin writer: %v", err)
+	}
+	rec := &recordingExecer{x: tx.Tx}
+	if err := applyRefDeltas(rec, deltas, now); err != nil {
+		_ = tx.Rollback()
+		t.Fatalf("apply: %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+
+	if len(rec.queries) == 0 {
+		t.Fatal("apply phase ran no writer statements")
+	}
+	for _, q := range rec.queries {
+		up := strings.ToUpper(q)
+		if strings.Contains(up, "SELECT") || strings.Contains(up, "NOT EXISTS") {
+			t.Errorf("apply statement embeds a read/orphanSQL construct: %q", q)
+		}
+		insert := strings.Contains(up, "INSERT OR IGNORE INTO INTEGRITY_QUARANTINE")
+		update := strings.Contains(up, "UPDATE INTEGRITY_QUARANTINE") && strings.Contains(up, "ROW_ID IN (")
+		if !insert && !update {
+			t.Errorf("unexpected apply statement shape (not INSERT OR IGNORE / UPDATE row_id IN): %q", q)
+		}
+	}
+
+	// End state: r1 inserted open, r2 reopened (open), r3 resolved (not open).
+	if !quarantineRowExists(t, d.conn, "orphan_dispatcher", "r1") {
+		t.Error("r1 should be inserted open")
+	}
+	if !quarantineRowExists(t, d.conn, "orphan_dispatcher", "r2") {
+		t.Error("r2 should be reopened (resolved_at cleared)")
+	}
+	if quarantineRowExists(t, d.conn, "orphan_dispatcher", "r3") {
+		t.Error("r3 should be resolved (no longer open)")
+	}
+}
+
+// TestLiveScanUsesReaderAndWriterTx (AC4, grep-able) asserts the live scan reads
+// on the reader pool and opens its apply via the writerTimeout-bounded
+// beginWriterTx, and never references orphanSQL directly in the apply path.
+func TestLiveScanUsesReaderAndWriterTx(t *testing.T) {
+	src, err := os.ReadFile("referential_integrity.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(src)
+	if !strings.Contains(text, "deltas, err := readRefDeltas(rctx, d.ro())") {
+		t.Error("RunReferentialScan read phase must run on the reader pool d.ro()")
+	}
+	if !strings.Contains(text, "tx, err := d.beginWriterTx()") {
+		t.Error("RunReferentialScan apply phase must open via beginWriterTx (writerTimeout-bounded)")
+	}
+	// applyRefDeltas must not embed orphanSQL: its body has no NOT EXISTS / orphanSQL.
+	apply := funcBodyText(text, "func applyRefDeltas(")
+	if apply == "" {
+		t.Fatal("could not isolate applyRefDeltas body")
+	}
+	if strings.Contains(apply, "orphanSQL") || strings.Contains(apply, "NOT EXISTS") {
+		t.Error("applyRefDeltas (writer surface) must not embed orphanSQL text")
+	}
+}
+
+// funcBodyText returns the source of the function whose signature starts with
+// sig, from sig to the matching top-level closing brace.
+func funcBodyText(src, sig string) string {
+	i := strings.Index(src, sig)
+	if i < 0 {
+		return ""
+	}
+	depth := 0
+	started := false
+	for j := i; j < len(src); j++ {
+		switch src[j] {
+		case '{':
+			depth++
+			started = true
+		case '}':
+			depth--
+			if started && depth == 0 {
+				return src[i : j+1]
+			}
+		}
+	}
+	return ""
+}
+
+// TestBootScanMatchesSplit proves the boot-time single-tx path
+// (runReferentialScan on the writer conn) and the live split path
+// ((*DB).RunReferentialScan) return identical open counts on the same fixture —
+// the two callers share readRefDeltas/applyRefDeltas, so their output cannot drift.
+func TestBootScanMatchesSplit(t *testing.T) {
+	seed := func(d *DB) {
+		seedProject(t, d.conn, "p1")
+		seedProfile(t, d.conn, "p1", "backend")
+		seedAgent(t, d.conn, "p1", "alice", "active", "backend", "", 0)
+		seedTask(t, d.conn, "t1", "p1", "pending", "ghost", "", "", "backend", "", "", false)
+		seedTask(t, d.conn, "t2", "p1", "pending", "alice", "ghost2", "", "backend", "", "", false)
+		seedTrigger(t, d.conn, "tr-orphan", "ghost-project")
+		seedMemory(t, d.conn, "mem-orphan", "ghost-project", false)
+	}
+
+	d1 := testDB(t)
+	seed(d1)
+	bootCounts, err := runReferentialScan(d1.conn)
+	if err != nil {
+		t.Fatalf("boot scan: %v", err)
+	}
+
+	d2 := testDB(t)
+	seed(d2)
+	splitCounts, err := d2.RunReferentialScan()
+	if err != nil {
+		t.Fatalf("split scan: %v", err)
+	}
+
+	if !reflect.DeepEqual(bootCounts, splitCounts) {
+		t.Errorf("boot vs split open counts differ:\n boot=%v\nsplit=%v", bootCounts, splitCounts)
 	}
 }


### PR DESCRIPTION
### niwa Q&A gate

An adversarial reviewer is reading this diff right now. Its verdict lands on this PR as a review (or a comment when the gate and the author share one GitHub account), and the merge waits for this repository's own checks to go green.

*Opened automatically — a rejected round comes back to the author, who pushes fixes to the same branch.*

## What & why

- **docs(scribe): provenance for wraith-db-referential-scan-must-not-hold-the-single-writer-read-phase-on-the-rea**
- **fix: [wraith/db] referential scan off the single writer — reader read-phase + short apply tx**
  <details><summary>details</summary>

  The 2-minute referential-integrity scan ran all ~16 orphan classes' five
  statements — each embedding the class orphanSQL — inside ONE writer tx bounded
  by referentialScanTimeout (30s) > writerTimeout (15s). Under fleet load the scan
  took 20-40s and every other write deadlined behind it (91 `context deadline
  exceeded` since 09-02).
  
  Split into a READ phase and an APPLY phase (pattern from dangling_board.go /
  limbo_sweep.go):
  
  - READ: per class run the orphanSQL ONCE on the reader pool (d.ro(), own
    referentialScanTimeout ctx), load the open/resolved quarantine sets, compute
    newOrphans = orphan\open, reopen = resolved∩orphan, resolve = open\orphan in Go.
  - APPLY: ONE short writer tx via beginWriterTx (writerTimeout-bounded) running
    only INSERT OR IGNORE (explicit values) and UPDATE ... WHERE row_id IN (...)
    against integrity_quarantine, IN-lists chunked at 500. No orphanSQL on the
    writer, so it is held for milliseconds, not the scan length.
  
  readRefDeltas/applyRefDeltas are shared by the live split path
  ((*DB).RunReferentialScan) and the boot-time single-tx path
  (runReferentialScan(conn), still used by migrate + reconcile before the reader
  pool exists), so the SQL and delta arithmetic have one source. Every orphanSQL
  string byte-identical (no LOWER() change — ticket B). Ruled race: a ref that heals
  between read and apply resolves one tick later; idempotent.
  
  Tests: 12 existing fixtures now drive the split path (AC2 byte-identical counts /
  sets / log lines); TestReadPhaseDoesNotHoldWriter (AC1) + TestReadPhaseHoldGuard
  control; TestScanHealBetweenReadAndApply (AC3); TestApplyPhaseRunsOnlyRowIDWrites
  + TestLiveScanUsesReaderAndWriterTx (AC4); TestBootScanMatchesSplit parity.
  
  verify: go test -tags fts5 ./internal/db/... green; full ./... green; AC tests
  green 3x under -race. Scope: internal/db/referential_integrity.go + its test.
  
  Task: 1ac2ce6e-40b6-41d8-a2ab-d282a14e267d
  
  Claude-Session: https://claude.ai/code/session_019FcVkfwxhJvA5ovCbPpBn3

  </details>

## Changes

<details><summary>Files changed (git diff --stat)</summary>

```
...hold-the-single-writer-read-phase-on-the-rea.md |  79 ++++
 internal/db/referential_integrity.go               | 426 ++++++++++++++++-----
 internal/db/referential_integrity_test.go          | 312 ++++++++++++++-
 3 files changed, 699 insertions(+), 118 deletions(-)
```

</details>

## Module graph

```mermaid
graph TD
  n0["features/wraith-db-referential-scan-must-not-hold-the-single-writer-read-phase-on-the-rea.md"]
  n1["internal/db"]
```

## Acceptance criteria

- [x] AC1 named test: while a scan's read phase is in progress (fixture with a slow orphanSQL or a hook that pauses between classes), a concurrent writerExec from another goroutine completes within 100ms — the scan does not hold the writer during reads; revert-check: running the read phase on d.conn inside a tx makes the concurrent write wait
- [x] AC2 named test: on the existing 13 referential_integrity_test.go fixtures the scan output is byte-identical to today's: per-class open counts, the detect/heal/reopen row sets, and the emitted log lines — including the orphan_profile pool-key OR-clause behavior (DEC-wraith-orphan-profile-burndown-1)
- [x] AC3 named test: a ref healed between the read phase and the apply tx is NOT resolved in that scan and IS resolved by the next scan (documents the accepted one-tick race)
- [x] AC4 in-diff: the apply tx contains no orphanSQL text — a named test or a grep-able assertion that the only statements executed on the writer are INSERT OR IGNORE / UPDATE ... WHERE row_id IN (...) against integrity_quarantine; the apply tx is opened via beginWriterTx (writerTimeout-bounded)
- [x] AC5 scope: diff touches at most internal/db/referential_integrity.go, internal/db/referential_integrity_test.go, internal/db/db.go; every orphanSQL string byte-identical (no LOWER() change); go test -tags fts5 ./internal/db/... green
## Provenance

📄 [Root cause, decisions &amp; QA log — `features/wraith-db-referential-scan-must-not-hold-the-single-writer-read-phase-on-the-rea.md`](https://github.com/TsukumoHQ/WRAI.TH/blob/wraith-backend-2/db-refscan-writer-split/features/wraith-db-referential-scan-must-not-hold-the-single-writer-read-phase-on-the-rea.md)

## Gate verdict

**✅ APPROVED** · round 2 · reviewer `review-1ac2ce6e-40b6-41d8-a2ab-d282a14e267d`

## review-agent-runtime verdict: SHIP

review-agent-runtime: PASS
Scope: internal/db/referential_integrity.go + internal/db/referential_integrity_test.go (referential scan; read/apply phase split)
BLOCKERS: none
- §1 schema/scan lockstep: N/A — no agentColumns/scanAgent/schema/migration change.
- §2 concurrency: apply uses guarded conditional UPDATEs (row_id IN explicit lists, resolved_at state guard) + idempotent INSERT OR IGNORE; single background sweeper (no concurrent scans); read↔apply gap is the ruled one-tick race (AC3). Explicit IN-lists are strictly safer than the old NOT IN (orphanSQL).
- §3 single-writer/availability: writer now held only for the short apply tx via beginWriterTx; reads on d.ro(); strictly LESS writer contention (this is the fix). Fallible reads check rows.Err()+Close, no nil-deref, no new hot-path write.
- §4 network/auth, §5 MCP surface, §6 lifecycle: untouched.
NITS: two test-only package vars (refScanReadHook/refScanBetweenHook) live in the production file — standard Go test-seam pattern, nil in production, negligible nil-check on a 2-min background path.
## review-agent-runtime verdict: SHIP

review-agent-runtime: PASS
Scope: internal/db/referential_integrity.go + internal/db/referential_integrity_test.go (referential scan; read/apply phase split)
BLOCKERS: none
- §1 schema/scan lockstep: N/A — no agentColumns/scanAgent/schema/migration change.
- §2 concurrency: apply uses guarded conditional UPDATEs (row_id IN explicit lists, resolved_at state guard) + idempotent INSERT OR IGNORE; single background sweeper (no concurrent scans); read↔apply gap is the ruled one-tick race (AC3). Explicit IN-lists are strictly safer than the old NOT IN (orphanSQL).
- §3 single-writer/availability: writer now held only for the short apply tx via beginWriterTx; reads on d.ro(); strictly LESS writer contention (this is the fix). Fallible reads check rows.Err()+Close, no nil-deref, no new hot-path write.
- §4 network/auth, §5 MCP surface, §6 lifecycle: untouched.
NITS: two test-only package vars (refScanReadHook/refScanBetweenHook) live in the production file — standard Go test-seam pattern, nil in production, negligible nil-check on a 2-min background path.
## review-agent-runtime verdict: SHIP

review-agent-runtime: PASS
Scope: internal/db/referential_integrity.go + internal/db/referential_integrity_test.go (referential scan; read/apply phase split)
BLOCKERS: none
- §1 schema/scan lockstep: N/A — no agentColumns/scanAgent/schema/migration change.
- §2 concurrency: apply uses guarded conditional UPDATEs (row_id IN explicit lists, resolved_at state guard) + idempotent INSERT OR IGNORE; single background sweeper (no concurrent scans); read↔apply gap is the ruled one-tick race (AC3). Explicit IN-lists are strictly safer than the old NOT IN (orphanSQL).
- §3 single-writer/availability: writer now held only for the short apply tx via beginWriterTx; reads on d.ro(); strictly LESS writer contention (this is the fix). Fallible reads check rows.Err()+Close, no nil-deref, no new hot-path write.
- §4 network/auth, §5 MCP surface, §6 lifecycle: untouched.
NITS: two test-only package vars (refScanReadHook/refScanBetweenHook) live in the production file — standard Go test-seam pattern, nil in production, negligible nil-check on a 2-min background path.

---
<sub>Authored by agent `wraith-backend-2` · branch `wraith-backend-2/db-refscan-writer-split` → `main` · reviewed by niwa-gate and merged when this repo's checks pass.</sub>

## Schéma

```mermaid
sequenceDiagram
    actor scan as Scan Goroutine
    participant ro as d.ro() Reader Pool
    participant conn as d.conn Single Writer
    participant other as Other Write Goroutines
    
    Note over scan,other: BEFORE: orphanSQL on writer (20-40s hold)
    scan->>conn: Begin() on writer
    scan->>conn: orphanSQL ~80 stmts
    other-->>conn: Waiting...
    scan->>conn: UPDATE/INSERT integrity_quarantine
    other-->>other: Timeout (91 deadline exceeded)
    scan->>conn: Commit()
    
    Note over scan,other: AFTER: READ on reader, APPLY on writer (ms)
    scan->>ro: readRefDeltas()
    ro->>ro: orphanSQL ~80 statements
    other->>conn: Can execute (not blocked)
    ro-->>scan: row_id lists
    scan->>conn: beginWriterTx() brief hold
    scan->>conn: applyRefDeltas()
    scan->>conn: Commit()
    other->>other: Complete within 100ms
```
