### PR TITLE
[wraith/relay] T2a settings spec table: one server-side spec drives allowlist + PUT validation (400/403 whole-request) + GET /api/settings per-key metadata (frozen contract)

### DIFF
--- a/features/wraith-relay-t2a-settings-spec-table-one-server-side-spec-drives-allowlist-put-v.md
+++ b/features/wraith-relay-t2a-settings-spec-table-one-server-side-spec-drives-allowlist-put-v.md
@@ -1,0 +1,82 @@
+# [wraith/relay] T2a settings spec table: one server-side spec drives allowlist + PUT validation (400/403 whole-request) + GET /api/settings per-key metadata (frozen contract)
+
+## Team : wraith-backend-2 (tsukumo)
+## Branch : wraith-backend-2/settings-spec (from main)
+## Relay task : cd34c6ce-1bdf-4eea-8819-26d132b03599
+## Status : 🔵 SUBMITTED
+
+## 1. Product Brief
+
+### Acceptance Criteria
+- [ ] 1. AC1 named test: writableKeys() is derived from settingSpecs and equals exactly the 24 writable keys = 9 legacy (sun_type, linear_enabled, linear_api_key, linear_team_key, linear_project, linear_reconcile_interval, linear_routing, linear_project_map, federation_peers) + the 15 Operational writable keys listed in the ticket; the legacy var writableSettings is ALSO spec-derived (Writable && group in console|linear|federation), equals exactly those 9 keys and is a strict subset of writableKeys(); apiPutSetting consults the spec (writableKeys), never writableSettings; spec keys are unique and every group is one of console|linear|federation|server|operational|timing (RULING wraith-cto A5 14:22Z, ticket contradiction AC1 vs AC5 reported by doer msg 75477041)
+- [ ] 2. AC2 named test: PUT message_retention=1h (below min 24h) returns 400 {error:invalid value,key,detail} and the stored value is unchanged; PUT ack_notify_age=50m ALONE with ack_escalate_age=45m stored returns 400 and nothing is applied; PUT {ack_notify_age:50m, ack_escalate_age:60m} returns 200 and both are stored
+- [ ] 3. AC3 named test: GET /api/settings returns the frozen shape: top-level groups in the fixed order and a settings array where EVERY entry has all 12 fields (key, group, kind, value, set, source, writable, secret, env_name, bounds, default, note); with LINEAR_API_KEY set in env the entry has source=env and set=true; a Timing entry (writer_timeout) has source=code, writable=false, value=15s
+- [ ] 4. AC4 named test: for linear_api_key the GET value is always empty and set reflects presence; PUT linear_api_key:"" leaves the stored key unchanged; PUT linear_api_key:null clears it (set=false afterwards); the captured server log for these requests contains no fragment of the secret value
+- [ ] 5. AC5 named test: PUT with an unknown key (evil_key) alongside a valid key returns 403 and applies nothing (whole-request), and the pre-existing TestV2ConfigPanel passes unchanged; scope: diff touches exactly internal/relay/settings_spec.go, internal/relay/api.go, internal/relay/settings_spec_test.go; go test -tags fts5 ./internal/relay/... green
+
+## 2. Root cause & decisions
+
+# Decision — ticket T2a cd34c6ce (settings spec table: allowlist + PUT validation + GET metadata)
+
+## ROOT_CAUSE
+Not a bug fix — a capability gap. The v2 config panel exposed only 8 keys (sun_type + 7
+Linear); the rest of the configuration surface was env-only / compile-time / hand-SQL with no
+server-side description, so nothing could drive an allowlist, PUT validation, or per-key GET
+metadata. Fix: one server-side settingSpec table as the single source for all three
+(design record trovex 6f73f179).
+
+## SCOPE
+3 files: internal/relay/settings_spec.go (new), internal/relay/api.go, internal/relay/settings_spec_test.go (new).
+
+## FIX
+- settings_spec.go: settingSpec + settingSpecs (full config surface, D2). Spec-derived
+  writableSettings (Writable && group console|linear|federation = 9 panel keys) and
+  writableKeys() (all 24 Writable). resolveSetting (env>setting>default; Timing=code).
+  validateValue (kind+bounds). validateSettings (whole-request 403/400 + cross-key
+  ack_escalate>ack_notify, dl_long>=dl_short vs effective/stored). settingsMetadata
+  (frozen 12-field shape).
+- api.go: apiGetSettings + PUT-200 return legacy v1-compat fields alongside groups/settings.
+  apiPutSetting decodes map[string]*string (null=clear, ""=unchanged on secret), validates
+  before any SetSetting (nothing applied on reject), hot-reload hooks unchanged, secrets
+  never logged. Old hardcoded writableSettings removed (now spec-derived).
+- 403 error="not writable: <key>"+key and 400 error="invalid value: <key>"+key+detail
+  (cto ruling A6, msg 8fb42359): symmetric human strings naming the refused key (keeps the
+  pre-existing panel ServerErrorSurfaced test green), machine-readable `key`/`detail` fields intact.
+
+## Tests (one per AC)
+- AC1 TestSettingsSpecAllowlistDerived: writableKeys()==24 (9 legacy + 15 op), writableSettings==9
+  spec-derived subset, PUT of an operational key (not in panel allowlist) applies via spec.
+- AC2 TestSettingsPutBoundsAndCrossKey: below-min 400 nothing stored; ack_notify alone vs stored
+  escalate 400 nothing applied; valid pair 200 both stored.
+- AC3 TestSettingsGetFrozenShape: groups fixed order; every entry 12 fields; env secret source=env
+  set=true; writer_timeout source=code writable=false value=15s.
+- AC4 TestSettingsSecretHandling: secret value always ""; PUT "" unchanged; PUT null clears (set=false);
+  server log never contains the secret.
+- AC5 TestSettingsUnknownKeyWholeRequest: unknown key alongside valid → 403, nothing applied; panel
+  allowlist stays 9. (Pre-existing TestV2ConfigPanel passes unchanged.)
+
+## review-agent-runtime verdict: SHIP
+Scope: internal/relay settings surface (settings_spec.go, api.go, settings_spec_test.go).
+§1 no agentColumns/scanAgent touch, no migration, no schema change — reads the existing settings table via GetSetting. §2 settingSpecs/specByKey/writableSettings/settingGroups are immutable package vars built once (no runtime mutation, no new goroutine, no shared-map write). §3 PUT still writes via SetSetting (single writer) at the same frequency (rare dashboard action, whole-request); GET/validate read via GetSetting (ro pool) — no new per-request write on a hot path; fallible reads return "" (GetSetting swallows err), no nil-deref. §4 no new route/bind/auth; PUT allowlist is now stricter (spec-driven), whole-request 403/400 before apply; secrets never returned (value "") or logged (verified by AC4 log-capture). §5/§6 no MCP tool, lifecycle or self-update change. v1 assets untouched; v1 GET fields (linear_mode + nested linear) preserved byte-compatible.
+BLOCKERS: none.
+NITS: sun_type gains kind=int min=1 validation (was unvalidated) — a deliberate PUT-validation improvement per ticket, rejects non-int sun_type; flagged, not a regression. Server RO group carries 14 env keys (11 + 3 webhook secrets) vs the ticket's "13" tally — no AC asserts the count; noted.
+Gate: go test -tags fts5 ./internal/relay/... = 474 pass; vet clean; gofmt clean; 5 AC tests + pre-existing TestV2ConfigPanel green.
+
+## 3. Files changed
+
+```
+internal/relay/api.go                |  87 +++++---
+ internal/relay/settings_spec.go      | 378 +++++++++++++++++++++++++++++++++++
+ internal/relay/settings_spec_test.go | 308 ++++++++++++++++++++++++++++
+ 3 files changed, 741 insertions(+), 32 deletions(-)
+```
+
+## 4. QA Log
+
+_(no review round yet)_
+
+## 5. Timeline
+
+
+---
+_Auto-assembled by the niwa scribe from the Q&A gate. Task `cd34c6ce-1bdf-4eea-8819-26d132b03599`._

