### PR TITLE
[wraith/db] writer-wait diagnostics: log any single-writer wait over 2s with the op — writer starvation is invisible today

### DIFF
--- a/features/wraith-db-writer-wait-diagnostics-log-any-single-writer-wait-over-2s-with-the-op.md
+++ b/features/wraith-db-writer-wait-diagnostics-log-any-single-writer-wait-over-2s-with-the-op.md
@@ -1,0 +1,54 @@
+# [wraith/db] writer-wait diagnostics: log any single-writer wait over 2s with the op — writer starvation is invisible today
+
+## Team : wraith-backend-2 (tsukumo)
+## Branch : wraith-backend-2/db-writer-wait-diag (from main)
+## Relay task : 2d5fb3c2-3f9a-4368-903f-d1ed8b1de6c9
+## Status : 🔵 SUBMITTED
+
+## 1. Product Brief
+
+### Acceptance Criteria
+- [ ] 1. AC1 named test: with writerSlowWait shrunk to 20ms and the writer held by an open tx for 60ms, a concurrent writerExec logs exactly one line containing `writer wait:` and the query prefix; revert-check: threshold raised above the hold -> no line
+- [ ] 2. AC2 named test: a writerExec that completes below writerSlowWait logs nothing (buffer empty)
+- [ ] 3. AC3 named test: beginWriterTx waiting behind a held writer logs one `writer wait: begin-tx caller=` line naming the calling function
+- [ ] 4. AC4 in-diff: writerExec error path (deadline exceeded) still returns the error unchanged AND logs the wait line — named test asserts both
+- [ ] 5. AC5 scope: writerTimeout and referentialScanTimeout values byte-identical; existing 13 tests in referential_integrity_test.go and wedge_test.go green; diff touches at most 3 files
+
+## 2. Root cause & decisions
+
+ROOT_CAUSE: Writer starvation was invisible — a scan/flush holding the sole writer connection (SetMaxOpenConns(1)) made every other write silently wait out writerTimeout, so the 91 `context deadline exceeded` lines since 2026-09-02 had no attributable cause in the log. Fix: log any single-writer acquire/exec that crosses writerSlowWait (2s), and the referential scan's total duration, with the op — observability only, zero change to writerTimeout, the pool, DSN, or any SQL.
+
+## review-agent-runtime verdict: SHIP
+
+```
+review-agent-runtime: PASS
+Scope: internal/db/db.go (+51/-2), internal/db/referential_integrity.go (+10), internal/db/db_writerwait_test.go (+190)
+BLOCKERS: none
+  §1 schema/scan: untouched — no agentColumns/scanAgent edit, no migration.
+  §2 concurrency: writerExec/beginWriterTx logic unchanged; added only start:=time.Now()+conditional log.Printf (stdlib log is mutex-guarded); refScanReadHook is a test-only seam, nil in prod. No new shared mutable state.
+  §3 single-writer: observability-only — no new writer handle, no DSN change, no new per-request SQLite write. The diagnostic is log.Printf, bounded by the writerSlowWait=2s threshold (low volume).
+  §4 boundary / §5 MCP surface / §6 lifecycle: N/A — diff touches none.
+  AC5: writerTimeout / referentialScanTimeout assignments byte-identical to main (git diff shows no +/- on those lines).
+NITS: none.
+```
+
+Tests: 6 AC tests in db_writerwait_test.go — writerExec slow-wait logs one prefixed line (AC1) / high-threshold reverts to silent (AC1) / uncontended is silent (AC2), begin-tx logs caller via runtime.Caller(1) (AC3), error/deadline path still logs + returns err (AC4), scan logs `integrity scan: took` on slow duration. `go test -tags fts5 ./internal/db/...` 313 pass; `-race -count=3` on the 6 new = 18 pass, no data race; `go vet` clean; gofmt clean.
+
+## 3. Files changed
+
+```
+internal/db/db.go                    |  51 +++++++++-
+ internal/db/db_writerwait_test.go    | 190 +++++++++++++++++++++++++++++++++++
+ internal/db/referential_integrity.go |  10 ++
+ 3 files changed, 249 insertions(+), 2 deletions(-)
+```
+
+## 4. QA Log
+
+_(no review round yet)_
+
+## 5. Timeline
+
+
+---
+_Auto-assembled by the niwa scribe from the Q&A gate. Task `2d5fb3c2-3f9a-4368-903f-d1ed8b1de6c9`._

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -10,6 +10,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -166,11 +167,47 @@ func (d *DB) ro() *sql.DB {
 // 15s wait.
 var writerTimeout = 15 * time.Second
 
-// writerExec runs Exec on the writer connection bounded by writerTimeout.
+// writerSlowWait is the threshold above which a single-writer op is logged as a
+// `writer wait:` line. Writer starvation was invisible before this: a scan or
+// flush that held the sole writer connection (SetMaxOpenConns(1)) just made every
+// other write silently wait out its timeout — the 91 `context deadline exceeded`
+// lines of 2026-09-02 had no attributable cause in the log. Observability only:
+// nothing about writerTimeout, the pool, or any SQL changes. A var, not a const,
+// so tests shrink it (same trick as writerTimeout in wedge_test.go).
+var writerSlowWait = 2 * time.Second
+
+// writerQueryPrefix renders the first 48 chars of a query with internal
+// whitespace collapsed, so a writer-wait line is one grep-able line.
+func writerQueryPrefix(query string) string {
+	q := strings.Join(strings.Fields(query), " ")
+	if len(q) > 48 {
+		q = q[:48]
+	}
+	return q
+}
+
+// shortFuncName strips the package path from a runtime function name
+// ("agent-relay/internal/db.(*DB).SweepDanglingBoards" -> "SweepDanglingBoards").
+func shortFuncName(full string) string {
+	if i := strings.LastIndex(full, "."); i >= 0 {
+		return full[i+1:]
+	}
+	return full
+}
+
+// writerExec runs Exec on the writer connection bounded by writerTimeout. It logs
+// one `writer wait:` line — on the success path AND the error/deadline path — when
+// the call, including the wait to acquire the single writer connection from the
+// pool, takes at least writerSlowWait. The returned result/error are unchanged.
 func (d *DB) writerExec(query string, args ...interface{}) (sql.Result, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), writerTimeout)
 	defer cancel()
