### PR TITLE
[wraith/relay] lowercase-at-write for profile slug, task assigned_to/profile_slug, agent profile_slug — closes the 4 write-path gaps behind the referential scan's LOWER()

### DIFF
--- a/features/wraith-relay-lowercase-at-write-for-profile-slug-task-assigned-to-profile-slug-a.md
+++ b/features/wraith-relay-lowercase-at-write-for-profile-slug-task-assigned-to-profile-slug-a.md
@@ -1,0 +1,56 @@
+# [wraith/relay] lowercase-at-write for profile slug, task assigned_to/profile_slug, agent profile_slug — closes the 4 write-path gaps behind the referential scan's LOWER()
+
+## Team : wraith-backend-2 (tsukumo)
+## Branch : wraith-backend-2/lowercase-at-write (from main)
+## Relay task : df850e85-7d64-4272-95bb-38b5e7121c86
+## Status : 🔵 SUBMITTED
+
+## 1. Product Brief
+
+### Acceptance Criteria
+- [ ] 1. AC1 named test: register_profile with slug 'Wraith-Backend' stores 'wraith-backend' and get_profile('Wraith-Backend') resolves it
+- [ ] 2. AC2 named test: dispatch_task with assigned_to 'Wraith-Backend-2' and profile_slug 'Wraith-Backend' stores both lowercase; update_task assigned_to 'Wraith-Backend-2' reassign stores lowercase
+- [ ] 3. AC3 named test: register_agent with profile_slug 'Wraith-Backend' stores 'wraith-backend'
+- [ ] 4. AC4 regression: existing handlers tests for profiles/tasks/agents green and a lowercase input at each of the 4 sites produces byte-identical stored rows to today's
+- [ ] 5. AC5 scope: diff touches at most handlers_profiles.go, handlers_tasks.go, handlers_agents.go and one test file; no db/ package change, no migration
+
+## 2. Root cause & decisions
+
+ROOT_CAUSE: The referential scan is dropping its LOWER() (ticket B2) to rely on plain equality, but four write paths still stored agent/profile identifiers verbatim — so a future mixed-case register would silently break lookups and the scan. Fix: normalize at write time (lowercase + trim) at all four gap sites, and lowercase the matching lookup inputs so a mixed-case caller still resolves. Handler contract unchanged (same params/responses), no DB or migration change.
+
+## review-agent-runtime verdict: SHIP
+
+```
+review-agent-runtime: PASS
+Scope: internal/relay/handlers_profiles.go (+5/-2), handlers_tasks.go (+6/-... 2 sites), handlers_agents.go (+2/-1), handlers_lowercase_write_test.go (+129)
+BLOCKERS: none
+  §1 schema/scan: untouched — no agentColumns/scanAgent edit, no migration, no new column.
+  §2 concurrency: no state-transition change; edits only normalize an input string before the existing DB call. No new shared state, no new locks.
+  §3 single-writer/availability: observability-neutral — no new writer handle, no DSN change, no new per-request write; get_profile still guards nil profile. get_profile/dispatch/reassign lookup inputs are lowercased so they match the now-lowercased stored rows — the ticket confirms live DB has 0 rows differing from LOWER() on agents.name/tasks.assigned_to/profiles.slug, so no existing mixed-case row is stranded; this normalization IS the enforcement B2 depends on.
+  §4 boundary / §6 lifecycle: N/A — no bind/auth/route/updater/shutdown change.
+  §5 MCP surface: no new tool (registry untouched), identity resolution (resolveProject/resolveAgent) unchanged; contract additive-safe — only the stored value is normalized, omitted fields still behave as today (optionalStringLower returns nil on "", same as optionalString).
+  AC5 scope: diff = exactly the 3 named handlers + 1 test file, no db/ package change, no migration.
+NITS: none.
+```
+
+Tests (internal/relay): 5 AC tests in handlers_lowercase_write_test.go — TestRegisterProfileLowercasesSlug (AC1: stores lowercase + mixed-case get_profile resolves), TestDispatchTaskLowercasesProfileSlug (AC2 dispatch), TestUpdateTaskReassignLowercasesAssignedTo (AC2 reassign, assigned_to + profile_slug), TestRegisterAgentLowercasesProfileSlug (AC3), TestLowercaseInputByteIdenticalStored (AC4: lowercase input is a no-op across all 4 sites). go test -tags fts5 ./internal/relay/... = 466 pass; -race -count=3 on the 5 new = 15 pass, no data race; go vet + gofmt clean; go build -tags fts5 ./... green.
+
+## 3. Files changed
+
+```
+internal/relay/handlers_agents.go               |   2 +-
+ internal/relay/handlers_lowercase_write_test.go | 129 ++++++++++++++++++++++++
+ internal/relay/handlers_profiles.go             |   5 +-
+ internal/relay/handlers_tasks.go                |   6 +-
+ 4 files changed, 136 insertions(+), 6 deletions(-)
+```
+
+## 4. QA Log
+
+_(no review round yet)_
+
+## 5. Timeline
+
+
+---
+_Auto-assembled by the niwa scribe from the Q&A gate. Task `df850e85-7d64-4272-95bb-38b5e7121c86`._