--- a/internal/relay/api.go
+++ b/internal/relay/api.go
@@ -418,6 +418,15 @@ func (r *Relay) apiDeleteProject(w http.ResponseWriter, name string) {
 }
 
 func (r *Relay) apiGetSettings(w http.ResponseWriter) {
+	writeJSON(w, r.settingsResponse())
+}
+
+// settingsResponse assembles the GET (and PUT-200) body: the legacy v1-compat
+// fields kept byte-compatible — the v1 console (api-client.js:490 fetchSettings)
+// reads `linear_mode` and the nested `linear` object, and v1 assets are
+// untouched (T2c) — plus the frozen v2 shape (`groups` + `settings`, design
+// record 6f73f179) ADDED alongside.
+func (r *Relay) settingsResponse() map[string]any {
 	sunType := r.DB.GetSetting("sun_type")
 	if sunType == "" {
 		sunType = "1"
@@ -430,7 +439,7 @@ func (r *Relay) apiGetSettings(w http.ResponseWriter) {
 			masked = "…" + apiKey[len(apiKey)-4:]
 		}
 	}
-	writeJSON(w, map[string]any{
+	return map[string]any{
 		"sun_type":    sunType,
 		"linear_mode": enabled,
 		"mode":        modeString(enabled),
@@ -444,50 +453,61 @@ func (r *Relay) apiGetSettings(w http.ResponseWriter) {
 			"source":         source,
 		},
 		"federation": r.federationStatus(),
-	})
+		"groups":     settingGroups,
+		"settings":   r.settingsMetadata(),
+	}
 }
 
-// writableSettings is the allowlist of keys the settings API may write. Without
-// it, an (unauthenticated by default) caller could set arbitrary key→value pairs
-// — including swapping linear_api_key or repointing the connector.
-var writableSettings = map[string]bool{
-	"sun_type":         true,
-	setLinearEnabled:   true,
-	setLinearAPIKey:    true,
-	setLinearTeamKey:   true,
-	setLinearProject:   true,
-	setLinearInterval:  true,
-	setLinearRouting:   true,
-	setLinearProjMap:   true,
-	setFederationPeers: true,
-}
+// The settings PUT allowlist and validation now live in settings_spec.go: the
+// panel-facing writableSettings (console/linear/federation) and the full API
+// allowlist writableKeys() are both derived from settingSpecs. apiPutSetting
+// consults the spec (via validateSettings/writableKeys), never writableSettings.
 
 func (r *Relay) apiPutSetting(w http.ResponseWriter, req *http.Request) {
-	var body map[string]string
+	// *string values so JSON null (explicit clear) is distinct from "" (unchanged
+	// on a secret) and from a real value.
+	var body map[string]*string
 	if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
 		http.Error(w, `{"error":"invalid json"}`, http.StatusBadRequest)
 		return
 	}