-	return d.conn.ExecContext(ctx, query, args...)
+	start := time.Now()
+	res, err := d.conn.ExecContext(ctx, query, args...)
+	if waited := time.Since(start); waited >= writerSlowWait {
+		log.Printf("writer wait: %s waited=%s", writerQueryPrefix(query), waited.Round(time.Millisecond))
+	}
+	return res, err
 }
 
 // writerTx wraps *sql.Tx to release the ctx bounding its lifetime as soon as
@@ -229,8 +266,18 @@ func (t *writerTx) release() {
 // budgets means the body is never reused after a background rollback.
 func (d *DB) beginWriterTx() (*writerTx, error) {
 	acqCtx, acqCancel := context.WithTimeout(context.Background(), writerTimeout)
+	start := time.Now()
 	conn, err := d.conn.Conn(acqCtx)
 	acqCancel()
+	if waited := time.Since(start); waited >= writerSlowWait {
+		caller := "?"
+		if pc, _, _, ok := runtime.Caller(1); ok {
+			if fn := runtime.FuncForPC(pc); fn != nil {
+				caller = shortFuncName(fn.Name())
+			}
+		}
+		log.Printf("writer wait: begin-tx caller=%s waited=%s", caller, waited.Round(time.Millisecond))
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/internal/db/db_writerwait_test.go
+++ b/internal/db/db_writerwait_test.go
@@ -1,0 +1,190 @@
+package db
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// Writer-wait diagnostics (task 2d5fb3c2). Writer starvation was invisible: a
+// scan/flush holding the sole writer connection (SetMaxOpenConns(1)) made every
+// other write silently wait out writerTimeout with no attributable cause in the
+// log. These pin the `writer wait:` / `integrity scan: took` observability lines.
+//
+// Contention is created the same way as wedge_test.go: d.conn.Begin() checks out
+// the writer pool's ONLY connection and holds it uncommitted, so any other writer
+// op blocks on pool-acquire until it is released. All timing vars are shrunk (the
+// wedge_test trick) so the tests run in tens of ms, never a real 2s wait.
+
+// acquireWriterTxForTest is a NAMED wrapper so beginWriterTx's runtime.Caller(1)
+// resolves to a stable, assertable caller name in the begin-tx wait line.
+func acquireWriterTxForTest(d *DB) (*writerTx, error) {
+	return d.beginWriterTx()
+}
+
+// TestWriterExecLogsSlowWait (AC1): a writerExec that waits past writerSlowWait
+// to acquire the sole writer connection logs exactly one `writer wait:` line
+// carrying the query prefix.
+func TestWriterExecLogsSlowWait(t *testing.T) {
+	d := testDB(t)
+	orig := writerSlowWait
+	writerSlowWait = 20 * time.Millisecond
+	defer func() { writerSlowWait = orig }()
+
+	tx, err := d.conn.Begin() // holds the writer pool's ONLY connection
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	go func() {
+		time.Sleep(60 * time.Millisecond)
+		_ = tx.Rollback() // frees the writer so writerExec can finally acquire it
+	}()
+
+	var res string
+	out := captureLog(t, func() {
+		_, _ = d.writerExec("UPDATE agents SET last_seen = ? WHERE name = ?", "x", "nobody")
+		res = "done"
+	})
+	_ = res
+
+	if n := strings.Count(out, "writer wait:"); n != 1 {
+		t.Fatalf("want exactly 1 `writer wait:` line, got %d\nlog:\n%s", n, out)
+	}
+	if !strings.Contains(out, "UPDATE agents") {
+		t.Fatalf("writer-wait line missing query prefix\nlog:\n%s", out)
+	}
+}
+
+// TestWriterExecHighThresholdNoLog (AC1 revert-check): the SAME ~60ms contention
+// with writerSlowWait raised above the wait logs nothing — the threshold, not the
+// wait itself, decides.
+func TestWriterExecHighThresholdNoLog(t *testing.T) {
+	d := testDB(t)
+	orig := writerSlowWait
+	writerSlowWait = 500 * time.Millisecond
+	defer func() { writerSlowWait = orig }()
+
+	tx, err := d.conn.Begin()
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	go func() {
+		time.Sleep(60 * time.Millisecond)
+		_ = tx.Rollback()
+	}()
+
+	out := captureLog(t, func() {
+		_, _ = d.writerExec("UPDATE agents SET last_seen = ? WHERE name = ?", "x", "nobody")
+	})
+
+	if strings.Contains(out, "writer wait:") {
+		t.Fatalf("want no `writer wait:` line below threshold, got:\n%s", out)
+	}
+}
+
+// TestWriterExecBelowThresholdLogsNothing (AC2): an uncontended, fast writerExec
+// is silent — the diagnostic never fires on the common healthy path.
+func TestWriterExecBelowThresholdLogsNothing(t *testing.T) {
+	d := testDB(t)
+	orig := writerSlowWait
+	writerSlowWait = 500 * time.Millisecond
+	defer func() { writerSlowWait = orig }()
+
+	out := captureLog(t, func() {
+		if _, err := d.writerExec("UPDATE agents SET last_seen = ? WHERE name = ?", "x", "nobody"); err != nil {
+			t.Fatalf("writerExec: %v", err)
+		}
+	})
+
+	if strings.Contains(out, "writer wait:") {
+		t.Fatalf("uncontended fast writerExec must be silent, got:\n%s", out)
+	}
+}
+
+// TestBeginWriterTxLogsSlowAcquire (AC3): a slow beginWriterTx acquire logs the
+// begin-tx wait line with the caller resolved via runtime.Caller(1).
+func TestBeginWriterTxLogsSlowAcquire(t *testing.T) {
+	d := testDB(t)
+	orig := writerSlowWait
+	writerSlowWait = 20 * time.Millisecond
+	defer func() { writerSlowWait = orig }()
+
+	tx, err := d.conn.Begin()
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	go func() {
+		time.Sleep(60 * time.Millisecond)
+		_ = tx.Rollback()
+	}()
+
+	var wtx *writerTx
+	out := captureLog(t, func() {
+		var e error
+		wtx, e = acquireWriterTxForTest(d)
+		if e != nil {
+			t.Errorf("acquireWriterTxForTest: %v", e)
+		}
+	})
+	if wtx != nil {
+		_ = wtx.Rollback()
+	}
+
+	if !strings.Contains(out, "writer wait: begin-tx caller=acquireWriterTxForTest") {
+		t.Fatalf("want begin-tx wait line with caller=acquireWriterTxForTest, got:\n%s", out)
+	}
+}
+
+// TestWriterExecErrorPathLogsAndReturnsError (AC4): when the wait exhausts
+// writerTimeout, writerExec both logs the wait AND returns the error — the
+// diagnostic covers the deadline path, not only the success path.
+func TestWriterExecErrorPathLogsAndReturnsError(t *testing.T) {
+	d := testDB(t)
+	origT := writerTimeout
+	origW := writerSlowWait
+	writerTimeout = 40 * time.Millisecond
+	writerSlowWait = 10 * time.Millisecond
+	defer func() { writerTimeout = origT; writerSlowWait = origW }()
+
+	tx, err := d.conn.Begin() // held for the whole test — never released in window
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	var execErr error
+	out := captureLog(t, func() {
+		_, execErr = d.writerExec("UPDATE agents SET last_seen = ? WHERE name = ?", "x", "nobody")
+	})
+
+	if execErr == nil {
+		t.Fatal("want writerExec to return the deadline error, got nil")
+	}
+	if !strings.Contains(out, "writer wait:") {
+		t.Fatalf("error path must still log the wait, got:\n%s", out)
+	}
+}
+
+// TestReferentialScanLogsSlowDuration: a scan whose total duration crosses
+// writerSlowWait logs `integrity scan: took` (silent on the fast clean-DB path).
+// The read-phase seam refScanReadHook is used to make the scan deterministically
+// slow without real contention.
+func TestReferentialScanLogsSlowDuration(t *testing.T) {
+	d := testDB(t)
+	orig := writerSlowWait
+	writerSlowWait = 5 * time.Millisecond
+	defer func() { writerSlowWait = orig }()
+
+	refScanReadHook = func() { time.Sleep(15 * time.Millisecond) }
+	defer func() { refScanReadHook = nil }()
+
+	out := captureLog(t, func() {
+		if _, err := d.RunReferentialScan(); err != nil {
+			t.Fatalf("RunReferentialScan: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "integrity scan: took") {
+		t.Fatalf("want `integrity scan: took` on a slow scan, got:\n%s", out)
+	}
+}

--- a/internal/db/referential_integrity.go
+++ b/internal/db/referential_integrity.go
@@ -571,6 +571,8 @@ func runReferentialScan(conn *sql.DB) (map[string]int, error) {
 // slow scan under fleet load can no longer starve send_message/claim_task/
 // complete_task/flush/expire into writerTimeout (task 1ac2ce6e). Idempotent.
 func (d *DB) RunReferentialScan() (map[string]int, error) {
+	scanStart := time.Now()
+
 	// Read phase — reader pool, own ctx (referentialScanTimeout). Holds no writer.
 	rctx, rcancel := context.WithTimeout(context.Background(), referentialScanTimeout)
 	deltas, err := readRefDeltas(rctx, d.ro())
@@ -612,6 +614,14 @@ func (d *DB) RunReferentialScan() (map[string]int, error) {
 	}
 	for _, l := range heal {
 		log.Print(l)
+	}
+
+	// Writer-starvation diagnostic (task 2d5fb3c2): a scan slower than
+	// writerSlowWait is what used to hold the writer long enough to starve other
+	// writes — surface its duration so the cause is attributable. Silent when fast
+	// (the common clean-DB near-no-op).
+	if took := time.Since(scanStart); took >= writerSlowWait {
+		log.Printf("integrity scan: took %s (%d classes)", took.Round(time.Millisecond), len(deltas))
 	}
 	return counts, nil
 }


### PR DESCRIPTION
### niwa Q&A gate

An adversarial reviewer is reading this diff right now. Its verdict lands on this PR as a review (or a comment when the gate and the author share one GitHub account), and the merge waits for this repository's own checks to go green.

*Opened automatically — a rejected round comes back to the author, who pushes fixes to the same branch.*

## What & why

- **docs(scribe): provenance for wraith-db-writer-wait-diagnostics-log-any-single-writer-wait-over-2s-with-the-op**
- **test: [wraith/db] writer-wait diagnostics: 6 AC tests (writerExec slow/threshold/error path, begin-tx caller, scan duration)**
  <details><summary>details</summary>

  Covers task 2d5fb3c2 ACs: slow single-writer waits now log an attributable
  `writer wait:` / `integrity scan: took` line. Tests shrink writerSlowWait/
  writerTimeout (wedge_test trick) and create contention via a held d.conn.Begin().
  
  Claude-Session: https://claude.ai/code/session_019FcVkfwxhJvA5ovCbPpBn3

  </details>
- **wip: [wraith/db] writer-wait diagnostics — db.go writerExec/beginWriterTx + scan duration (task 2d5fb3c2)**
  <details><summary>details</summary>

  Instrumentation only (no tests yet). writerSlowWait var + writerQueryPrefix +
  shortFuncName; writerExec logs 'writer wait: <prefix> waited=' on success+error
  path; beginWriterTx logs 'writer wait: begin-tx caller=' on slow acquire;
  RunReferentialScan logs 'integrity scan: took .. (N classes)' when slow.
  Values writerTimeout/referentialScanTimeout untouched.
  
  Task: 2d5fb3c2-3f9a-4368-903f-d1ed8b1de6c9
  
  Claude-Session: https://claude.ai/code/session_019FcVkfwxhJvA5ovCbPpBn3

  </details>

## Changes

<details><summary>Files changed (git diff --stat)</summary>

```
...g-any-single-writer-wait-over-2s-with-the-op.md |  54 ++++++
 internal/db/db.go                                  |  51 +++++-
 internal/db/db_writerwait_test.go                  | 190 +++++++++++++++++++++
 internal/db/referential_integrity.go               |  10 ++
 4 files changed, 303 insertions(+), 2 deletions(-)
```

</details>

## Module graph

```mermaid
graph TD
  n0["features/wraith-db-writer-wait-diagnostics-log-any-single-writer-wait-over-2s-with-the-op.md"]
  n1["internal/db"]
```

## Acceptance criteria

- [x] AC1 named test: with writerSlowWait shrunk to 20ms and the writer held by an open tx for 60ms, a concurrent writerExec logs exactly one line containing `writer wait:` and the query prefix; revert-check: threshold raised above the hold -> no line
- [x] AC2 named test: a writerExec that completes below writerSlowWait logs nothing (buffer empty)
- [x] AC3 named test: beginWriterTx waiting behind a held writer logs one `writer wait: begin-tx caller=` line naming the calling function
- [x] AC4 in-diff: writerExec error path (deadline exceeded) still returns the error unchanged AND logs the wait line — named test asserts both
- [x] AC5 scope: writerTimeout and referentialScanTimeout values byte-identical; existing 13 tests in referential_integrity_test.go and wedge_test.go green; diff touches at most 3 files
## Provenance

📄 [Root cause, decisions &amp; QA log — `features/wraith-db-writer-wait-diagnostics-log-any-single-writer-wait-over-2s-with-the-op.md`](https://github.com/TsukumoHQ/WRAI.TH/blob/wraith-backend-2/db-writer-wait-diag/features/wraith-db-writer-wait-diagnostics-log-any-single-writer-wait-over-2s-with-the-op.md)

## Gate verdict

**✅ APPROVED** · round 1 · reviewer `review-2d5fb3c2-3f9a-4368-903f-d1ed8b1de6c9`

## review-agent-runtime verdict: SHIP

```
review-agent-runtime: PASS
Scope: internal/db/db.go (+51/-2), internal/db/referential_integrity.go (+10), internal/db/db_writerwait_test.go (+190)
BLOCKERS: none
  §1 schema/scan: untouched — no agentColumns/scanAgent edit, no migration.
  §2 concurrency: writerExec/beginWriterTx logic unchanged; added only start:=time.Now()+conditional log.Printf (stdlib log is mutex-guarded); refScanReadHook is a test-only seam, nil in prod. No new shared mutable state.
  §3 single-writer: observability-only — no new writer handle, no DSN change, no new per-request SQLite write. The diagnostic is log.Printf, bounded by the writerSlowWait=2s threshold (low volume).
  §4 boundary / §5 MCP surface / §6 lifecycle: N/A — diff touches none.
  AC5: writerTimeout / referentialScanTimeout assignments byte-identical to main (git diff shows no +/- on those lines).
NITS: none.
```

Tests: 6 AC tests in db_writerwait_test.go — writerExec slow-wait logs one prefixed line (AC1) / high-threshold reverts to silent (AC1) / uncontended is silent (AC2), begin-tx logs caller via runtime.Caller(1) (AC3), error/deadline path still logs + returns err (AC4), scan logs `integrity scan: took` on slow duration. `go test -tags fts5 ./internal/db/...` 313 pass; `-race -count=3` on the 6 new = 18 pass, no data race; `go vet` clean; gofmt clean.
## review-agent-runtime verdict: SHIP

```
review-agent-runtime: PASS
Scope: internal/db/db.go (+51/-2), internal/db/referential_integrity.go (+10), internal/db/db_writerwait_test.go (+190)
BLOCKERS: none
  §1 schema/scan: untouched — no agentColumns/scanAgent edit, no migration.
  §2 concurrency: writerExec/beginWriterTx logic unchanged; added only start:=time.Now()+conditional log.Printf (stdlib log is mutex-guarded); refScanReadHook is a test-only seam, nil in prod. No new shared mutable state.
  §3 single-writer: observability-only — no new writer handle, no DSN change, no new per-request SQLite write. The diagnostic is log.Printf, bounded by the writerSlowWait=2s threshold (low volume).
  §4 boundary / §5 MCP surface / §6 lifecycle: N/A — diff touches none.
  AC5: writerTimeout / referentialScanTimeout assignments byte-identical to main (git diff shows no +/- on those lines).
NITS: none.
```

Tests: 6 AC tests in db_writerwait_test.go — writerExec slow-wait logs one prefixed line (AC1) / high-threshold reverts to silent (AC1) / uncontended is silent (AC2), begin-tx logs caller via runtime.Caller(1) (AC3), error/deadline path still logs + returns err (AC4), scan logs `integrity scan: took` on slow duration. `go test -tags fts5 ./internal/db/...` 313 pass; `-race -count=3` on the 6 new = 18 pass, no data race; `go vet` clean; gofmt clean.

---
<sub>Authored by agent `wraith-backend-2` · branch `wraith-backend-2/db-writer-wait-diag` → `main` · reviewed by niwa-gate and merged when this repo's checks pass.</sub>
