### PR TITLE
[wraith/console] v2 header: 'v1 console' back-link to / (mirror of v1 #v2-link) — founder order 11:30Z

### DIFF
--- a/features/wraith-console-v2-header-v1-console-back-link-to-mirror-of-v1-v2-link-founder-or.md
+++ b/features/wraith-console-v2-header-v1-console-back-link-to-mirror-of-v1-v2-link-founder-or.md
@@ -1,0 +1,79 @@
+# [wraith/console] v2 header: 'v1 console' back-link to / (mirror of v1 #v2-link) — founder order 11:30Z
+
+## Team : wraith-engine-2 (tsukumo)
+## Branch : wraith-engine-2/v2-v1-link (from main)
+## Relay task : bd7b7922-9c34-49ed-a2d2-bd7ad56a0be9
+## Status : 🔵 SUBMITTED
+
+## 1. Product Brief
+
+### Acceptance Criteria
+- [ ] 1. AC1 named test: static/v2/index.html contains an <a> with id="v1-link", href="/", class containing back-chip, a non-empty aria-label, and no tabindex attribute (keyboard-reachable); the element sits inside the hdr-right div
+- [ ] 2. AC2 named test: the string v1-link appears in NO v1 asset (static/index.html, static/style.css, static/js/main.js) and v1's existing id="v2-link" anchor (href="/v2/") is still present unchanged
+- [ ] 3. AC3 named smoke test: the v2 index still contains the live status span id="liveStatus" inside hdr-right after the link (layout preserved); scope: diff touches exactly internal/web/static/v2/index.html + internal/relay/console_v2_v1_link_test.go; go test -tags fts5 ./internal/relay/... green
+
+## 2. Root cause & decisions
+
+# Decision — bd7b7922 [wraith/console] v2 header 'v1 console' back-link
+
+ROOT_CAUSE: v2 console had no way back to the v1 console; founder order 11:30Z
+(cto-tsukumo msg 9118bd5e T1: "il faut un bouton pour revenir a la v1 depuis la v2").
+
+## Decision
+Add a back-link `<a id="v1-link" class="back-chip" href="/">v1 console</a>` inside the
+v2 header's `<div class="hdr-right">`, before the live-status span. Mirror of the v1
+`#v2-link` anchor (internal/web/static/index.html:70). Reuse the existing `.back-chip`
+class already in v2.css (used by the project back link) so v2.css is NOT touched. Plain
+`<a href>` = natively keyboard-focusable, so no tabindex and no JS.
+
+## Files (2)
+- internal/web/static/v2/index.html — +1 line, the anchor
+- internal/relay/console_v2_v1_link_test.go — new, 3 named tests (readCfgAsset pattern)
+
+## ACs → tests
+- AC1 TestV2V1LinkPresent — anchor id=v1-link, href=/, class has back-chip, non-empty
+  aria-label, no tabindex, inside hdr-right.
+- AC2 TestV2V1LinkNoV1Leak — id v1-link in NO v1 asset; v1 id=v2-link (href=/v2/) intact.
+- AC3 TestV2V1LinkLayoutPreserved — liveStatus span still in hdr-right, after the link.
+
+## Rejected alternatives
+- New CSS class / edit v2.css: rejected — .back-chip already fits, keeps diff to 2 files.
+- Button + JS navigation: rejected — plain anchor is natively focusable, zero JS.
+
+## Verify
+go test -tags fts5 ./internal/relay/... → 469 passed (3 new). build/vet/gofmt clean.
+
+No LEGACY_OPPORTUNITY. v1 assets byte-identical.
+
+## review-wraith verdict: SHIP
+Scope: internal/web/static/v2/index.html (+1 line anchor), internal/relay/console_v2_v1_link_test.go (new, 3 tests)
+Gate: build -tags fts5 OK / vet OK / gofmt OK / test -tags fts5 OK (469 passed, 3 new)
+
+BLOCKERS (must fix before merge):
+- none
+
+NITS (non-blocking):
+- none
+
+Notes: static asset + test only. No DB/schema/writer/messaging/dispatch/MCP/updater
+surface touched — thesis (SSOT, single-writer, backward-compat) not in scope. v2.css
+untouched (reused .back-chip). v1 assets byte-identical (AC2 asserts no v1-link leak +
+v2-link intact). Plain anchor, no tabindex/JS = natively keyboard-reachable.
+
+## 3. Files changed
+
+```
+internal/relay/console_v2_v1_link_test.go | 103 ++++++++++++++++++++++++++++++
+ internal/web/static/v2/index.html         |   1 +
+ 2 files changed, 104 insertions(+)
+```
+
+## 4. QA Log
+
+_(no review round yet)_
+
+## 5. Timeline
+
+
+---
+_Auto-assembled by the niwa scribe from the Q&A gate. Task `bd7b7922-9c34-49ed-a2d2-bd7ad56a0be9`._

--- a/internal/relay/console_v2_v1_link_test.go
+++ b/internal/relay/console_v2_v1_link_test.go
@@ -1,0 +1,103 @@
+package relay
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+
+	"agent-relay/internal/web"
+)
+
+// readV1LinkAsset loads an embedded static asset (readCfgAsset pattern, see
+// console_v2_config_panel_test.go:13 — web.StaticFiles.ReadFile).
+func readV1LinkAsset(t *testing.T, name string) string {
+	t.Helper()
+	b, err := web.StaticFiles.ReadFile(name)
+	if err != nil {
+		t.Fatalf("read embedded asset %s: %v", name, err)
+	}
+	return string(b)
+}
+
+// hdrRightBlock returns the inner HTML of the v2 header's <div class="hdr-right">.
+// hdr-right holds no nested <div>, so the first </div> after it closes it.
+func hdrRightBlock(t *testing.T, html string) string {
+	t.Helper()
+	open := strings.Index(html, `<div class="hdr-right">`)
+	if open < 0 {
+		t.Fatal("v2 index: no <div class=\"hdr-right\"> in header")
+	}
+	rest := html[open:]
+	end := strings.Index(rest, "</div>")
+	if end < 0 {
+		t.Fatal("v2 index: hdr-right div is not closed")
+	}
+	return rest[:end]
+}
+
+var v1LinkAnchorRe = regexp.MustCompile(`<a\b[^>]*\bid="v1-link"[^>]*>`)
+
+// TestV2HeaderV1LinkPresent — AC1: the v2 header carries a keyboard-reachable back-link
+// to the v1 console: an <a> with id="v1-link", href="/", a class containing
+// back-chip, a non-empty aria-label, and NO tabindex, sitting inside hdr-right.
+func TestV2HeaderV1LinkPresent(t *testing.T) {
+	html := readV1LinkAsset(t, "static/v2/index.html")
+	block := hdrRightBlock(t, html)
+
+	tag := v1LinkAnchorRe.FindString(block)
+	if tag == "" {
+		t.Fatal("hdr-right has no <a id=\"v1-link\"> back-link")
+	}
+	if !strings.Contains(tag, `href="/"`) {
+		t.Errorf("v1-link href is not \"/\": %q", tag)
+	}
+	cls := regexp.MustCompile(`class="([^"]*)"`).FindStringSubmatch(tag)
+	if cls == nil || !strings.Contains(cls[1], "back-chip") {
+		t.Errorf("v1-link class does not contain back-chip: %q", tag)
+	}
+	al := regexp.MustCompile(`aria-label="([^"]*)"`).FindStringSubmatch(tag)
+	if al == nil || strings.TrimSpace(al[1]) == "" {
+		t.Errorf("v1-link has no non-empty aria-label: %q", tag)
+	}
+	if strings.Contains(tag, "tabindex") {
+		t.Errorf("v1-link carries a tabindex (must be natively focusable): %q", tag)
+	}
+}
+
+// TestV1AssetsUntouchedByV1Link — AC2: the id v1-link appears in NO v1 asset, and v1's
+// existing id="v2-link" anchor (href="/v2/") is still present unchanged.
+func TestV1AssetsUntouchedByV1Link(t *testing.T) {
+	for _, name := range []string{"static/index.html", "static/style.css", "static/js/main.js"} {
+		a := readV1LinkAsset(t, name)
+		if strings.Contains(a, "v1-link") {
+			t.Errorf("v1 asset %s leaked the v2 id v1-link", name)
+		}
+	}
+	v1 := readV1LinkAsset(t, "static/index.html")
+	v2Anchor := regexp.MustCompile(`<a\b[^>]*\bid="v2-link"[^>]*>`).FindString(v1)
+	if v2Anchor == "" {
+		t.Fatal("v1 index no longer has its id=\"v2-link\" anchor")
+	}
+	if !strings.Contains(v2Anchor, `href="/v2/"`) {
+		t.Errorf("v1 v2-link anchor href changed (want /v2/): %q", v2Anchor)
+	}
+}
+
+// TestV2HeaderLayoutPreservedSmoke — AC3: the live status span id="liveStatus" is
+// still inside hdr-right, and it sits AFTER the v1 back-link (layout preserved).
+func TestV2HeaderLayoutPreservedSmoke(t *testing.T) {
+	html := readV1LinkAsset(t, "static/v2/index.html")
+	block := hdrRightBlock(t, html)
+
+	linkIdx := strings.Index(block, `id="v1-link"`)
+	liveIdx := strings.Index(block, `id="liveStatus"`)
+	if linkIdx < 0 {
+		t.Fatal("hdr-right has no v1-link")
+	}
+	if liveIdx < 0 {
+		t.Fatal("hdr-right no longer has the liveStatus span")
+	}
+	if linkIdx >= liveIdx {
+		t.Errorf("v1-link must sit before liveStatus (link at %d, live at %d)", linkIdx, liveIdx)
+	}
+}