-	// Reject the whole request if any key is not writable (fail before applying).
-	for k := range body {
-		if !writableSettings[k] {
-			// json.Marshal so the (quoted) key is escaped — a raw fmt into a JSON
-			// literal produced invalid JSON, which the client's res.json() then
-			// swallowed, hiding the reason. Encoded, the message always parses.
-			eb, _ := json.Marshal(map[string]string{"error": fmt.Sprintf("setting %q is not writable", k)})
-			http.Error(w, string(eb), http.StatusForbidden)
-			return
+	// Whole-request validation BEFORE any write: 403 {error:"not writable",key}
+	// for unknown/non-writable keys, 400 {error:"invalid value",key,detail} for
+	// bad kind/bounds/cross-key. validateSettings never touches the DB, so a
+	// rejected request applies nothing.
+	if status, key, detail := r.validateSettings(body); status != http.StatusOK {
+		var eb []byte
+		if status == http.StatusForbidden {
+			// error names the key ("not writable: <key>") so the pre-existing
+			// v2 panel test (ServerErrorSurfaced) and the panel banner both see
+			// the refused key; the machine-readable `key` field carries it too.
+			eb, _ = json.Marshal(map[string]string{"error": "not writable: " + key, "key": key})
+		} else {
+			eb, _ = json.Marshal(map[string]string{"error": "invalid value", "key": key, "detail": detail})
 		}
+		http.Error(w, string(eb), status)
+		return
 	}
 	linearChanged := false
 	federationChanged := false
 	for k, v := range body {
-		if k == setFederationPeers {
-			// Preserve stored tokens for peers the UI submitted with an empty
-			// token (it only ever holds masked values).
-			v = r.mergeFederationPeersJSON(v)
+		spec := specByKey[k]
+		switch {
+		case v == nil:
+			// JSON null = explicit clear.
+			r.DB.SetSetting(k, "")
+		case spec.Secret && *v == "":
+			// "" on a secret = unchanged: never log, never apply.
+			continue
+		default:
+			val := *v
+			if k == setFederationPeers {
+				// Preserve stored tokens for peers the UI submitted with an empty
+				// token (it only ever holds masked values).
+				val = r.mergeFederationPeersJSON(val)
+			}
+			r.DB.SetSetting(k, val)
 		}
-		r.DB.SetSetting(k, v)
 		if strings.HasPrefix(k, "linear_") {
 			linearChanged = true
 		}
@@ -502,7 +522,8 @@ func (r *Relay) apiPutSetting(w http.ResponseWriter, req *http.Request) {
 	if federationChanged {
 		r.ReconfigureFederation()
 	}
-	writeJSON(w, map[string]string{"ok": "true"})
+	// 200 returns the same shape as GET (frozen contract A3).
+	writeJSON(w, r.settingsResponse())
 }
 
 // apiLinearTeams lists the Linear workspace teams using the effective API key

--- a/internal/relay/api.go
+++ b/internal/relay/api.go
@@ -483,7 +483,9 @@ func (r *Relay) apiPutSetting(w http.ResponseWriter, req *http.Request) {
 			// the refused key; the machine-readable `key` field carries it too.
 			eb, _ = json.Marshal(map[string]string{"error": "not writable: " + key, "key": key})
 		} else {
-			eb, _ = json.Marshal(map[string]string{"error": "invalid value", "key": key, "detail": detail})
+			// Symmetric with the 403 form (cto A6): human `error` names the key,
+			// `detail` carries the reason (panel renders j.detail || j.error).
+			eb, _ = json.Marshal(map[string]string{"error": "invalid value: " + key, "key": key, "detail": detail})
 		}
 		http.Error(w, string(eb), status)
 		return

--- a/internal/relay/settings_spec.go
+++ b/internal/relay/settings_spec.go
@@ -1,0 +1,378 @@
+package relay
+
+import (
+	"encoding/json"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// settingSpec is the single server-side description of one configuration key. It
+// drives three things at once so they can never drift: (i) the PUT allowlist
+// (writableKeys / writableSettings), (ii) PUT validation by kind + bounds +
+// cross-key rules, (iii) the GET /api/settings per-key metadata (the frozen
+// contract in trovex 6f73f179). Design record: wraith-v2-config-surface-20260907.
+type settingSpec struct {
+	Key      string      // snake_case, unique
+	Group    string      // one of settingGroups
+	Kind     settingKind // bool|int|duration|enum|string|json|secret
+	Source   string      // classification: db | env | code (code = compile-time const)
+	EnvName  string      // env twin, "" when none
+	Writable bool        // settable via PUT /api/settings
+	Secret   bool        // value never returned/logged; GET exposes `set` only
+	Min      string      // int: decimal; duration: time.Duration.String(); "" = unbounded
+	Max      string      // same encoding as Min; "" = unbounded
+	Enum     []string    // enum: allowed values
+	Default  string      // same encoding as value; "" when none
+	Note     string      // free text for the panel
+}
+
+type settingKind string
+
+const (
+	kindBool     settingKind = "bool"
+	kindInt      settingKind = "int"
+	kindDuration settingKind = "duration"
+	kindEnum     settingKind = "enum"
+	kindString   settingKind = "string"
+	kindJSON     settingKind = "json"
+	kindSecret   settingKind = "secret"
+)
+
+const (
+	groupConsole     = "console"
+	groupLinear      = "linear"
+	groupFederation  = "federation"
+	groupServer      = "server"
+	groupOperational = "operational"
+	groupTiming      = "timing"
+)
+
+// settingGroups is the fixed render order returned as GET's top-level `groups`.
+var settingGroups = []string{groupConsole, groupLinear, groupFederation, groupServer, groupOperational, groupTiming}
+
+// dur is a tiny helper so bounds/defaults are written as real durations and
+// encoded exactly as GET returns them (time.Duration.String()).
+func dur(d time.Duration) string { return d.String() }
+
+// settingSpecs covers every key of the configuration surface (design record D2).
+// Durations are encoded via time.Duration.String(); ints as decimal strings.
+var settingSpecs = []settingSpec{
+	// ---- Console ----
+	{Key: "sun_type", Group: groupConsole, Kind: kindInt, Source: "db", Writable: true, Min: "1", Default: "1", Note: "console sun/dyson variant index"},
+
+	// ---- Linear (7 writable + the RO webhook secret) ----
+	{Key: "linear_enabled", Group: groupLinear, Kind: kindBool, Source: "env", EnvName: "RELAY_LINEAR_MODE", Writable: true, Default: "0"},
+	{Key: "linear_api_key", Group: groupLinear, Kind: kindSecret, Source: "env", EnvName: "LINEAR_API_KEY", Writable: true, Secret: true},
+	{Key: "linear_team_key", Group: groupLinear, Kind: kindString, Source: "env", EnvName: "LINEAR_TEAM_KEY", Writable: true},
+	{Key: "linear_project", Group: groupLinear, Kind: kindString, Source: "db", Writable: true},
+	{Key: "linear_reconcile_interval", Group: groupLinear, Kind: kindDuration, Source: "env", EnvName: "RELAY_LINEAR_RECONCILE_INTERVAL", Writable: true, Min: dur(30 * time.Second), Max: dur(time.Hour), Default: dur(time.Minute)},
+	{Key: "linear_routing", Group: groupLinear, Kind: kindJSON, Source: "db", Writable: true},
+	{Key: "linear_project_map", Group: groupLinear, Kind: kindJSON, Source: "db", Writable: true},
+	{Key: "linear_webhook_secret", Group: groupLinear, Kind: kindSecret, Source: "env", EnvName: "LINEAR_WEBHOOK_SECRET", Secret: true, Note: "HMAC secret for inbound Linear webhooks"},
+
+	// ---- Federation (RO summary in panel; still API-writable via the federation editor) ----
+	{Key: "federation_peers", Group: groupFederation, Kind: kindJSON, Source: "env", EnvName: "RELAY_FEDERATION_PEERS", Writable: true, Note: "edited on the federation page"},
+
+	// ---- Server (all RO env) ----
+	{Key: "bind", Group: groupServer, Kind: kindString, Source: "env", EnvName: "RELAY_BIND", Default: "127.0.0.1"},
+	{Key: "port", Group: groupServer, Kind: kindInt, Source: "env", EnvName: "PORT", Default: "8090"},
+	{Key: "api_key", Group: groupServer, Kind: kindSecret, Source: "env", EnvName: "RELAY_API_KEY", Secret: true, Note: "unset = auth off"},
+	{Key: "cors_origins", Group: groupServer, Kind: kindString, Source: "env", EnvName: "RELAY_CORS_ORIGINS"},
+	{Key: "max_body", Group: groupServer, Kind: kindInt, Source: "env", EnvName: "RELAY_MAX_BODY", Default: "1048576"},
+	{Key: "rate_limit", Group: groupServer, Kind: kindInt, Source: "env", EnvName: "RELAY_RATE_LIMIT", Default: "0"},
+	{Key: "db_path", Group: groupServer, Kind: kindString, Source: "env", EnvName: "RELAY_DB", Default: "~/.agent-relay/relay.db"},
+	{Key: "ui_dir", Group: groupServer, Kind: kindString, Source: "env", EnvName: "RELAY_UI_DIR", Note: "embedded when unset"},
+	{Key: "log_level", Group: groupServer, Kind: kindString, Source: "env", EnvName: "RELAY_LOG_LEVEL", Default: "info"},
+	{Key: "log_format", Group: groupServer, Kind: kindString, Source: "env", EnvName: "RELAY_LOG_FORMAT", Default: "text"},
+	{Key: "trust_loopback", Group: groupServer, Kind: kindBool, Source: "env", EnvName: "RELAY_TRUST_LOOPBACK", Default: "1"},
+	{Key: "webhook_secret", Group: groupServer, Kind: kindSecret, Source: "env", EnvName: "RELAY_WEBHOOK_SECRET", Secret: true},
+	{Key: "github_webhook_secret", Group: groupServer, Kind: kindSecret, Source: "env", EnvName: "RELAY_GITHUB_WEBHOOK_SECRET", Secret: true},
+	{Key: "signal_webhook_secret", Group: groupServer, Kind: kindSecret, Source: "env", EnvName: "RELAY_SIGNAL_WEBHOOK_SECRET", Secret: true},
+
+	// ---- Operational writable (read at tick time in T2b) ----
+	{Key: "agent_max_age", Group: groupOperational, Kind: kindDuration, Source: "db", Writable: true, Min: dur(5 * time.Minute), Max: dur(24 * time.Hour), Default: dur(30 * time.Minute)},
+	{Key: "message_retention", Group: groupOperational, Kind: kindDuration, Source: "db", Writable: true, Min: dur(24 * time.Hour), Max: dur(90 * 24 * time.Hour), Default: dur(7 * 24 * time.Hour)},
+	{Key: "audit_log_retention", Group: groupOperational, Kind: kindDuration, Source: "db", Writable: true, Min: dur(7 * 24 * time.Hour), Max: dur(365 * 24 * time.Hour), Default: dur(90 * 24 * time.Hour)},
+	{Key: "deadletter_short_retention", Group: groupOperational, Kind: kindDuration, Source: "db", Writable: true, Min: dur(24 * time.Hour), Max: dur(180 * 24 * time.Hour), Default: dur(30 * 24 * time.Hour)},
+	{Key: "deadletter_long_retention", Group: groupOperational, Kind: kindDuration, Source: "db", Writable: true, Min: dur(24 * time.Hour), Max: dur(730 * 24 * time.Hour), Default: dur(180 * 24 * time.Hour), Note: "must be >= deadletter_short_retention"},
+	{Key: "token_usage_retention_days", Group: groupOperational, Kind: kindInt, Source: "db", Writable: true, Min: "1", Max: "90", Default: "14", Note: "drives both token-usage purge and rollup window"},
+	{Key: "ack_notify_age", Group: groupOperational, Kind: kindDuration, Source: "db", Writable: true, Min: dur(time.Minute), Max: dur(24 * time.Hour), Default: dur(15 * time.Minute)},
+	{Key: "ack_escalate_age", Group: groupOperational, Kind: kindDuration, Source: "db", Writable: true, Min: dur(time.Minute), Max: dur(24 * time.Hour), Default: dur(45 * time.Minute), Note: "must be > ack_notify_age"},
+	{Key: "backup_keep", Group: groupOperational, Kind: kindInt, Source: "env", EnvName: "RELAY_BACKUP_KEEP", Writable: true, Min: "1", Max: "24", Default: "3", Note: "env wins over setting"},
+	{Key: "reviewer_ttl_days", Group: groupOperational, Kind: kindInt, Source: "env", EnvName: "RELAY_REVIEWER_TTL_DAYS", Writable: true, Min: "1", Max: "90", Default: "7", Note: "env wins over setting"},
+	{Key: "foreign_backup_min_age", Group: groupOperational, Kind: kindDuration, Source: "db", Writable: true, Min: dur(time.Hour), Max: dur(30 * 24 * time.Hour), Default: dur(24 * time.Hour)},
+	{Key: "activity_idle_seconds", Group: groupOperational, Kind: kindInt, Source: "db", Writable: true, Min: "5", Max: "86400", Default: "120"},
+	{Key: "activity_waiting_seconds", Group: groupOperational, Kind: kindInt, Source: "db", Writable: true, Min: "5", Max: "86400", Default: "10"},
+	{Key: "activity_exit_seconds", Group: groupOperational, Kind: kindInt, Source: "db", Writable: true, Min: "5", Max: "86400", Default: "300"},
+	{Key: "cost_default_model", Group: groupOperational, Kind: kindString, Source: "db", Writable: true, Default: "opus"},
+
+	// ---- Operational RO (destructive toggles / dynamic keys stay out of the panel) ----
+	{Key: "limbo_sweep_apply", Group: groupOperational, Kind: kindBool, Source: "db", Default: "0", Note: "destructive; env/SQL only"},
+	{Key: "dangling_board_apply", Group: groupOperational, Kind: kindBool, Source: "db", Default: "0", Note: "destructive; env/SQL only"},
+	{Key: "cron_schedules", Group: groupOperational, Kind: kindJSON, Source: "db"},
+	{Key: "github_webhook_project", Group: groupOperational, Kind: kindString, Source: "db"},
+	{Key: "signal_webhook_project", Group: groupOperational, Kind: kindString, Source: "db"},
+
+	// ---- Timing (RO, compile-time consts) ----
+	{Key: "purge_interval", Group: groupTiming, Kind: kindDuration, Source: "code", Default: dur(5 * time.Minute)},
+	{Key: "ack_check_interval", Group: groupTiming, Kind: kindDuration, Source: "code", Default: dur(5 * time.Minute)},
+	{Key: "backup_interval", Group: groupTiming, Kind: kindDuration, Source: "code", Default: dur(time.Hour)},
+	{Key: "writer_timeout", Group: groupTiming, Kind: kindDuration, Source: "code", Default: dur(15 * time.Second), Note: "compile-time (code); must stay < referential_scan_timeout"},
+	{Key: "writer_slow_wait", Group: groupTiming, Kind: kindDuration, Source: "code", Default: dur(2 * time.Second)},
+	{Key: "referential_scan_timeout", Group: groupTiming, Kind: kindDuration, Source: "code", Default: dur(30 * time.Second), Note: "compile-time (code); must stay > writer_timeout"},
+	{Key: "task_sweep_interval", Group: groupTiming, Kind: kindDuration, Source: "code", Default: dur(2 * time.Minute)},
+	{Key: "notify_sweep_interval", Group: groupTiming, Kind: kindDuration, Source: "code", Default: dur(1500 * time.Millisecond)},
+	{Key: "digest_tick", Group: groupTiming, Kind: kindDuration, Source: "code", Default: dur(time.Minute)},
+	{Key: "cron_tick", Group: groupTiming, Kind: kindDuration, Source: "code", Default: dur(30 * time.Second)},
+	{Key: "ingest_tick", Group: groupTiming, Kind: kindDuration, Source: "code", Default: dur(2 * time.Second)},
+	{Key: "sse_ping", Group: groupTiming, Kind: kindDuration, Source: "code", Default: dur(25 * time.Second)},
+	{Key: "dashboard_poll", Group: groupTiming, Kind: kindDuration, Source: "code", Default: dur(5 * time.Second)},
+}
+
+// specByKey indexes settingSpecs. Built once; settingSpecs is never mutated.
+var specByKey = func() map[string]settingSpec {
+	m := make(map[string]settingSpec, len(settingSpecs))
+	for _, s := range settingSpecs {
+		m[s.Key] = s
+	}
+	return m
+}()
+
+// writableSettings is the PANEL-facing allowlist (console/linear/federation
+// groups) kept in lockstep with v2/settings.js FIELDS via the
+// FieldsMatchWritableAllowlist contract test. The FULL API PUT allowlist is
+// writableKeys() — every Writable spec, including Operational keys the panel
+// does not render yet (widened in T2c). Var name preserved so the panel test
+// keeps compiling.
+var writableSettings = func() map[string]bool {
+	m := map[string]bool{}
+	for _, s := range settingSpecs {
+		if s.Writable && (s.Group == groupConsole || s.Group == groupLinear || s.Group == groupFederation) {
+			m[s.Key] = true
+		}
+	}
+	return m
+}()
+
+// writableKeys is the full PUT allowlist derived from the spec: every key with
+// Writable=true (the 9 legacy panel keys + the 15 Operational knobs).
+func writableKeys() map[string]bool {
+	m := make(map[string]bool, len(settingSpecs))
+	for _, s := range settingSpecs {
+		if s.Writable {
+			m[s.Key] = true
+		}
+	}
+	return m
+}
+
+// boundsJSON renders the per-kind `bounds` object of the frozen contract.
+func (s settingSpec) boundsJSON() map[string]any {
+	switch s.Kind {
+	case kindInt, kindDuration:
+		return map[string]any{"min": s.Min, "max": s.Max}
+	case kindEnum:
+		vals := s.Enum
+		if vals == nil {
+			vals = []string{}
+		}
+		return map[string]any{"values": vals}
+	default:
+		return map[string]any{}
+	}
+}
+
+// resolveSetting computes the effective (value, set, source) for one key.
+// Precedence: env > setting > default; Timing consts resolve to source=code.
+// `set` is true whenever the value comes from env/setting/code (i.e. not the
+// bare default). For secrets `value` is always "" — `set` is the only signal.
+func (r *Relay) resolveSetting(s settingSpec) (value string, set bool, source string) {
+	if s.Source == "code" {
+		return s.Default, true, "code"
+	}
+	if s.EnvName != "" {
+		if ev := os.Getenv(s.EnvName); ev != "" {
+			if s.Secret {
+				return "", true, "env"
+			}
+			return ev, true, "env"
+		}
+	}
+	if dv := r.DB.GetSetting(s.Key); dv != "" {
+		if s.Secret {
+			return "", true, "setting"
+		}
+		return dv, true, "setting"
+	}
+	if s.Secret {
+		return "", false, "default"
+	}
+	return s.Default, false, "default"
+}
+
+// validateValue checks a single non-null value against its spec's kind + bounds.
+// Returns "" when valid, else a human-readable detail for the 400 response.
+func validateValue(s settingSpec, val string) string {
+	switch s.Kind {
+	case kindBool:
+		if val != "0" && val != "1" {
+			return "must be 0 or 1"
+		}
+	case kindInt:
+		n, err := strconv.Atoi(val)
+		if err != nil {
+			return "must be an integer"
+		}
+		if s.Min != "" {
+			if mn, _ := strconv.Atoi(s.Min); n < mn {
+				return "below minimum " + s.Min
+			}
+		}
+		if s.Max != "" {
+			if mx, _ := strconv.Atoi(s.Max); n > mx {
+				return "above maximum " + s.Max
+			}
+		}
+	case kindDuration:
+		d, err := time.ParseDuration(val)
+		if err != nil {
+			return "must be a duration (e.g. 30s, 5m, 24h)"
+		}
+		if s.Min != "" {
+			if mn, _ := time.ParseDuration(s.Min); d < mn {
+				return "below minimum " + s.Min
+			}
+		}
+		if s.Max != "" {
+			if mx, _ := time.ParseDuration(s.Max); d > mx {
+				return "above maximum " + s.Max
+			}
+		}
+	case kindEnum:
+		for _, v := range s.Enum {
+			if v == val {
+				return ""
+			}
+		}
+		return "must be one of " + strings.Join(s.Enum, ", ")
+	case kindJSON:
+		if !json.Valid([]byte(val)) {
+			return "must be valid JSON"
+		}
+	case kindString, kindSecret:
+		// no per-kind constraint; bounds/cross-key handled elsewhere
+	}
+	return ""
+}
+
+// validateSettings runs the WHOLE-REQUEST validation for a PUT body before any
+// value is applied. body values are *string: nil = explicit clear (JSON null).
+// Returns (200,"","") when the whole body is applicable, else the status
+// (403 unknown/non-writable, 400 bad value/bounds/cross-key), offending key and
+// detail. Nothing is written here — the caller applies only on 200.
+func (r *Relay) validateSettings(body map[string]*string) (status int, key, detail string) {
+	// 1. Allowlist — any unknown or non-writable key rejects the whole request.
+	for k := range body {
+		s, ok := specByKey[k]
+		if !ok || !s.Writable {
+			return http.StatusForbidden, k, ""
+		}
+	}
+	// 2. Per-key kind + bounds.
+	for k, v := range body {
+		s := specByKey[k]
+		if v == nil {
+			continue // explicit clear
+		}
+		if s.Secret && *v == "" {
+			continue // "" on a secret = unchanged
+		}
+		if d := validateValue(s, *v); d != "" {
+			return http.StatusBadRequest, k, d
+		}
+	}
+	// 3. Cross-key rules, evaluated against the effective value (body value if
+	// present — null → default — else the current stored value, else default).
+	eff := func(k string) string {
+		if v, ok := body[k]; ok {
+			if v == nil || *v == "" {
+				return specByKey[k].Default
+			}
+			return *v
+		}
+		if cur := r.DB.GetSetting(k); cur != "" {
+			return cur
+		}
+		return specByKey[k].Default
+	}
+	if _, in1 := body["ack_notify_age"]; in1 {
+		if d := crossDurationGreater(eff, "ack_escalate_age", "ack_notify_age"); d != "" {
+			return http.StatusBadRequest, "ack_escalate_age", d
+		}
+	} else if _, in2 := body["ack_escalate_age"]; in2 {
+		if d := crossDurationGreater(eff, "ack_escalate_age", "ack_notify_age"); d != "" {
+			return http.StatusBadRequest, "ack_escalate_age", d
+		}
+	}
+	if _, in3 := body["deadletter_short_retention"]; in3 {
+		if d := crossDurationGreaterEqual(eff, "deadletter_long_retention", "deadletter_short_retention"); d != "" {
+			return http.StatusBadRequest, "deadletter_long_retention", d
+		}
+	} else if _, in4 := body["deadletter_long_retention"]; in4 {
+		if d := crossDurationGreaterEqual(eff, "deadletter_long_retention", "deadletter_short_retention"); d != "" {
+			return http.StatusBadRequest, "deadletter_long_retention", d
+		}
+	}
+	return http.StatusOK, "", ""
+}
+
+func crossDurationGreater(eff func(string) string, hi, lo string) string {
+	h, herr := time.ParseDuration(eff(hi))
+	l, lerr := time.ParseDuration(eff(lo))
+	if herr != nil || lerr != nil {
+		return ""
+	}
+	if !(h > l) {
+		return hi + " must be greater than " + lo
+	}
+	return ""
+}
+
+func crossDurationGreaterEqual(eff func(string) string, hi, lo string) string {
+	h, herr := time.ParseDuration(eff(hi))
+	l, lerr := time.ParseDuration(eff(lo))
+	if herr != nil || lerr != nil {
+		return ""
+	}
+	if h < l {
+		return hi + " must be >= " + lo
+	}
+	return ""
+}
+
+// settingsMetadata builds the frozen-contract `settings` array: one entry per
+// spec in group/spec order, every entry carrying all 12 fields.
+func (r *Relay) settingsMetadata() []map[string]any {
+	out := make([]map[string]any, 0, len(settingSpecs))
+	for _, s := range settingSpecs {
+		value, set, source := r.resolveSetting(s)
+		out = append(out, map[string]any{
+			"key":      s.Key,
+			"group":    s.Group,
+			"kind":     string(s.Kind),
+			"value":    value,
+			"set":      set,
+			"source":   source,
+			"writable": s.Writable,
+			"secret":   s.Secret,
+			"env_name": s.EnvName,
+			"bounds":   s.boundsJSON(),
+			"default":  s.Default,
+			"note":     s.Note,
+		})
+	}
+	return out
+}

--- a/internal/relay/settings_spec_test.go
+++ b/internal/relay/settings_spec_test.go
@@ -1,0 +1,307 @@
+package relay
+
+import (
+	"bytes"
+	"log"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// getSettingEntry returns the settings[] metadata entry for key from a GET
+// /api/settings response, and whether it was found.
+func getSettingEntry(t *testing.T, body map[string]any, key string) (map[string]any, bool) {
+	t.Helper()
+	arr, ok := body["settings"].([]any)
+	if !ok {
+		t.Fatalf("GET /settings: `settings` is not an array: %T", body["settings"])
+	}
+	for _, e := range arr {
+		m, ok := e.(map[string]any)
+		if !ok {
+			t.Fatalf("settings entry is not an object: %T", e)
+		}
+		if m["key"] == key {
+			return m, true
+		}
+	}
+	return nil, false
+}
+
+// TestSettingsSpecAllowlistDerived (T2a AC1): writableKeys() is the spec-derived
+// full PUT allowlist (24 = 9 legacy + 15 Operational); writableSettings is the
+// spec-derived panel subset (9, console|linear|federation) and a strict subset;
+// apiPutSetting consults the spec (an Operational key not in writableSettings
+// still applies); spec keys are unique and every group is valid.
+func TestSettingsSpecAllowlistDerived(t *testing.T) {
+	legacy := []string{
+		"sun_type", "linear_enabled", "linear_api_key", "linear_team_key",
+		"linear_project", "linear_reconcile_interval", "linear_routing",
+		"linear_project_map", "federation_peers",
+	}
+	operational := []string{
+		"agent_max_age", "message_retention", "audit_log_retention",
+		"deadletter_short_retention", "deadletter_long_retention",
+		"token_usage_retention_days", "ack_notify_age", "ack_escalate_age",
+		"backup_keep", "reviewer_ttl_days", "foreign_backup_min_age",
+		"activity_idle_seconds", "activity_waiting_seconds",
+		"activity_exit_seconds", "cost_default_model",
+	}
+
+	wk := writableKeys()
+	wantWK := map[string]bool{}
+	for _, k := range append(append([]string{}, legacy...), operational...) {
+		wantWK[k] = true
+	}
+	if len(wk) != 24 || len(wantWK) != 24 {
+		t.Fatalf("writableKeys size %d, expected set size %d, want 24", len(wk), len(wantWK))
+	}
+	for k := range wantWK {
+		if !wk[k] {
+			t.Errorf("writableKeys missing %q", k)
+		}
+	}
+	for k := range wk {
+		if !wantWK[k] {
+			t.Errorf("writableKeys has unexpected %q", k)
+		}
+	}
+
+	// writableSettings = the 9 panel keys, strict subset of writableKeys.
+	if len(writableSettings) != len(legacy) {
+		t.Errorf("writableSettings size %d, want %d", len(writableSettings), len(legacy))
+	}
+	for _, k := range legacy {
+		if !writableSettings[k] {
+			t.Errorf("writableSettings missing panel key %q", k)
+		}
+	}
+	for k := range writableSettings {
+		if !wk[k] {
+			t.Errorf("writableSettings key %q not in writableKeys (not a subset)", k)
+		}
+	}
+
+	// Spec keys unique; every group valid.
+	validGroup := map[string]bool{
+		groupConsole: true, groupLinear: true, groupFederation: true,
+		groupServer: true, groupOperational: true, groupTiming: true,
+	}
+	seen := map[string]bool{}
+	for _, s := range settingSpecs {
+		if seen[s.Key] {
+			t.Errorf("duplicate spec key %q", s.Key)
+		}
+		seen[s.Key] = true
+		if !validGroup[s.Group] {
+			t.Errorf("spec key %q has invalid group %q", s.Key, s.Group)
+		}
+	}
+
+	// apiPutSetting consults the spec, not writableSettings: an Operational key
+	// (writable in the spec, absent from writableSettings) applies via PUT.
+	r := testRelay(t)
+	if _, ok := writableSettings["message_retention"]; ok {
+		t.Fatal("precondition: message_retention must NOT be in the panel allowlist")
+	}
+	w := doAPI(r, http.MethodPut, "/settings", `{"message_retention":"48h"}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("PUT operational key: status %d, want 200\nbody: %s", w.Code, w.Body.String())
+	}
+	if got := r.DB.GetSetting("message_retention"); got != "48h" {
+		t.Errorf("message_retention stored %q, want 48h", got)
+	}
+}
+
+// TestSettingsPutBoundsAndCrossKey (T2a AC2): out-of-bounds and cross-key PUTs
+// are rejected 400 whole-request with nothing applied; a valid pair applies.
+func TestSettingsPutBoundsAndCrossKey(t *testing.T) {
+	r := testRelay(t)
+
+	// Below min 24h → 400, nothing stored.
+	w := doAPI(r, http.MethodPut, "/settings", `{"message_retention":"1h"}`)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("message_retention=1h: status %d, want 400\nbody: %s", w.Code, w.Body.String())
+	}
+	j := decodeJSON(t, w)
+	if j["error"] != "invalid value" || j["key"] != "message_retention" || j["detail"] == "" {
+		t.Errorf("400 body = %v, want {error:invalid value, key:message_retention, detail:non-empty}", j)
+	}
+	if got := r.DB.GetSetting("message_retention"); got != "" {
+		t.Errorf("message_retention should be unchanged (empty), got %q", got)
+	}
+
+	// ack_escalate_age=45m stored; PUT ack_notify_age=50m ALONE → 400 (50m !< 45m),
+	// nothing applied.
+	r.DB.SetSetting("ack_escalate_age", "45m")
+	w = doAPI(r, http.MethodPut, "/settings", `{"ack_notify_age":"50m"}`)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("ack_notify_age=50m alone: status %d, want 400\nbody: %s", w.Code, w.Body.String())
+	}
+	if got := r.DB.GetSetting("ack_notify_age"); got != "" {
+		t.Errorf("ack_notify_age should not be applied, got %q", got)
+	}
+	if got := r.DB.GetSetting("ack_escalate_age"); got != "45m" {
+		t.Errorf("ack_escalate_age must stay 45m, got %q", got)
+	}
+
+	// Valid pair → 200, both stored.
+	w = doAPI(r, http.MethodPut, "/settings", `{"ack_notify_age":"50m","ack_escalate_age":"60m"}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("valid ack pair: status %d, want 200\nbody: %s", w.Code, w.Body.String())
+	}
+	if got := r.DB.GetSetting("ack_notify_age"); got != "50m" {
+		t.Errorf("ack_notify_age stored %q, want 50m", got)
+	}
+	if got := r.DB.GetSetting("ack_escalate_age"); got != "60m" {
+		t.Errorf("ack_escalate_age stored %q, want 60m", got)
+	}
+}
+
+// TestSettingsGetFrozenShape (T2a AC3): GET returns the frozen shape — groups in
+// fixed order, every settings entry carrying all 12 fields; an env-set secret
+// resolves source=env/set=true; a Timing const resolves source=code, RO, value=15s.
+func TestSettingsGetFrozenShape(t *testing.T) {
+	t.Setenv("LINEAR_API_KEY", "env-linear-key-xyz")
+	r := testRelay(t)
+
+	w := doAPI(r, http.MethodGet, "/settings", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("GET /settings: status %d, want 200", w.Code)
+	}
+	body := decodeJSON(t, w)
+
+	// groups in the fixed order.
+	gs, ok := body["groups"].([]any)
+	if !ok {
+		t.Fatalf("`groups` is not an array: %T", body["groups"])
+	}
+	wantGroups := []string{"console", "linear", "federation", "server", "operational", "timing"}
+	if len(gs) != len(wantGroups) {
+		t.Fatalf("groups len %d, want %d", len(gs), len(wantGroups))
+	}
+	for i, g := range wantGroups {
+		if gs[i] != g {
+			t.Errorf("groups[%d] = %v, want %q", i, gs[i], g)
+		}
+	}
+
+	// Every entry has all 12 fields.
+	fields := []string{"key", "group", "kind", "value", "set", "source", "writable", "secret", "env_name", "bounds", "default", "note"}
+	arr, ok := body["settings"].([]any)
+	if !ok || len(arr) == 0 {
+		t.Fatalf("`settings` missing/empty: %T", body["settings"])
+	}
+	for _, e := range arr {
+		m := e.(map[string]any)
+		if len(m) != len(fields) {
+			t.Errorf("entry %v has %d fields, want %d", m["key"], len(m), len(fields))
+		}
+		for _, f := range fields {
+			if _, present := m[f]; !present {
+				t.Errorf("entry %v missing field %q", m["key"], f)
+			}
+		}
+	}
+
+	// linear_api_key: env-resolved secret.
+	if e, ok := getSettingEntry(t, body, "linear_api_key"); ok {
+		if e["source"] != "env" || e["set"] != true || e["value"] != "" {
+			t.Errorf("linear_api_key = {source:%v set:%v value:%v}, want {env,true,\"\"}", e["source"], e["set"], e["value"])
+		}
+	} else {
+		t.Error("linear_api_key entry missing")
+	}
+
+	// writer_timeout: compile-time const.
+	if e, ok := getSettingEntry(t, body, "writer_timeout"); ok {
+		if e["source"] != "code" || e["writable"] != false || e["value"] != "15s" {
+			t.Errorf("writer_timeout = {source:%v writable:%v value:%v}, want {code,false,15s}", e["source"], e["writable"], e["value"])
+		}
+	} else {
+		t.Error("writer_timeout entry missing")
+	}
+}
+
+// TestSettingsSecretHandling (T2a AC4): a secret's GET value is always empty and
+// `set` tracks presence; PUT "" leaves it unchanged; PUT null clears it; and the
+// secret value never appears in the server log for any of these requests.
+func TestSettingsSecretHandling(t *testing.T) {
+	// No LINEAR_API_KEY in env → DB is the resolved source for this test.
+	t.Setenv("LINEAR_API_KEY", "")
+	r := testRelay(t)
+
+	const secret = "sk-super-secret-value-9f3a"
+
+	var buf bytes.Buffer
+	old := log.Writer()
+	log.SetOutput(&buf)
+	defer log.SetOutput(old)
+
+	// Set it.
+	if w := doAPI(r, http.MethodPut, "/settings", `{"linear_api_key":"`+secret+`"}`); w.Code != http.StatusOK {
+		t.Fatalf("set linear_api_key: status %d\nbody: %s", w.Code, w.Body.String())
+	}
+	body := decodeJSON(t, doAPI(r, http.MethodGet, "/settings", ""))
+	if e, ok := getSettingEntry(t, body, "linear_api_key"); ok {
+		if e["value"] != "" || e["set"] != true || e["source"] != "setting" {
+			t.Errorf("after set: {value:%v set:%v source:%v}, want {\"\",true,setting}", e["value"], e["set"], e["source"])
+		}
+	} else {
+		t.Fatal("linear_api_key entry missing")
+	}
+
+	// PUT "" = unchanged.
+	if w := doAPI(r, http.MethodPut, "/settings", `{"linear_api_key":""}`); w.Code != http.StatusOK {
+		t.Fatalf("put empty secret: status %d", w.Code)
+	}
+	if got := r.DB.GetSetting("linear_api_key"); got != secret {
+		t.Errorf("PUT \"\" must leave secret unchanged, got %q", got)
+	}
+
+	// PUT null = explicit clear.
+	if w := doAPI(r, http.MethodPut, "/settings", `{"linear_api_key":null}`); w.Code != http.StatusOK {
+		t.Fatalf("clear secret: status %d", w.Code)
+	}
+	body = decodeJSON(t, doAPI(r, http.MethodGet, "/settings", ""))
+	if e, ok := getSettingEntry(t, body, "linear_api_key"); ok {
+		if e["set"] != false || e["value"] != "" {
+			t.Errorf("after clear: {set:%v value:%v}, want {false,\"\"}", e["set"], e["value"])
+		}
+	} else {
+		t.Fatal("linear_api_key entry missing after clear")
+	}
+
+	if strings.Contains(buf.String(), secret) {
+		t.Errorf("server log leaked the secret value:\n%s", buf.String())
+	}
+}
+
+// TestSettingsUnknownKeyWholeRequest (T2a AC5): a PUT carrying an unknown key
+// alongside a valid one is rejected 403 whole-request and applies nothing; the
+// panel-facing writableSettings stays the 9-key contract the v2 panel test pins.
+func TestSettingsUnknownKeyWholeRequest(t *testing.T) {
+	r := testRelay(t)
+
+	w := doAPI(r, http.MethodPut, "/settings", `{"sun_type":"2","evil_key":"x"}`)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("unknown key: status %d, want 403\nbody: %s", w.Code, w.Body.String())
+	}
+	j := decodeJSON(t, w)
+	errStr, _ := j["error"].(string)
+	if !strings.Contains(errStr, "not writable") || j["key"] != "evil_key" {
+		t.Errorf("403 body = %v, want error containing \"not writable\" + key:evil_key", j)
+	}
+	// Whole-request: the valid key was NOT applied.
+	if got := r.DB.GetSetting("sun_type"); got != "" {
+		t.Errorf("sun_type must be unchanged after a rejected whole request, got %q", got)
+	}
+	// Panel contract (guarded end-to-end by the pre-existing TestV2ConfigPanel):
+	// writableSettings excludes evil_key and every Operational key.
+	if writableSettings["evil_key"] {
+		t.Error("writableSettings must not contain evil_key")
+	}
+	if writableSettings["message_retention"] {
+		t.Error("writableSettings (panel) must not contain Operational keys")
+	}
+}

--- a/internal/relay/settings_spec_test.go
+++ b/internal/relay/settings_spec_test.go
@@ -124,8 +124,9 @@ func TestSettingsPutBoundsAndCrossKey(t *testing.T) {
 		t.Fatalf("message_retention=1h: status %d, want 400\nbody: %s", w.Code, w.Body.String())
 	}
 	j := decodeJSON(t, w)
-	if j["error"] != "invalid value" || j["key"] != "message_retention" || j["detail"] == "" {
-		t.Errorf("400 body = %v, want {error:invalid value, key:message_retention, detail:non-empty}", j)
+	errStr, _ := j["error"].(string)
+	if !strings.Contains(errStr, "invalid value") || j["key"] != "message_retention" || j["detail"] == "" {
+		t.Errorf("400 body = %v, want error containing \"invalid value\" + key:message_retention + detail:non-empty", j)
 	}
 	if got := r.DB.GetSetting("message_retention"); got != "" {
 		t.Errorf("message_retention should be unchanged (empty), got %q", got)


### PR DESCRIPTION
### niwa Q&A gate

An adversarial reviewer is reading this diff right now. Its verdict lands on this PR as a review (or a comment when the gate and the author share one GitHub account), and the merge waits for this repository's own checks to go green.

*Opened automatically — a rejected round comes back to the author, who pushes fixes to the same branch.*

## What & why

- **docs(scribe): provenance for wraith-relay-t2a-settings-spec-table-one-server-side-spec-drives-allowlist-put-v**
- **fix: [wraith/relay] symmetric 400 error "invalid value: <key>" (cto A6)**
  <details><summary>details</summary>

  Claude-Session: https://claude.ai/code/session_01PrKgY1PpQX9DTAF7HGAsAB

  </details>
- **feat: [wraith/relay] settings spec table drives allowlist + PUT validation + GET metadata**
  <details><summary>details</summary>

  New internal/relay/settings_spec.go: settingSpec + settingSpecs covering the
  full config surface (D2), spec-derived writableSettings (panel 9) and
  writableKeys (full 24), resolveSetting (env>setting>default, code for Timing),
  validateValue (kind+bounds), validateSettings (whole-request 403/400 + cross-key
  ack/deadletter), settingsMetadata (frozen 12-field shape).
  
  api.go: apiGetSettings + PUT-200 return legacy v1-compat fields alongside the
  frozen groups/settings; apiPutSetting decodes *string (null=clear, ""=unchanged
  on secret), validates whole-request before any SetSetting, never logs secrets.
  
  5 named AC tests in settings_spec_test.go. go test -tags fts5 ./internal/relay/... = 474 pass.
  
  Claude-Session: https://claude.ai/code/session_01PrKgY1PpQX9DTAF7HGAsAB

  </details>

## Changes

<details><summary>Files changed (git diff --stat)</summary>

```
...-one-server-side-spec-drives-allowlist-put-v.md |  82 +++++
 internal/relay/api.go                              |  87 +++--
 internal/relay/settings_spec.go                    | 378 +++++++++++++++++++++
 internal/relay/settings_spec_test.go               | 308 +++++++++++++++++
 4 files changed, 823 insertions(+), 32 deletions(-)
```

</details>

## Module graph

```mermaid
graph TD
  n0["features/wraith-relay-t2a-settings-spec-table-one-server-side-spec-drives-allowlist-put-v.md"]
  n1["internal/relay"]
```

## Acceptance criteria

- [x] AC1 named test: writableKeys() is derived from settingSpecs and equals exactly the 24 writable keys = 9 legacy (sun_type, linear_enabled, linear_api_key, linear_team_key, linear_project, linear_reconcile_interval, linear_routing, linear_project_map, federation_peers) + the 15 Operational writable keys listed in the ticket; the legacy var writableSettings is ALSO spec-derived (Writable && group in console|linear|federation), equals exactly those 9 keys and is a strict subset of writableKeys(); apiPutSetting consults the spec (writableKeys), never writableSettings; spec keys are unique and every group is one of console|linear|federation|server|operational|timing (RULING wraith-cto A5 14:22Z, ticket contradiction AC1 vs AC5 reported by doer msg 75477041)
- [x] AC2 named test: PUT message_retention=1h (below min 24h) returns 400 {error:invalid value,key,detail} and the stored value is unchanged; PUT ack_notify_age=50m ALONE with ack_escalate_age=45m stored returns 400 and nothing is applied; PUT {ack_notify_age:50m, ack_escalate_age:60m} returns 200 and both are stored
- [x] AC3 named test: GET /api/settings returns the frozen shape: top-level groups in the fixed order and a settings array where EVERY entry has all 12 fields (key, group, kind, value, set, source, writable, secret, env_name, bounds, default, note); with LINEAR_API_KEY set in env the entry has source=env and set=true; a Timing entry (writer_timeout) has source=code, writable=false, value=15s
- [x] AC4 named test: for linear_api_key the GET value is always empty and set reflects presence; PUT linear_api_key:"" leaves the stored key unchanged; PUT linear_api_key:null clears it (set=false afterwards); the captured server log for these requests contains no fragment of the secret value
- [x] AC5 named test: PUT with an unknown key (evil_key) alongside a valid key returns 403 and applies nothing (whole-request), and the pre-existing TestV2ConfigPanel passes unchanged; scope: diff touches exactly internal/relay/settings_spec.go, internal/relay/api.go, internal/relay/settings_spec_test.go; go test -tags fts5 ./internal/relay/... green
## Provenance

📄 [Root cause, decisions &amp; QA log — `features/wraith-relay-t2a-settings-spec-table-one-server-side-spec-drives-allowlist-put-v.md`](https://github.com/TsukumoHQ/WRAI.TH/blob/wraith-backend-2/settings-spec/features/wraith-relay-t2a-settings-spec-table-one-server-side-spec-drives-allowlist-put-v.md)

## Gate verdict

**✅ APPROVED** · round 1 · reviewer `review-cd34c6ce-1bdf-4eea-8819-26d132b03599`

## review-agent-runtime verdict: SHIP
Scope: internal/relay settings surface (settings_spec.go, api.go, settings_spec_test.go).
§1 no agentColumns/scanAgent touch, no migration, no schema change — reads the existing settings table via GetSetting. §2 settingSpecs/specByKey/writableSettings/settingGroups are immutable package vars built once (no runtime mutation, no new goroutine, no shared-map write). §3 PUT still writes via SetSetting (single writer) at the same frequency (rare dashboard action, whole-request); GET/validate read via GetSetting (ro pool) — no new per-request write on a hot path; fallible reads return "" (GetSetting swallows err), no nil-deref. §4 no new route/bind/auth; PUT allowlist is now stricter (spec-driven), whole-request 403/400 before apply; secrets never returned (value "") or logged (verified by AC4 log-capture). §5/§6 no MCP tool, lifecycle or self-update change. v1 assets untouched; v1 GET fields (linear_mode + nested linear) preserved byte-compatible.
BLOCKERS: none.
NITS: sun_type gains kind=int min=1 validation (was unvalidated) — a deliberate PUT-validation improvement per ticket, rejects non-int sun_type; flagged, not a regression. Server RO group carries 14 env keys (11 + 3 webhook secrets) vs the ticket's "13" tally — no AC asserts the count; noted.
Gate: go test -tags fts5 ./internal/relay/... = 474 pass; vet clean; gofmt clean; 5 AC tests + pre-existing TestV2ConfigPanel green.
## review-agent-runtime verdict: SHIP
Scope: internal/relay settings surface (settings_spec.go, api.go, settings_spec_test.go).
§1 no agentColumns/scanAgent touch, no migration, no schema change — reads the existing settings table via GetSetting. §2 settingSpecs/specByKey/writableSettings/settingGroups are immutable package vars built once (no runtime mutation, no new goroutine, no shared-map write). §3 PUT still writes via SetSetting (single writer) at the same frequency (rare dashboard action, whole-request); GET/validate read via GetSetting (ro pool) — no new per-request write on a hot path; fallible reads return "" (GetSetting swallows err), no nil-deref. §4 no new route/bind/auth; PUT allowlist is now stricter (spec-driven), whole-request 403/400 before apply; secrets never returned (value "") or logged (verified by AC4 log-capture). §5/§6 no MCP tool, lifecycle or self-update change. v1 assets untouched; v1 GET fields (linear_mode + nested linear) preserved byte-compatible.
BLOCKERS: none.
NITS: sun_type gains kind=int min=1 validation (was unvalidated) — a deliberate PUT-validation improvement per ticket, rejects non-int sun_type; flagged, not a regression. Server RO group carries 14 env keys (11 + 3 webhook secrets) vs the ticket's "13" tally — no AC asserts the count; noted.
Gate: go test -tags fts5 ./internal/relay/... = 474 pass; vet clean; gofmt clean; 5 AC tests + pre-existing TestV2ConfigPanel green.

---
<sub>Authored by agent `wraith-backend-2` · branch `wraith-backend-2/settings-spec` → `main` · reviewed by niwa-gate and merged when this repo's checks pass.</sub>

## Schéma

```mermaid
flowchart TD
    spec["settings_spec.go"]
    
    writableKeys["writableKeys()"]
    validate["validateSettings()"]
    valVal["validateValue()"]
    metadata["settingsMetadata()"]
    
    spec --> writableKeys
    spec --> validate
    spec --> valVal
    spec --> metadata
    
    api["api.go"]
    
    validate -.->|drives| api
    valVal -.->|drives| api
    metadata -.->|drives| api
    
    api --> put["apiPutSetting()"]
    api --> get["apiGetSettings()"]
```

```mermaid
flowchart TD
    PUT["PUT /api/settings"]
    
    DECODE["Decode map"]
    VAL["validateSettings"]
    
    CHECK1{"All keys in writableKeys?"}
    CHECK2{"All values valid?"}
    
    PUT --> DECODE
    DECODE --> VAL
    VAL --> CHECK1
    
    CHECK1 -->|No| F403["403: not writable"]
    CHECK1 -->|Yes| CHECK2
    
    CHECK2 -->|No| F400["400: invalid value"]
    CHECK2 -->|Yes| APPLY["SetSetting all"]
    
    F403 --> NONE["Apply: NOTHING"]
    F400 --> NONE
    APPLY --> OK["200 OK"]
```