--- a/internal/relay/handlers_agents.go
+++ b/internal/relay/handlers_agents.go
@@ -102,7 +102,7 @@ func (h *Handlers) HandleRegisterAgent(ctx context.Context, req mcp.CallToolRequ
 	role := req.GetString("role", "")
 	description := req.GetString("description", "")
 	reportsTo := optionalStringLower(req.GetString("reports_to", ""))
-	profileSlug := optionalString(req.GetString("profile_slug", ""))
+	profileSlug := optionalStringLower(req.GetString("profile_slug", ""))
 	isExecutive := req.GetBool("is_executive", false)
 	sessionID := optionalString(req.GetString("session_id", ""))
 	interestTags := req.GetString("interest_tags", "[]")

--- a/internal/relay/handlers_lowercase_write_test.go
+++ b/internal/relay/handlers_lowercase_write_test.go
@@ -1,0 +1,129 @@
+package relay
+
+import "testing"
+
+// Lowercase-at-write for profile slug / agent name / task assigned_to+profile_slug
+// (task df850e85). The referential scan drops its LOWER() (ticket B2) and relies on
+// plain equality, so every identifier must be stored lowercase at write time — a
+// future mixed-case register must never silently break a lookup. These pin the four
+// gap sites the ticket named: register_profile / get_profile, dispatch profile,
+// update_task reassign, register_agent profile_slug. Handler contract is unchanged
+// (same params, same responses); only the stored value is normalized.
+
+// dispatchWithProfile dispatches a task and returns its id (handlers return a nil Go
+// error in practice; the codebase idiom ignores it and lets parseJSON surface an
+// IsError result).
+func dispatchWithProfile(t *testing.T, h *Handlers, project, as, profile string) string {
+	t.Helper()
+	res, _ := h.HandleDispatchTask(ctx, call(map[string]any{
+		"project": project, "as": as, "profile": profile, "title": "t",
+	}))
+	return parseJSON(t, res)["task"].(map[string]any)["id"].(string)
+}
+
+func taskFields(t *testing.T, h *Handlers, project, taskID string) map[string]any {
+	t.Helper()
+	res, _ := h.HandleGetTask(ctx, call(map[string]any{"project": project, "task_id": taskID}))
+	return parseJSON(t, res)
+}
+
+// TestRegisterProfileLowercasesSlug (AC1): register_profile with a mixed-case slug
+// stores it lowercase, and get_profile resolves it from the mixed-case input.
+func TestRegisterProfileLowercasesSlug(t *testing.T) {
+	h := testHandlers(t)
+
+	regRes, _ := h.HandleRegisterProfile(ctx, call(map[string]any{
+		"project": "p1", "slug": "Wraith-Backend", "name": "Wraith Backend",
+	}))
+	if got := parseJSON(t, regRes)["slug"]; got != "wraith-backend" {
+		t.Fatalf("register_profile stored slug %q, want %q", got, "wraith-backend")
+	}
+
+	// Lookup with the ORIGINAL mixed-case input must still resolve.
+	getRes, _ := h.HandleGetProfile(ctx, call(map[string]any{"project": "p1", "slug": "Wraith-Backend"}))
+	if got := parseJSON(t, getRes)["slug"]; got != "wraith-backend" {
+		t.Fatalf("get_profile(mixed-case) resolved slug %q, want %q", got, "wraith-backend")
+	}
+}
+
+// TestDispatchTaskLowercasesProfileSlug (AC2, dispatch): dispatch_task with a
+// mixed-case profile stores the task's profile_slug lowercase.
+func TestDispatchTaskLowercasesProfileSlug(t *testing.T) {
+	h := testHandlers(t)
+
+	taskID := dispatchWithProfile(t, h, "p1", "boss", "Wraith-Backend")
+	if got := taskFields(t, h, "p1", taskID)["profile_slug"]; got != "wraith-backend" {
+		t.Fatalf("dispatched task profile_slug %q, want %q", got, "wraith-backend")
+	}
+}
+
+// TestUpdateTaskReassignLowercasesAssignedTo (AC2, reassign): update_task with a
+// mixed-case assigned_to (+ profile_slug) stores both lowercase.
+func TestUpdateTaskReassignLowercasesAssignedTo(t *testing.T) {
+	h := testHandlers(t)
+
+	taskID := dispatchWithProfile(t, h, "p1", "boss", "dev")
+	// Caller = dispatcher (boss), task still pending -> both fields update freely.
+	if _, err := h.HandleUpdateTask(ctx, call(map[string]any{
+		"project": "p1", "as": "boss", "task_id": taskID,
+		"assigned_to": "Wraith-Backend-2", "profile_slug": "Wraith-Backend",
+	})); err != nil {
+		t.Fatalf("update_task: %v", err)
+	}
+
+	got := taskFields(t, h, "p1", taskID)
+	if got["assigned_to"] != "wraith-backend-2" {
+		t.Fatalf("reassigned assigned_to %q, want %q", got["assigned_to"], "wraith-backend-2")
+	}
+	if got["profile_slug"] != "wraith-backend" {
+		t.Fatalf("reassigned profile_slug %q, want %q", got["profile_slug"], "wraith-backend")
+	}
+}
+
+// TestRegisterAgentLowercasesProfileSlug (AC3): register_agent with a mixed-case
+// profile_slug stores it lowercase.
+func TestRegisterAgentLowercasesProfileSlug(t *testing.T) {
+	h := testHandlers(t)
+
+	res, _ := h.HandleRegisterAgent(ctx, call(map[string]any{
+		"project": "p1", "name": "bot-a", "profile_slug": "Wraith-Backend",
+	}))
+	agent := parseJSON(t, res)["agent"].(map[string]any)
+	if got := agent["profile_slug"]; got != "wraith-backend" {
+		t.Fatalf("registered agent profile_slug %q, want %q", got, "wraith-backend")
+	}
+}
+
+// TestLowercaseInputByteIdenticalStored (AC4): an already-lowercase input at each
+// of the four sites stores the exact value it does today — the normalization is a
+// no-op on well-formed input, so existing callers see byte-identical rows.
+func TestLowercaseInputByteIdenticalStored(t *testing.T) {
+	h := testHandlers(t)
+
+	profRes, _ := h.HandleRegisterProfile(ctx, call(map[string]any{
+		"project": "p1", "slug": "wraith-backend", "name": "n",
+	}))
+	if got := parseJSON(t, profRes)["slug"]; got != "wraith-backend" {
+		t.Fatalf("profile slug mutated for lowercase input: %q", got)
+	}
+
+	agentRes, _ := h.HandleRegisterAgent(ctx, call(map[string]any{
+		"project": "p1", "name": "bot-a", "profile_slug": "wraith-backend",
+	}))
+	agent := parseJSON(t, agentRes)["agent"].(map[string]any)
+	if got := agent["profile_slug"]; got != "wraith-backend" {
+		t.Fatalf("agent profile_slug mutated for lowercase input: %q", got)
+	}
+
+	taskID := dispatchWithProfile(t, h, "p1", "boss", "wraith-backend")
+	if _, err := h.HandleUpdateTask(ctx, call(map[string]any{
+		"project": "p1", "as": "boss", "task_id": taskID, "assigned_to": "wraith-backend-2",
+	})); err != nil {
+		t.Fatalf("update_task: %v", err)
+	}
+	got := taskFields(t, h, "p1", taskID)
+	if got["profile_slug"] != "wraith-backend" || got["assigned_to"] != "wraith-backend-2" {
+		t.Fatalf("task fields mutated for lowercase input: profile_slug=%q assigned_to=%q",
+			got["profile_slug"], got["assigned_to"])
+	}
+}

--- a/internal/relay/handlers_profiles.go
+++ b/internal/relay/handlers_profiles.go
@@ -4,13 +4,14 @@ import (
 	"agent-relay/internal/models"
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/mark3labs/mcp-go/mcp"
 )
 
 func (h *Handlers) HandleRegisterProfile(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	project := h.resolveProject(ctx, req)
-	slug := req.GetString("slug", "")
+	slug := strings.ToLower(strings.TrimSpace(req.GetString("slug", "")))
 	if slug == "" {
 		return toolResultError("slug is required"), nil
 	}
@@ -30,7 +31,7 @@ func (h *Handlers) HandleRegisterProfile(ctx context.Context, req mcp.CallToolRe
 
 func (h *Handlers) HandleGetProfile(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	project := h.resolveProject(ctx, req)
-	slug := req.GetString("slug", "")
+	slug := strings.ToLower(strings.TrimSpace(req.GetString("slug", "")))
 	if slug == "" {
 		return toolResultError("slug is required"), nil
 	}

--- a/internal/relay/handlers_tasks.go
+++ b/internal/relay/handlers_tasks.go
@@ -68,7 +68,7 @@ func taskErrorCategory(code string) (category string, retryable bool) {
 func (h *Handlers) HandleDispatchTask(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	project := h.resolveProject(ctx, req)
 	agent := resolveAgent(ctx, req)
-	profile := req.GetString("profile", "")
+	profile := strings.ToLower(strings.TrimSpace(req.GetString("profile", "")))
 	requiredSkill := req.GetString("required_skill", "")
 	// Quota check: tasks
 	if qErr := h.db.CheckQuotaError(project, agent, "tasks"); qErr != "" {
@@ -937,8 +937,8 @@ func (h *Handlers) HandleUpdateTask(ctx context.Context, req mcp.CallToolRequest
 		}
 	}
 
-	assignedTo := optionalString(strings.TrimSpace(req.GetString("assigned_to", "")))
-	profileSlug := optionalString(strings.TrimSpace(req.GetString("profile_slug", "")))
+	assignedTo := optionalStringLower(strings.TrimSpace(req.GetString("assigned_to", "")))
+	profileSlug := optionalStringLower(strings.TrimSpace(req.GetString("profile_slug", "")))
 
 	title := optionalString(req.GetString("title", ""))
 	description := optionalString(req.GetString("description", ""))


### PR DESCRIPTION
### niwa Q&A gate

An adversarial reviewer is reading this diff right now. Its verdict lands on this PR as a review (or a comment when the gate and the author share one GitHub account), and the merge waits for this repository's own checks to go green.

*Opened automatically — a rejected round comes back to the author, who pushes fixes to the same branch.*

## What & why

- **docs(scribe): provenance for wraith-relay-lowercase-at-write-for-profile-slug-task-assigned-to-profile-slug-a**
- **fix: [wraith/relay] lowercase-at-write for profile slug, task assigned_to/profile_slug, agent profile_slug**
  <details><summary>details</summary>

  Closes the 4 write-path gaps behind the referential scan's LOWER() drop (ticket B2):
  register_profile/get_profile slug (handlers_profiles.go), dispatch profile +
  update_task reassign assigned_to/profile_slug (handlers_tasks.go), register_agent
  profile_slug (handlers_agents.go). Uses the existing optionalStringLower /
  strings.ToLower(strings.TrimSpace(...)) helper; lookups lowercase their input so a
  mixed-case caller still resolves. Handler contract unchanged, no DB/migration.
  
  Claude-Session: https://claude.ai/code/session_019FcVkfwxhJvA5ovCbPpBn3

  </details>

## Changes

<details><summary>Files changed (git diff --stat)</summary>

```
...profile-slug-task-assigned-to-profile-slug-a.md |  56 +++++++++
 internal/relay/handlers_agents.go                  |   2 +-
 internal/relay/handlers_lowercase_write_test.go    | 129 +++++++++++++++++++++
 internal/relay/handlers_profiles.go                |   5 +-
 internal/relay/handlers_tasks.go                   |   6 +-
 5 files changed, 192 insertions(+), 6 deletions(-)
```

</details>

## Module graph

```mermaid
graph TD
  n0["features/wraith-relay-lowercase-at-write-for-profile-slug-task-assigned-to-profile-slug-a.md"]
  n1["internal/relay"]
```

## Acceptance criteria

- [x] AC1 named test: register_profile with slug 'Wraith-Backend' stores 'wraith-backend' and get_profile('Wraith-Backend') resolves it
- [x] AC2 named test: dispatch_task with assigned_to 'Wraith-Backend-2' and profile_slug 'Wraith-Backend' stores both lowercase; update_task assigned_to 'Wraith-Backend-2' reassign stores lowercase
- [x] AC3 named test: register_agent with profile_slug 'Wraith-Backend' stores 'wraith-backend'
- [x] AC4 regression: existing handlers tests for profiles/tasks/agents green and a lowercase input at each of the 4 sites produces byte-identical stored rows to today's
- [x] AC5 scope: diff touches at most handlers_profiles.go, handlers_tasks.go, handlers_agents.go and one test file; no db/ package change, no migration
## Provenance

📄 [Root cause, decisions &amp; QA log — `features/wraith-relay-lowercase-at-write-for-profile-slug-task-assigned-to-profile-slug-a.md`](https://github.com/TsukumoHQ/WRAI.TH/blob/wraith-backend-2/lowercase-at-write/features/wraith-relay-lowercase-at-write-for-profile-slug-task-assigned-to-profile-slug-a.md)

## Gate verdict

**✅ APPROVED** · round 1 · reviewer `review-df850e85-7d64-4272-95bb-38b5e7121c86`

## review-agent-runtime verdict: SHIP

```
review-agent-runtime: PASS
Scope: internal/relay/handlers_profiles.go (+5/-2), handlers_tasks.go (+6/-... 2 sites), handlers_agents.go (+2/-1), handlers_lowercase_write_test.go (+129)
BLOCKERS: none
  §1 schema/scan: untouched — no agentColumns/scanAgent edit, no migration, no new column.
  §2 concurrency: no state-transition change; edits only normalize an input string before the existing DB call. No new shared state, no new locks.
  §3 single-writer/availability: observability-neutral — no new writer handle, no DSN change, no new per-request write; get_profile still guards nil profile. get_profile/dispatch/reassign lookup inputs are lowercased so they match the now-lowercased stored rows — the ticket confirms live DB has 0 rows differing from LOWER() on agents.name/tasks.assigned_to/profiles.slug, so no existing mixed-case row is stranded; this normalization IS the enforcement B2 depends on.
  §4 boundary / §6 lifecycle: N/A — no bind/auth/route/updater/shutdown change.
  §5 MCP surface: no new tool (registry untouched), identity resolution (resolveProject/resolveAgent) unchanged; contract additive-safe — only the stored value is normalized, omitted fields still behave as today (optionalStringLower returns nil on "", same as optionalString).
  AC5 scope: diff = exactly the 3 named handlers + 1 test file, no db/ package change, no migration.
NITS: none.
```

Tests (internal/relay): 5 AC tests in handlers_lowercase_write_test.go — TestRegisterProfileLowercasesSlug (AC1: stores lowercase + mixed-case get_profile resolves), TestDispatchTaskLowercasesProfileSlug (AC2 dispatch), TestUpdateTaskReassignLowercasesAssignedTo (AC2 reassign, assigned_to + profile_slug), TestRegisterAgentLowercasesProfileSlug (AC3), TestLowercaseInputByteIdenticalStored (AC4: lowercase input is a no-op across all 4 sites). go test -tags fts5 ./internal/relay/... = 466 pass; -race -count=3 on the 5 new = 15 pass, no data race; go vet + gofmt clean; go build -tags fts5 ./... green.
## review-agent-runtime verdict: SHIP

```
review-agent-runtime: PASS
Scope: internal/relay/handlers_profiles.go (+5/-2), handlers_tasks.go (+6/-... 2 sites), handlers_agents.go (+2/-1), handlers_lowercase_write_test.go (+129)
BLOCKERS: none
  §1 schema/scan: untouched — no agentColumns/scanAgent edit, no migration, no new column.
  §2 concurrency: no state-transition change; edits only normalize an input string before the existing DB call. No new shared state, no new locks.
  §3 single-writer/availability: observability-neutral — no new writer handle, no DSN change, no new per-request write; get_profile still guards nil profile. get_profile/dispatch/reassign lookup inputs are lowercased so they match the now-lowercased stored rows — the ticket confirms live DB has 0 rows differing from LOWER() on agents.name/tasks.assigned_to/profiles.slug, so no existing mixed-case row is stranded; this normalization IS the enforcement B2 depends on.
  §4 boundary / §6 lifecycle: N/A — no bind/auth/route/updater/shutdown change.
  §5 MCP surface: no new tool (registry untouched), identity resolution (resolveProject/resolveAgent) unchanged; contract additive-safe — only the stored value is normalized, omitted fields still behave as today (optionalStringLower returns nil on "", same as optionalString).
  AC5 scope: diff = exactly the 3 named handlers + 1 test file, no db/ package change, no migration.
NITS: none.
```

Tests (internal/relay): 5 AC tests in handlers_lowercase_write_test.go — TestRegisterProfileLowercasesSlug (AC1: stores lowercase + mixed-case get_profile resolves), TestDispatchTaskLowercasesProfileSlug (AC2 dispatch), TestUpdateTaskReassignLowercasesAssignedTo (AC2 reassign, assigned_to + profile_slug), TestRegisterAgentLowercasesProfileSlug (AC3), TestLowercaseInputByteIdenticalStored (AC4: lowercase input is a no-op across all 4 sites). go test -tags fts5 ./internal/relay/... = 466 pass; -race -count=3 on the 5 new = 15 pass, no data race; go vet + gofmt clean; go build -tags fts5 ./... green.

---
<sub>Authored by agent `wraith-backend-2` · branch `wraith-backend-2/lowercase-at-write` → `main` · reviewed by niwa-gate and merged when this repo's checks pass.</sub>