--- a/internal/web/static/v2/index.html
+++ b/internal/web/static/v2/index.html
@@ -31,6 +31,7 @@
         </div>
       </div>
       <div class="hdr-right">
+        <a id="v1-link" class="back-chip" href="/" title="Back to the v1 console" aria-label="Back to the v1 console">v1 console</a>
         <span class="live" id="liveStatus" data-state="connecting">
           <span class="live-dot"></span><span class="live-label" id="liveLabel">connecting</span>
         </span>


### PR DESCRIPTION
### niwa Q&A gate

An adversarial reviewer is reading this diff right now. Its verdict lands on this PR as a review (or a comment when the gate and the author share one GitHub account), and the merge waits for this repository's own checks to go green.

*Opened automatically — a rejected round comes back to the author, who pushes fixes to the same branch.*

## What & why

- **docs(scribe): provenance for wraith-console-v2-header-v1-console-back-link-to-mirror-of-v1-v2-link-founder-or**
- **feat: [wraith/console] v2 header 'v1 console' back-link to /**
  <details><summary>details</summary>

  Founder order 11:30Z (cto-tsukumo msg 9118bd5e T1). Mirror of v1 #v2-link.
  Add <a id=v1-link class=back-chip href=/> in v2 hdr-right, before live status.
  Reuse existing .back-chip style (v2.css untouched). Plain anchor = natively
  focusable, no tabindex/JS. v1 assets byte-identical.
  
  Tests (internal/relay/console_v2_v1_link_test.go, readCfgAsset pattern):
  - TestV2V1LinkPresent (AC1)
  - TestV2V1LinkNoV1Leak (AC2)
  - TestV2V1LinkLayoutPreserved (AC3)
  
  Task: bd7b7922-9c34-49ed-a2d2-bd7ad56a0be9
  Claude-Session: https://claude.ai/code/session_01XbzhXo1kXCNX9qC6jaZ6pp

  </details>

## Changes

<details><summary>Files changed (git diff --stat)</summary>

```
...back-link-to-mirror-of-v1-v2-link-founder-or.md |  79 ++++++++++++++++
 internal/relay/console_v2_v1_link_test.go          | 103 +++++++++++++++++++++
 internal/web/static/v2/index.html                  |   1 +
 3 files changed, 183 insertions(+)
```

</details>

## Module graph

```mermaid
graph TD
  n0["features/wraith-console-v2-header-v1-console-back-link-to-mirror-of-v1-v2-link-founder-or.md"]
  n1["internal/relay"]
  n2["internal/web"]
  n1 --- n2
```

## Acceptance criteria

- [x] AC1 named test: static/v2/index.html contains an <a> with id="v1-link", href="/", class containing back-chip, a non-empty aria-label, and no tabindex attribute (keyboard-reachable); the element sits inside the hdr-right div
- [x] AC2 named test: the string v1-link appears in NO v1 asset (static/index.html, static/style.css, static/js/main.js) and v1's existing id="v2-link" anchor (href="/v2/") is still present unchanged
- [x] AC3 named smoke test: the v2 index still contains the live status span id="liveStatus" inside hdr-right after the link (layout preserved); scope: diff touches exactly internal/web/static/v2/index.html + internal/relay/console_v2_v1_link_test.go; go test -tags fts5 ./internal/relay/... green
## Provenance

📄 [Root cause, decisions &amp; QA log — `features/wraith-console-v2-header-v1-console-back-link-to-mirror-of-v1-v2-link-founder-or.md`](https://github.com/TsukumoHQ/WRAI.TH/blob/wraith-engine-2/v2-v1-link/features/wraith-console-v2-header-v1-console-back-link-to-mirror-of-v1-v2-link-founder-or.md)

## Gate verdict

**✅ APPROVED** · round 1 · reviewer `review-bd7b7922-9c34-49ed-a2d2-bd7ad56a0be9`

## review-wraith verdict: SHIP
Scope: internal/web/static/v2/index.html (+1 line anchor), internal/relay/console_v2_v1_link_test.go (new, 3 tests)
Gate: build -tags fts5 OK / vet OK / gofmt OK / test -tags fts5 OK (469 passed, 3 new)

BLOCKERS (must fix before merge):
- none

NITS (non-blocking):
- none

Notes: static asset + test only. No DB/schema/writer/messaging/dispatch/MCP/updater
surface touched — thesis (SSOT, single-writer, backward-compat) not in scope. v2.css
untouched (reused .back-chip). v1 assets byte-identical (AC2 asserts no v1-link leak +
v2-link intact). Plain anchor, no tabindex/JS = natively keyboard-reachable.
## review-wraith verdict: SHIP
Scope: internal/web/static/v2/index.html (+1 line anchor), internal/relay/console_v2_v1_link_test.go (new, 3 tests)
Gate: build -tags fts5 OK / vet OK / gofmt OK / test -tags fts5 OK (469 passed, 3 new)

BLOCKERS (must fix before merge):
- none

NITS (non-blocking):
- none

Notes: static asset + test only. No DB/schema/writer/messaging/dispatch/MCP/updater
surface touched — thesis (SSOT, single-writer, backward-compat) not in scope. v2.css
untouched (reused .back-chip). v1 assets byte-identical (AC2 asserts no v1-link leak +
v2-link intact). Plain anchor, no tabindex/JS = natively keyboard-reachable.

---
<sub>Authored by agent `wraith-engine-2` · branch `wraith-engine-2/v2-v1-link` → `main` · reviewed by niwa-gate and merged when this repo's checks pass.</sub>

## Schéma

```mermaid
flowchart LR
    subgraph Before["BEFORE"]
        direction LR
        V1B["v1 console"] -->|v2-link| V2B["v2 console"]
    end
    
    subgraph After["AFTER"]
        direction LR
        V1A["v1 console"] -->|v2-link| V2A["v2 console"]
        V2A -->|v1-link| V1A
    end
```
