### PR TITLE
[wraith/console] T2c v2 config panel renders the full surface from GET /api/settings metadata: 6 groups, source badges, locks, inline 400 errors, secrets set/unset

### DIFF
--- a/features/wraith-console-t2c-v2-config-panel-renders-the-full-surface-from-get-api-setting.md
+++ b/features/wraith-console-t2c-v2-config-panel-renders-the-full-surface-from-get-api-setting.md
@@ -1,0 +1,118 @@
+# [wraith/console] T2c v2 config panel renders the full surface from GET /api/settings metadata: 6 groups, source badges, locks, inline 400 errors, secrets set/unset
+
+## Team : wraith-engine-2 (tsukumo)
+## Branch : wraith-engine-2/t2c-config-panel (from main)
+## Relay task : 2abc3bef-c6e8-403f-bc70-26e84b3f4c75
+## Status : 🔵 SUBMITTED
+
+## 1. Product Brief
+
+### Acceptance Criteria
+- [ ] 1. AC1 named test: settings.js renders sections from the response groups array in server order and has NO hardcoded writable key list (no `key: '` FIELDS literals); the LABELS map keys are a subset of the frozen-contract fixture keys and every writable fixture key has a label
+- [ ] 2. AC2 named test: settings.js contains the badge text map with exactly the four texts env / setting / default / compile-time (code), and the lock condition covers both writable=false and source=env
+- [ ] 3. AC3 named test: on a 400 response settings.js renders the detail next to the offending key (data-err-key attribute path present) and keeps the existing 403 path via j.detail || j.error in v2/api.js
+- [ ] 4. AC4 named test: for kind=secret the panel renders a set/unset pill and a replace input with no value attribute, the clear action sends JSON null, an empty replace input omits the key from the PUT body, and no asset contains console.log or a fixture secret string
+- [ ] 5. AC5 named smoke test: the federation group renders as a read-only summary with a link to the federation page (no inline JSON editor), the Timing rows render note text when present, and no new v2 id/class leaks into v1 assets; scope: diff touches exactly internal/web/static/v2/settings.js, internal/web/static/v2/v2.css, internal/relay/console_v2_config_panel_test.go; go test -tags fts5 ./internal/relay/... green
+
+## 2. Root cause & decisions
+
+# Decision — 2abc3bef T2c v2 config panel (full surface from GET /api/settings)
+
+ROOT_CAUSE: the v2 config panel exposed only 8 keys (sun_type + 7 Linear) from a
+hardcoded FIELDS list; founder ask "la page config pas assez bien, il manque bcp
+de config". T2a froze the full metadata contract (settings_spec.go); T2c makes
+the panel render the whole surface from that metadata.
+
+## Decision
+Rewrite internal/web/static/v2/settings.js to render from GET /api/settings
+{groups, settings} instead of a hardcoded list: one section per group in server
+order, per-key source badge (env/setting/default/compile-time (code)), read-only
+lock when !writable || source==='env', per-row note, inline 400 {error,key,detail}
+placed next to the offending key via data-err-key (no re-render → form state kept).
+Kind-aware inputs (bool/enum/int/duration/json/string/secret). Secrets: set/unset
+pill + never-prefilled replace input + clear (sends JSON null); empty replace is
+omitted from the PUT (never sends ""). Federation = RO summary (peer count +
+labels, tokens never rendered) + link to #/federation; no inline editor. The
+existing Boards group (S7b) is preserved unchanged.
+
+## Rulings applied
+- A5: editable set derived from the real spec — writableKeys() minus
+  federation_peers = 23; the test derives `want` from settingSpecs/writableKeys(),
+  never from writableSettings (which stays the 9 legacy keys in api.go).
+- A6: 403 error "not writable: <key>" (+key), 400 "invalid value: <key>" (+key,
+  +detail); the panel renders `detail` (unchanged) inline and surfaces 403 via
+  api.js j.detail||j.error. v1-compat GET flat fields (linear_mode, linear{}) are
+  ignored by the panel (it iterates settings[]).
+- Q3: Timing rows show badge "compile-time (code)" (source=code), RO.
+
+## Files (3)
+- internal/web/static/v2/settings.js — metadata-driven rendering + save/clear.
+- internal/web/static/v2/v2.css — badge/lock/pill/err/note/federation styles.
+- internal/relay/console_v2_config_panel_test.go — rewritten, 5 AC tests.
+
+## ACs → tests (one per AC; live handler via httptest where possible)
+- AC1 TestV2ConfigPanelLabelsSubsetOfSpec — no hardcoded key list; s.groups.map;
+  LABELS ⊆ settingSpecs keys; every editable writable key (writableKeys minus
+  federation_peers) has a label.
+- AC2 TestV2ConfigPanelSourceBadgesAndLock — SOURCE_BADGE exactly 4 texts incl
+  "compile-time (code)"; lock condition covers writable=false AND source=env.
+- AC3 TestV2ConfigPanelInlineValidationError — live PUT: 400 "invalid value: <key>"
+  +key+detail nothing applied, 403 "not writable: <key>" +key nothing applied;
+  settings.js targets data-err-key + api.js j.detail||j.error.
+- AC4 TestV2ConfigPanelSecretSetUnsetClear — pill; replace input has no value=;
+  clear sends JSON null; empty replace omitted; no console.log in assets; live GET
+  never returns a secret value (value "" + set true + secret true).
+- AC5 TestV2ConfigPanelFederationSummaryAndScope — federation RO summary + link,
+  no inline editor; rows render note; no v2 token leaks into v1 assets; live GET
+  returns groups in fixed order + 12-field settings entries.
+
+## Rejected alternatives
+- Keep the old TestV2ConfigPanel subtests: impossible — they asserted the removed
+  hardcoded FIELDS + old GET shape; the ticket mandates the rewrite.
+- Touch api.js for the 400 key: rejected (out of 3-file scope) — settings.js does
+  its own whole-request PUT to read the structured {error,key,detail}; api.js
+  stays unchanged (403 path still greps j.detail||j.error).
+
+## Verify
+go build -tags fts5 ./... OK; go vet OK; gofmt clean;
+go test -tags fts5 ./internal/relay/... → 471 passed (5 new AC tests).
+Live: built binary, GET /api/settings on a local relay (RELAY_DB tmp, PORT 8199,
+RELAY_BIND 127.0.0.1, HOME tmp) → valid JSON, groups in order, 57 settings, 24
+writable, 6 secret, federation source=default value="", timing source=code.
+v1 assets untouched. No LEGACY_OPPORTUNITY.
+
+## review-wraith verdict: SHIP
+Scope: internal/web/static/v2/settings.js, internal/web/static/v2/v2.css,
+internal/relay/console_v2_config_panel_test.go
+Gate: build -tags fts5 OK / vet OK / gofmt OK / test -tags fts5 OK (471 passed)
+
+BLOCKERS (must fix before merge):
+- none
+
+NITS (non-blocking):
+- none
+
+Notes: no DB writer / schema / migration / messaging / dispatch / SSE / updater
+surface touched — the fleet-backbone thesis (SSOT, single-writer, backward-compat)
+is not in scope. The test's live-handler use is GET (read) + PUT validation only,
+no new writer. Secrets never leave the server (live GET asserts masked). v1 assets
+byte-identical (AC5 asserts no v2-token leak). Federation tokens never rendered.
+
+## 3. Files changed
+
+```
+internal/relay/console_v2_config_panel_test.go | 522 +++++++++++++++----------
+ internal/web/static/v2/settings.js             | 378 ++++++++++++------
+ internal/web/static/v2/v2.css                  |  34 ++
+ 3 files changed, 604 insertions(+), 330 deletions(-)
+```
+
+## 4. QA Log
+
+_(no review round yet)_
+
+## 5. Timeline
+
+
+---
+_Auto-assembled by the niwa scribe from the Q&A gate. Task `2abc3bef-c6e8-403f-bc70-26e84b3f4c75`._

--- a/internal/relay/console_v2_config_panel_test.go
+++ b/internal/relay/console_v2_config_panel_test.go
@@ -1,8 +1,6 @@
 package relay
 
 import (
-	"encoding/json"
-	"net/http"
 	"regexp"
 	"strings"
 	"testing"
@@ -10,7 +8,16 @@ import (
 	"agent-relay/internal/web"
 )
 
-func readCfgAsset(t *testing.T, name string) string {
+// TestV2ConfigPanel* — the S5/T2c contract: the v2 settings panel renders the
+// WHOLE relay configuration surface from the frozen GET /api/settings metadata
+// (T2a: settings_spec.go). The panel is metadata-driven, so its editable set is
+// derived here from the REAL server spec (settingSpecs / writableKeys()), never
+// from writableSettings (ruling A5). The JS-only behaviour (this repo ships no JS
+// runtime under `go test`) is pinned at the source level; everything that can be
+// is exercised against the live handlers (httptest), including the A6 error
+// strings. Each test maps to exactly one acceptance criterion (AC1..AC5).
+
+func readPanelAsset(t *testing.T, name string) string {
 	t.Helper()
 	b, err := web.StaticFiles.ReadFile(name)
 	if err != nil {
@@ -19,234 +26,315 @@ func readCfgAsset(t *testing.T, name string) string {
 	return string(b)
 }
 
-// fieldKeyRe extracts the `key: '<k>'` literals from the FIELDS table in
-// settings.js. Only the FIELDS entries use that quoted form; runtime uses of the
-// key (data-key="${f.key}") carry no colon-then-single-quote, so this matches the
-// declared field set exactly.
-var fieldKeyRe = regexp.MustCompile(`\bkey:\s*'([^']+)'`)
+// labelsBlock returns the body of the `const LABELS = { ... };` object in
+// settings.js (used to parse the declared label keys).
+func labelsBlock(t *testing.T, js string) string {
+	t.Helper()
+	const marker = "const LABELS = {"
+	i := strings.Index(js, marker)
+	if i < 0 {
+		t.Fatal("settings.js has no `const LABELS = {` map")
+	}
+	rest := js[i+len(marker):]
+	end := strings.Index(rest, "\n};")
+	if end < 0 {
+		t.Fatal("settings.js LABELS map is not closed with `\\n};`")
+	}
+	return rest[:end]
+}
 
-// TestV2ConfigPanel is the S5 (task 8f4e3172) contract, round 2: the v2 console
-// exposes the writable NON-federation settings through the existing server-side
-// allowlist (writableSettings, api.go), with no backend change. Where a claim is
-// a server round-trip it is exercised behaviorally against the real handlers
-// (httptest); the irreducible DOM layer (rendered error banner, reload) is
-// asserted at the source level — this repo ships no JS runtime for `go test`, and
-// the manual serve-local verification is recorded in the PR body (AC6).
-func TestV2ConfigPanel(t *testing.T) {
-	cfg := readCfgAsset(t, "static/v2/settings.js")
+// topLevelKeyRe matches an object entry whose value is a nested object, i.e. a
+// top-level LABELS key `  sun_type: {`. The nested `label:`/`help:` pairs use a
+// string value (`: '`), so they never match this.
+var topLevelKeyRe = regexp.MustCompile(`(?m)^\s*([A-Za-z_][A-Za-z0-9_]*):\s*\{`)
 
-	// AC1 — cross-boundary set equality: the FIELDS keys the panel exposes are
-	// EXACTLY the server allowlist minus federation_peers (federation has its own
-	// page). Parsed from the JS, compared to the Go allowlist — not strings.Contains.
-	t.Run("FieldsMatchWritableAllowlist", func(t *testing.T) {
-		want := map[string]bool{}
-		for k := range writableSettings {
-			want[k] = true
+// AC1 — the panel is metadata-driven: it renders sections from the response
+// `groups` array (no hardcoded FIELDS list), and its LABELS map is a subset of
+// the real spec keys with every EDITABLE writable key labelled. Editable set =
+// writableKeys() minus federation_peers (federation is a RO summary; ruling A5).
+func TestV2ConfigPanelLabelsSubsetOfSpec(t *testing.T) {
+	js := readPanelAsset(t, "static/v2/settings.js")
+
+	// No hardcoded writable key list: the old `key: '<k>'` FIELDS literals are gone.
+	if regexp.MustCompile(`\bkey:\s*'`).MatchString(js) {
+		t.Error("settings.js still contains a hardcoded `key: '...'` FIELDS literal")
+	}
+	// Sections come from the server groups order.
+	if !strings.Contains(js, "s.groups.map(") {
+		t.Error("settings.js does not render sections from the response groups array (s.groups.map)")
+	}
+
+	// Real spec key set and the editable-writable set, derived from the spec.
+	specKeys := map[string]bool{}
+	for _, s := range settingSpecs {
+		specKeys[s.Key] = true
+	}
+	want := writableKeys() // 24 writable keys (map[string]bool)
+	delete(want, "federation_peers")
+
+	labels := map[string]bool{}
+	for _, m := range topLevelKeyRe.FindAllStringSubmatch(labelsBlock(t, js), -1) {
+		labels[m[1]] = true
+	}
+	if len(labels) == 0 {
+		t.Fatal("parsed zero LABELS keys from settings.js")
+	}
+
+	// Every LABELS key must be a real spec key (subset).
+	for k := range labels {
+		if !specKeys[k] {
+			t.Errorf("LABELS key %q is not in the server spec", k)
 		}
-		delete(want, setFederationPeers) // owned by the federation page, not this panel
-
-		got := map[string]bool{}
-		for _, m := range fieldKeyRe.FindAllStringSubmatch(cfg, -1) {
-			got[m[1]] = true
+	}
+	// Every EDITABLE writable key must have a label (all editable rows are named).
+	for k := range want {
+		if !labels[k] {
+			t.Errorf("editable writable key %q has no LABELS entry", k)
 		}
+	}
+}
 
-		for k := range want {
-			if !got[k] {
-				t.Errorf("settings.js FIELDS is missing writable key %q", k)
+// sourceBadgeBlock returns the body of the `const SOURCE_BADGE = { ... };` map.
+func sourceBadgeBlock(t *testing.T, js string) string {
+	t.Helper()
+	const marker = "const SOURCE_BADGE = {"
+	i := strings.Index(js, marker)
+	if i < 0 {
+		t.Fatal("settings.js has no `const SOURCE_BADGE = {` map")
+	}
+	rest := js[i+len(marker):]
+	end := strings.Index(rest, "\n};")
+	if end < 0 {
+		t.Fatal("settings.js SOURCE_BADGE map is not closed")
+	}
+	return rest[:end]
+}
+
+// AC2 — the source badge map has exactly the four texts env / setting / default /
+// compile-time (code), and the lock condition covers both writable=false and
+// source=env.
+func TestV2ConfigPanelSourceBadgesAndLock(t *testing.T) {
+	js := readPanelAsset(t, "static/v2/settings.js")
+	block := sourceBadgeBlock(t, js)
+
+	entryRe := regexp.MustCompile(`(?m)^\s*[A-Za-z_]+:\s*'([^']*)'`)
+	got := entryRe.FindAllStringSubmatch(block, -1)
+	if len(got) != 4 {
+		t.Fatalf("SOURCE_BADGE must have exactly 4 entries, got %d", len(got))
+	}
+	want := map[string]bool{"env": true, "setting": true, "default": true, "compile-time (code)": true}
+	for _, m := range got {
+		if !want[m[1]] {
+			t.Errorf("unexpected SOURCE_BADGE text %q", m[1])
+		}
+		delete(want, m[1])
+	}
+	for k := range want {
+		t.Errorf("SOURCE_BADGE missing required text %q", k)
+	}
+
+	// The lock condition is exactly writable=false OR source=env.
+	if !strings.Contains(js, "!st.writable || st.source === 'env'") {
+		t.Error("lock condition must cover both writable=false and source=env")
+	}
+}
+
+// AC3 — a 400 validation error carries {error:"invalid value: <key>", key, detail}
+// and applies nothing; an unknown key is 403 {error:"not writable: <key>", key}
+// (ruling A6, live handler). The panel renders the 400 detail inline next to the
+// offending key (data-err-key) and the 403 path still surfaces via api.js.
+func TestV2ConfigPanelInlineValidationError(t *testing.T) {
+	r := testRelay(t)
+
+	// 400: a duration below its minimum. message_retention min is 24h.
+	w := doAPI(r, "PUT", "/settings", `{"message_retention":"1h"}`)
+	if w.Code != 400 {
+		t.Fatalf("invalid value PUT: want 400, got %d: %s", w.Code, w.Body.String())
+	}
+	b := decodeJSON(t, w)
+	if b["error"] != "invalid value: message_retention" {
+		t.Errorf("400 error string (A6): got %q", b["error"])
+	}
+	if b["key"] != "message_retention" {
+		t.Errorf("400 must name the key: got %q", b["key"])
+	}
+	if d, _ := b["detail"].(string); strings.TrimSpace(d) == "" {
+		t.Error("400 must carry a non-empty detail")
+	}
+	if got := r.DB.GetSetting("message_retention"); got != "" {
+		t.Errorf("nothing may be applied on a 400: message_retention=%q", got)
+	}
+
+	// 403: an unknown key, whole-request refused, nothing applied.
+	w = doAPI(r, "PUT", "/settings", `{"evil_key":"x"}`)
+	if w.Code != 403 {
+		t.Fatalf("unknown key PUT: want 403, got %d: %s", w.Code, w.Body.String())
+	}
+	b = decodeJSON(t, w)
+	if b["error"] != "not writable: evil_key" {
+		t.Errorf("403 error string (A6): got %q", b["error"])
+	}
+	if b["key"] != "evil_key" {
+		t.Errorf("403 must name the key: got %q", b["key"])
+	}
+	if got := r.DB.GetSetting("evil_key"); got != "" {
+		t.Errorf("unknown key was written: %q", got)
+	}
+
+	// The panel places the 400 detail into the slot for its key, without a
+	// re-render (form state preserved), and the 403 path uses api.js.
+	js := readPanelAsset(t, "static/v2/settings.js")
+	if !strings.Contains(js, `data-err-key="`) || !strings.Contains(js, `.cfg-err[data-err-key="`) {
+		t.Error("settings.js does not target an inline error slot by key")
+	}
+	if !strings.Contains(js, "e.status === 400") || !strings.Contains(js, "showFieldError(e.key") {
+		t.Error("settings.js does not render the 400 detail next to the offending key")
+	}
+	apiJS := readPanelAsset(t, "static/v2/api.js")
+	if !strings.Contains(apiJS, "j.detail || j.error") {
+		t.Error("api.js no longer lifts the server error via j.detail || j.error")
+	}
+}
+
+var secretInputRe = regexp.MustCompile(`<input[^>]*data-type="secret"[^>]*>`)
+
+// AC4 — a secret renders a set/unset pill and a never-prefilled replace input;
+// the clear action sends JSON null; an empty replace input is omitted from the
+// PUT; no shipped asset logs or embeds a secret; and the live GET never returns a
+// secret value (masked, `set` only).
+func TestV2ConfigPanelSecretSetUnsetClear(t *testing.T) {
+	js := readPanelAsset(t, "static/v2/settings.js")
+
+	// set/unset pill.
+	if !strings.Contains(js, "cfg-pill-") || !strings.Contains(js, "st.set ? 'set' : 'unset'") {
+		t.Error("settings.js does not render a secret set/unset pill")
+	}
+	// The replace input must NOT carry a value= attribute (never prefilled).
+	sin := secretInputRe.FindString(js)
+	if sin == "" {
+		t.Fatal("settings.js has no secret replace input")
+	}
+	if strings.Contains(sin, "value=") {
+		t.Errorf("secret replace input must not be prefilled with a value=: %q", sin)
+	}
+	// Clear sends an explicit JSON null; empty replace omits the key from the PUT.
+	if !strings.Contains(js, "putSettings({ [key]: null })") {
+		t.Error("the clear action does not send JSON null")
+	}
+	if !strings.Contains(js, "if (raw) body[st.key] = raw;") {
+		t.Error("an empty secret replace is not omitted from the PUT body")
+	}
+	// No asset logs, and no secret value is embedded anywhere.
+	for _, name := range []string{"static/v2/settings.js", "static/v2/api.js", "static/v2/v2.css"} {
+		if strings.Contains(readPanelAsset(t, name), "console.log") {
+			t.Errorf("asset %s contains console.log (a logged value can leak a secret)", name)
+		}
+	}
+
+	// Live: a stored secret is never returned by GET; only `set` signals presence.
+	r := testRelay(t)
+	const secret = "lin_supersecret_ABCD"
+	r.DB.SetSetting("linear_api_key", secret)
+	g := doAPI(r, "GET", "/settings", "")
+	if g.Code != 200 {
+		t.Fatalf("GET /settings: want 200, got %d", g.Code)
+	}
+	if strings.Contains(g.Body.String(), secret) {
+		t.Fatal("GET /settings leaked a secret value")
+	}
+	st := findSetting(t, decodeJSON(t, g), "linear_api_key")
+	if st["secret"] != true {
+		t.Errorf("linear_api_key metadata not marked secret: %v", st["secret"])
+	}
+	if v, _ := st["value"].(string); v != "" {
+		t.Errorf("secret value must be empty in metadata, got %q", v)
+	}
+	if st["set"] != true {
+		t.Errorf("secret `set` must reflect the stored value: %v", st["set"])
+	}
+}
+
+// findSetting returns the settings[] entry with the given key from a GET body.
+func findSetting(t *testing.T, resp map[string]any, key string) map[string]any {
+	t.Helper()
+	arr, _ := resp["settings"].([]any)
+	if arr == nil {
+		t.Fatal("GET /settings has no settings array")
+	}
+	for _, e := range arr {
+		m, _ := e.(map[string]any)
+		if m != nil && m["key"] == key {
+			return m
+		}
+	}
+	t.Fatalf("settings[] has no entry for key %q", key)
+	return nil
+}
+
+// AC5 (smoke) — federation is a read-only summary linking to its own page (no
+// inline editor); Timing rows render note text when present; no new v2 id/class
+// leaks into any v1 asset; and the live GET returns the frozen shape (groups in
+// the fixed order + full-metadata settings entries).
+func TestV2ConfigPanelFederationSummaryAndScope(t *testing.T) {
+	js := readPanelAsset(t, "static/v2/settings.js")
+
+	// RO summary + link to the federation editor page, and no inline editor input
+	// in the federation branch.
+	if !strings.Contains(js, "cfg-fed-summary") || !strings.Contains(js, `href="#/federation"`) {
+		t.Error("federation group is not a RO summary with a link to the federation page")
+	}
+	fedStart := strings.Index(js, "function federationHTML(")
+	fedEnd := strings.Index(js, "function groupHTML(")
+	if fedStart < 0 || fedEnd < 0 || fedEnd <= fedStart {
+		t.Fatal("cannot isolate federationHTML() in settings.js")
+	}
+	if strings.Contains(js[fedStart:fedEnd], "data-type=") {
+		t.Error("federation summary must not render an inline editor input")
+	}
+
+	// Rows render their note when non-empty (e.g. the Timing writerTimeout note).
+	if !strings.Contains(js, "st.note") || !strings.Contains(js, "cfg-note-row") {
+		t.Error("rows do not render note text when present")
+	}
+
+	// Scope: none of the new v2 panel classes/attrs leak into any v1 asset.
+	leaks := []string{"cfg-badge", "cfg-fed-summary", "cfg-secret-wrap", "cfg-pill", "data-err-key"}
+	for _, name := range []string{"static/index.html", "static/style.css", "static/js/main.js"} {
+		a := readPanelAsset(t, name)
+		for _, leak := range leaks {
+			if strings.Contains(a, leak) {
+				t.Errorf("v1 asset %s leaked a v2 panel token %q", name, leak)
 			}
 		}
-		for k := range got {
-			if !want[k] {
-				t.Errorf("settings.js FIELDS exposes non-writable / out-of-scope key %q", k)
-			}
-		}
-		if len(got) != len(want) {
-			t.Errorf("FIELDS key count %d != allowlist-minus-federation %d", len(got), len(want))
-		}
-	})
+	}
 
-	// AC2 — save through the allowlist: an allowlist key round-trips and persists;
-	// a key OUTSIDE the allowlist is refused (403) and nothing is written. Live
-	// handlers, same pattern as TestApiPutSetting_Allowlist / TestAPISettings.
-	t.Run("SaveThroughAllowlistNonAllowlistRejected", func(t *testing.T) {
-		r := testRelay(t)
-
-		// Non-allowlist key → 403, nothing persisted.
-		w := doAPI(r, "PUT", "/settings", `{"evil_key":"x"}`)
-		if w.Code != http.StatusForbidden {
-			t.Fatalf("non-allowlist PUT: want 403, got %d: %s", w.Code, w.Body.String())
+	// Live frozen shape: groups in the fixed order, and every settings entry
+	// carries all 12 metadata fields.
+	r := testRelay(t)
+	g := doAPI(r, "GET", "/settings", "")
+	if g.Code != 200 {
+		t.Fatalf("GET /settings: want 200, got %d", g.Code)
+	}
+	resp := decodeJSON(t, g)
+	groups, _ := resp["groups"].([]any)
+	wantGroups := []string{"console", "linear", "federation", "server", "operational", "timing"}
+	if len(groups) != len(wantGroups) {
+		t.Fatalf("groups: want %v, got %v", wantGroups, groups)
+	}
+	for i, gname := range wantGroups {
+		if groups[i] != gname {
+			t.Errorf("groups[%d]: want %q, got %v", i, gname, groups[i])
 		}
-		if got := r.DB.GetSetting("evil_key"); got != "" {
-			t.Fatalf("non-allowlist key was written: %q", got)
+	}
+	settings, _ := resp["settings"].([]any)
+	if len(settings) == 0 {
+		t.Fatal("GET /settings returned no settings entries")
+	}
+	fields := []string{"key", "group", "kind", "value", "set", "source", "writable", "secret", "env_name", "bounds", "default", "note"}
+	first, _ := settings[0].(map[string]any)
+	for _, f := range fields {
+		if _, ok := first[f]; !ok {
+			t.Errorf("settings entry missing field %q: %v", f, first)
 		}
-
-		// Allowlist key → 200 and persisted (the reload contract reads it back).
-		if w := doAPI(r, "PUT", "/settings", `{"sun_type":"3"}`); w.Code != http.StatusOK {
-			t.Fatalf("allowlist PUT: want 200, got %d: %s", w.Code, w.Body.String())
-		}
-		if got := r.DB.GetSetting("sun_type"); got != "3" {
-			t.Fatalf("allowlist key not persisted: sun_type=%q", got)
-		}
-	})
-
-	// AC3 — a server-side rejection is SURFACED, not swallowed: the error string
-	// the server emits reaches the rendered banner. Behaviorally the server emits
-	// the message (below); the wrapper (api.js) lifts j.error into the thrown
-	// Error, and settings.js renders ${e.message} — so the exact server string is
-	// what the user sees. api.js:15-18, settings.js catch→render cited in the PR.
-	t.Run("ServerErrorSurfaced", func(t *testing.T) {
-		r := testRelay(t)
-		w := doAPI(r, "PUT", "/settings", `{"evil_key":"x"}`)
-		if w.Code != http.StatusForbidden {
-			t.Fatalf("want 403, got %d", w.Code)
-		}
-		var body map[string]any
-		if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
-			t.Fatalf("403 body is not JSON: %v (%s)", err, w.Body.String())
-		}
-		serverMsg, _ := body["error"].(string)
-		if !strings.Contains(serverMsg, "not writable") || !strings.Contains(serverMsg, "evil_key") {
-			t.Errorf("server error message not descriptive (must name the refused key): %q", serverMsg)
-		}
-
-		// The wrapper lifts the server's error field, and the panel renders it.
-		apiJS := readCfgAsset(t, "static/v2/api.js")
-		if !strings.Contains(apiJS, "j.detail || j.error") {
-			t.Error("api.js does not lift the server error body into the thrown Error")
-		}
-		for _, want := range []string{"save failed:", "${e.message}"} {
-			if !strings.Contains(cfg, want) {
-				t.Errorf("settings.js does not render the surfaced error (%q missing)", want)
-			}
-		}
-	})
-
-	// AC4 — reload reflects persisted values, and the secret is returned MASKED
-	// (never in plaintext). GET-PUT-GET on the panel's keys; the write-only pair
-	// (linear_routing/linear_project_map) is not echoed by GET by design, so its
-	// persistence is checked at the store.
-	t.Run("ReloadReflectsPersistedSecretMasked", func(t *testing.T) {
-		r := testRelay(t)
-
-		// GET-PUT-GET over ALL 8 panel keys (the full FIELDS set), not a subset:
-		// sun_type + the 6 GET-echoed Linear keys + the 2 write-only Linear keys.
-		const secret = "lin_supersecret_ABCD"
-		put := `{"sun_type":"7","linear_enabled":"1","linear_team_key":"SYN",` +
-			`"linear_project":"growth","linear_reconcile_interval":"5m",` +
-			`"linear_api_key":"` + secret + `","linear_routing":"{\"p\":\"a\"}",` +
-			`"linear_project_map":"{\"p\":\"proj\"}"}`
-		if w := doAPI(r, "PUT", "/settings", put); w.Code != http.StatusOK {
-			t.Fatalf("PUT: want 200, got %d: %s", w.Code, w.Body.String())
-		}
-
-		// Write-only keys persist at the store (GET never exposes them).
-		if got := r.DB.GetSetting("linear_routing"); got == "" {
-			t.Error("linear_routing (write-only) not persisted")
-		}
-		if got := r.DB.GetSetting("linear_project_map"); got == "" {
-			t.Error("linear_project_map (write-only) not persisted")
-		}
-
-		// Reload: GET must reflect the persisted values and mask the secret.
-		w := doAPI(r, "GET", "/settings", "")
-		if w.Code != http.StatusOK {
-			t.Fatalf("GET: want 200, got %d", w.Code)
-		}
-		raw := w.Body.String()
-		if strings.Contains(raw, secret) {
-			t.Fatal("GET /settings leaked the linear_api_key in plaintext")
-		}
-		var s map[string]any
-		if err := json.Unmarshal([]byte(raw), &s); err != nil {
-			t.Fatalf("GET body not JSON: %v", err)
-		}
-		if s["sun_type"] != "7" {
-			t.Errorf("reload did not reflect sun_type: got %v", s["sun_type"])
-		}
-		lin, _ := s["linear"].(map[string]any)
-		if lin == nil {
-			t.Fatal("GET body has no linear block")
-		}
-		if lin["team_key"] != "SYN" {
-			t.Errorf("reload did not reflect linear team_key: got %v", lin["team_key"])
-		}
-		if lin["project"] != "growth" {
-			t.Errorf("reload did not reflect linear project: got %v", lin["project"])
-		}
-		// The backend normalizes the duration on read (time.Duration round-trip),
-		// so "5m" comes back canonicalized as "5m0s" — assert the persisted value.
-		if lin["interval"] != "5m0s" {
-			t.Errorf("reload did not reflect linear interval: got %v", lin["interval"])
-		}
-		if lin["enabled"] != true {
-			t.Errorf("reload did not reflect linear enabled: got %v", lin["enabled"])
-		}
-		masked, _ := lin["api_key_masked"].(string)
-		if masked == "" || !strings.HasSuffix(masked, "ABCD") || masked == secret {
-			t.Errorf("api key not returned masked: got %q", masked)
-		}
-
-		// The panel never logs (a logged secret is a leak).
-		if strings.Contains(cfg, "console.log") {
-			t.Error("settings.js logs — a secret must never be logged")
-		}
-	})
-
-	// AC5 — v1 is untouched and build is green: none of the config-panel ids leak
-	// into any v1 asset (static/ outside v2/). Build-green is implied by this file
-	// compiling and running.
-	t.Run("V1ZeroDiffBuildGreen", func(t *testing.T) {
-		v1Assets := []string{"static/index.html", "static/style.css", "static/js/main.js"}
-		for _, name := range v1Assets {
-			a := readCfgAsset(t, name)
-			for _, leak := range []string{"cfg-wrap", "initSettings", "cfg-save"} {
-				if strings.Contains(a, leak) {
-					t.Errorf("v1 asset %s leaked a v2 config-panel id %q", name, leak)
-				}
-			}
-		}
-		v2 := readCfgAsset(t, "static/v2/v2.js")
-		for _, want := range []string{"initSettings", "settings"} {
-			if !strings.Contains(v2, want) {
-				t.Errorf("v2.js does not register the settings route (%q missing)", want)
-			}
-		}
-	})
-
-	// AC6 (surface) — the secret is a masked field and the panel never logs, so a
-	// token cannot leak to the console. The DOM behavior itself has no JS runtime
-	// under `go test` (verified in serve local, PR body); this pins the source
-	// guarantees the manual pass rides on.
-	t.Run("SecretMaskedNeverLogged", func(t *testing.T) {
-		for _, want := range []string{`data-type="secret"`, `type="password"`, "api_key_masked"} {
-			if !strings.Contains(cfg, want) {
-				t.Errorf("settings.js missing masked-secret marker %q", want)
-			}
-		}
-		if strings.Contains(cfg, "console.log") {
-			t.Error("settings.js logs — a secret must never be logged")
-		}
-	})
-
-	// AC (r4 data-loss guard) — a FAILED load (s === null) must not let a Save
-	// wipe the stored config with blanks/'0'. Source-pinned (no JS runtime under
-	// `go test`; manual serve-local failed-load pass recorded in the PR body):
-	// on null state the panel disables every input, replaces Save with a Retry
-	// button, and wire() binds no save handler (early-return on !s), so collect()
-	// and the PUT are unreachable.
-	t.Run("FailedLoadDisablesSaveNoWipe", func(t *testing.T) {
-		// Inputs disabled when there is no snapshot.
-		if !strings.Contains(cfg, "!s || (f.linear && linearLocked())") {
-			t.Error("fieldHTML does not disable inputs on a failed load (s === null)")
-		}
-		// Save is swapped for a Retry button (no Save present in the null branch).
-		if !strings.Contains(cfg, "cfgRetry") {
-			t.Error("render does not offer a Retry-load button on a failed load")
-		}
-		// wire() returns early on !s, so no save handler exists to wipe config.
-		guard := regexp.MustCompile(`if\s*\(!s\)\s*\{`)
-		if !guard.MatchString(cfg) {
-			t.Error("wire() does not early-return on a failed load (!s) — a Save could wipe config")
-		}
-	})
+	}
 }

--- a/internal/web/static/v2/settings.js
+++ b/internal/web/static/v2/settings.js
@@ -1,47 +1,86 @@
-// Config panel — the writable non-federation settings the console client asked
-// for. Reads/writes /api/settings through the existing server-side allowlist
-// (writableSettings, api.go). Federation stays on its own page (federation.js);
-// this panel owns sun_type + the Linear connector keys.
+// Config panel — renders the WHOLE relay configuration surface from the frozen
+// GET /api/settings metadata (T2a contract): a `groups` order array + a
+// `settings` array where every entry carries {key, group, kind, value, set,
+// source, writable, secret, env_name, bounds, default, note}. There is NO
+// hardcoded writable key list here anymore; the panel is driven entirely by the
+// server metadata, and the server remains the single allowlist authority.
 //
-// Two hard rules mirrored from the backend:
-//   - Secret (linear_api_key) is shown MASKED and never rendered in full or
-//     logged. Leaving it blank on save keeps the stored secret (we simply don't
-//     send the key), same "blank = unchanged" contract federation.js uses.
-//   - Only allowlist keys are ever sent. Every field's key comes from FIELDS
-//     below (all writableSettings entries), so an out-of-allowlist key can't be
-//     assembled here; the server also rejects the whole PUT if one slips in, and
-//     that rejection is surfaced to the user, not swallowed.
-//
-// GET /api/settings returns current values for sun_type + linear
-// enabled/api_key_masked/team_key/project/interval. It does NOT return
-// linear_routing / linear_project_map, so those two are WRITE-ONLY here (labeled
-// as such; blank keeps the stored value) — exposing them read/write would need a
-// backend change this slice is scoped to avoid.
+// Hard rules mirrored from the backend:
+//   - Secrets never render their value (metadata value is always ""); the panel
+//     shows a set/unset pill and a never-prefilled 'replace' input. An empty
+//     replace input is OMITTED from the PUT (blank = unchanged, never sends "");
+//     an explicit 'clear' sends JSON null for that key.
+//   - A key is read-only when the server says so (!writable) or when it is
+//     resolved from the environment (source === 'env'); locked inputs are
+//     disabled so a save can never write them.
+//   - Federation is summarised read-only with a link to its own editor page;
+//     tokens are never shown here (one editor: v2/federation.js).
+//   - No value is ever logged.
 import { api } from './api.js';
 
-const FIELDS = [
-  { key: 'sun_type', group: 'Console', label: 'Sun variant', type: 'text',
-    hint: 'console theme variant (e.g. 1)', get: (s) => s.sun_type || '' },
-  { key: 'linear_enabled', group: 'Linear', label: 'Connector enabled', type: 'check', linear: true,
-    hint: 'mirror Linear issues into the relay', get: (s) => !!(s.linear && s.linear.enabled) },
-  { key: 'linear_api_key', group: 'Linear', label: 'API key', type: 'secret', linear: true,
-    hint: 'personal Linear token — stored server-side, shown masked; blank keeps current',
-    get: (s) => (s.linear && s.linear.api_key_masked) || '' },
-  { key: 'linear_team_key', group: 'Linear', label: 'Team key', type: 'text', linear: true,
-    hint: 'e.g. SYN', get: (s) => (s.linear && s.linear.team_key) || '' },
-  { key: 'linear_project', group: 'Linear', label: 'Mirror project', type: 'text', linear: true,
-    hint: 'relay project hosting the mirror', get: (s) => (s.linear && s.linear.project) || '' },
-  { key: 'linear_reconcile_interval', group: 'Linear', label: 'Reconcile interval', type: 'text', linear: true,
-    hint: 'e.g. 5m', get: (s) => (s.linear && s.linear.interval) || '' },
-  { key: 'linear_routing', group: 'Linear', label: 'Routing map (JSON)', type: 'json', linear: true, writeOnly: true,
-    hint: '{ "linearProjectId": "agentName" } — write-only; blank keeps current', get: () => '' },
-  { key: 'linear_project_map', group: 'Linear', label: 'Project map (JSON)', type: 'json', linear: true, writeOnly: true,
-    hint: '{ "linearProjectId": "relayProject" } — write-only; blank keeps current', get: () => '' },
-];
+// Group id (server) -> human header, in the server's `groups` order.
+const GROUP_LABELS = {
+  console: 'Console',
+  linear: 'Linear',
+  federation: 'Federation',
+  server: 'Server',
+  operational: 'Operational',
+  timing: 'Timing',
+};
+
+// Source badge text (exact, cto Q3). `code` = a compile-time const (Timing).
+const SOURCE_BADGE = {
+  env: 'env',
+  setting: 'setting',
+  default: 'default',
+  code: 'compile-time (code)',
+};
+
+// A key is locked (read-only input) when the server marks it non-writable OR its
+// value is resolved from the environment (env wins over any DB write).
+const isLocked = (st) => !st.writable || st.source === 'env';
+
+// Human labels + one-line help per key. Keys absent here render their raw key.
+// This map is a subset of the server spec keys; every WRITABLE spec key has an
+// entry (the panel is friendlier, and the contract test enforces the coverage).
+const LABELS = {
+  // Console
+  sun_type: { label: 'Sun variant', help: 'console theme variant (e.g. 1)' },
+  // Linear
+  linear_enabled: { label: 'Connector enabled', help: 'mirror Linear issues into the relay' },
+  linear_api_key: { label: 'API key', help: 'personal Linear token — stored server-side, never shown' },
+  linear_team_key: { label: 'Team key', help: 'e.g. SYN' },
+  linear_project: { label: 'Mirror project', help: 'relay project hosting the mirror' },
+  linear_reconcile_interval: { label: 'Reconcile interval', help: 'e.g. 5m' },
+  linear_routing: { label: 'Routing map (JSON)', help: '{ "linearProjectId": "agentName" }' },
+  linear_project_map: { label: 'Project map (JSON)', help: '{ "linearProjectId": "relayProject" }' },
+  linear_webhook_secret: { label: 'Webhook secret', help: 'set via RELAY env — read-only here' },
+  // Federation
+  federation_peers: { label: 'Federation peers', help: 'managed on the federation page' },
+  // Operational (writable)
+  agent_max_age: { label: 'Agent max age', help: 'idle agent cleanup horizon' },
+  message_retention: { label: 'Message retention', help: 'how long messages are kept' },
+  audit_log_retention: { label: 'Audit log retention', help: 'how long audit rows are kept' },
+  deadletter_short_retention: { label: 'Dead-letter (short)', help: 'short-lived dead-letter retention' },
+  deadletter_long_retention: { label: 'Dead-letter (long)', help: 'must be >= the short retention' },
+  token_usage_retention_days: { label: 'Token usage retention (days)', help: 'drives purge + rollup window' },
+  ack_notify_age: { label: 'Ack notify age', help: 'when an unacked delivery is re-notified' },
+  ack_escalate_age: { label: 'Ack escalate age', help: 'must be greater than the notify age' },
+  backup_keep: { label: 'Backups kept', help: 'env RELAY_BACKUP_KEEP wins when set' },
+  reviewer_ttl_days: { label: 'Reviewer TTL (days)', help: 'env RELAY_REVIEWER_TTL_DAYS wins when set' },
+  foreign_backup_min_age: { label: 'Foreign backup min age', help: 'minimum age before a foreign backup is swept' },
+  activity_idle_seconds: { label: 'Activity: idle (s)', help: 'seconds before an agent reads as idle' },
+  activity_waiting_seconds: { label: 'Activity: waiting (s)', help: 'seconds before an agent reads as waiting' },
+  activity_exit_seconds: { label: 'Activity: exit (s)', help: 'seconds before an agent reads as exited' },
+  cost_default_model: { label: 'Default cost model', help: 'model id used when a token row has none' },
+  // Timing (read-only consts, shown for transparency)
+  writer_timeout: { label: 'Writer timeout', help: 'must stay below the referential scan timeout' },
+  referential_scan_timeout: { label: 'Referential scan timeout', help: 'writer timeout must stay below this' },
+};
 
 export function initSettings(el, ctx) {
   const esc = ctx.esc;
-  let s = null;            // last-loaded settings snapshot
+  let s = null;            // last-loaded settings snapshot { groups, settings }
   let msg = null;          // {kind:'ok'|'err', text}
   // Boards group (S7b-2): archive a board through POST /api/boards/{id}/archive.
   // Independent of the settings snapshot above so it works even when the config
@@ -49,9 +88,13 @@ export function initSettings(el, ctx) {
   let boards = [];
   let boardsProject = null;
 
+  // A well-formed metadata snapshot has both the groups order and the settings.
+  const loaded = () => !!(s && Array.isArray(s.groups) && Array.isArray(s.settings));
+
   async function load() {
     try {
       s = await api.settings();
+      msg = null;
     } catch (e) {
       s = null;
       msg = { kind: 'err', text: `load failed: ${e.message}` };
@@ -59,63 +102,111 @@ export function initSettings(el, ctx) {
     render();
   }
 
-  // The Linear connector can be pinned by env (RELAY_LINEAR_*). When it is, the
-  // backend ignores DB writes for those keys, so we lock the inputs (federation.js
-  // does the same) rather than pretend a save took.
-  const linearLocked = () => !!(s && s.linear && s.linear.source === 'env');
+  // ---- config rendering (metadata-driven) --------------------------------
 
-  function fieldHTML(f) {
-    // A failed load (s === null) disables EVERY input: render() below also
-    // replaces Save with a Retry button and wire() binds no save handler, so a
-    // click can never assemble a body of blanks/'0' that would wipe the stored
-    // config (the data-loss path). Env-pinned Linear stays locked as before.
-    const locked = (!s || (f.linear && linearLocked())) ? 'disabled' : '';
-    const v = s ? f.get(s) : (f.type === 'check' ? false : '');
-    if (f.type === 'check') {
-      return `<label class="cfg-row cfg-check">
-        <span class="cfg-lbl">${esc(f.label)}<small class="cfg-hint">${esc(f.hint)}</small></span>
-        <input type="checkbox" data-key="${f.key}" data-type="check" ${v ? 'checked' : ''} ${locked}>
-      </label>`;
-    }
-    if (f.type === 'json') {
-      return `<label class="cfg-row">
-        <span class="cfg-lbl">${esc(f.label)}<small class="cfg-hint">${esc(f.hint)}</small></span>
-        <textarea class="cfg-in cfg-json" data-key="${f.key}" data-type="json" rows="2" spellcheck="false"
-          placeholder="write-only — leave blank to keep" ${locked}></textarea>
-      </label>`;
-    }
-    if (f.type === 'secret') {
-      // Never put the secret in a value= attribute. Masked hint only; the real
-      // input starts empty and is only sent when the user types a new key.
-      const mask = v ? `${esc(v)} (unchanged)` : 'not set';
-      return `<label class="cfg-row">
-        <span class="cfg-lbl">${esc(f.label)}<small class="cfg-hint">${esc(f.hint)}</small></span>
-        <input type="password" class="cfg-in" data-key="${f.key}" data-type="secret" autocomplete="off"
-          value="" placeholder="${mask}" ${locked}>
-      </label>`;
-    }
-    return `<label class="cfg-row">
-      <span class="cfg-lbl">${esc(f.label)}<small class="cfg-hint">${esc(f.hint)}</small></span>
-      <input type="text" class="cfg-in" data-key="${f.key}" data-type="text" value="${esc(v)}" ${locked}>
-    </label>`;
+  function badgeHTML(st) {
+    const text = SOURCE_BADGE[st.source] || st.source || '';
+    return `<span class="cfg-badge cfg-badge-${esc(st.source)}">${esc(text)}</span>`;
   }
 
-  function groupHTML(name) {
-    const rows = FIELDS.filter((f) => f.group === name).map(fieldHTML).join('');
-    const locked = name === 'Linear' && linearLocked();
-    const note = locked
-      ? `<div class="cfg-note cfg-note-warn">Linear is configured via environment (<code>RELAY_LINEAR_*</code>). Read-only here — unset the env vars to manage it from the console.</div>`
+  function inputHTML(st, locked) {
+    const dis = locked ? 'disabled' : '';
+    const kind = st.kind;
+    if (kind === 'bool') {
+      return `<input type="checkbox" data-key="${esc(st.key)}" data-type="bool" ${st.value === '1' ? 'checked' : ''} ${dis}>`;
+    }
+    if (kind === 'enum') {
+      const vals = (st.bounds && Array.isArray(st.bounds.values)) ? st.bounds.values : [];
+      const opts = vals.map((v) => `<option value="${esc(v)}" ${v === st.value ? 'selected' : ''}>${esc(v)}</option>`).join('');
+      return `<select class="cfg-in" data-key="${esc(st.key)}" data-type="enum" ${dis}>${opts}</select>`;
+    }
+    if (kind === 'int' || kind === 'duration') {
+      const b = st.bounds || {};
+      const hint = (b.min != null && b.max != null) ? `${esc(b.min)}..${esc(b.max)}` : '';
+      return `<input type="text" class="cfg-in" data-key="${esc(st.key)}" data-type="${kind}" value="${esc(st.value)}" placeholder="${hint}" ${dis}>`;
+    }
+    if (kind === 'json') {
+      return `<textarea class="cfg-in cfg-json" data-key="${esc(st.key)}" data-type="json" rows="2" spellcheck="false" ${dis}>${esc(st.value)}</textarea>`;
+    }
+    if (kind === 'secret') {
+      // Never render the secret value. A pill states presence; the replace input
+      // starts empty (no value= attribute) and is only sent when the user types.
+      const pill = `<span class="cfg-pill cfg-pill-${st.set ? 'set' : 'unset'}">${st.set ? 'set' : 'unset'}</span>`;
+      const replace = locked
+        ? ''
+        : `<input type="password" class="cfg-in cfg-secret" data-key="${esc(st.key)}" data-type="secret" autocomplete="off" placeholder="replace — leave blank to keep">`;
+      const clear = (!locked && st.set)
+        ? `<button type="button" class="cfg-clear" data-clear="${esc(st.key)}">clear</button>`
+        : '';
+      return `<div class="cfg-secret-wrap">${pill}${replace}${clear}</div>`;
+    }
+    // string (and any unknown kind) → plain text
+    return `<input type="text" class="cfg-in" data-key="${esc(st.key)}" data-type="string" value="${esc(st.value)}" ${dis}>`;
+  }
+
+  function rowHTML(st) {
+    const meta = LABELS[st.key] || null;
+    const label = meta ? meta.label : st.key;
+    const help = meta ? meta.help : '';
+    const locked = isLocked(st);
+    const lock = locked ? `<span class="cfg-lock" title="read-only">read-only</span>` : '';
+    const note = (st.note && st.note.trim())
+      ? `<div class="cfg-note-row">${esc(st.note)}</div>` : '';
+    return `<div class="cfg-row cfg-row-meta">
+      <span class="cfg-lbl">${esc(label)}
+        <small class="cfg-hint">${esc(help)}</small>
+        <span class="cfg-tags">${badgeHTML(st)}${lock}</span>
+      </span>
+      <span class="cfg-ctl">
+        ${inputHTML(st, locked)}
+        ${note}
+        <div class="cfg-err" data-err-key="${esc(st.key)}" role="alert" hidden></div>
+      </span>
+    </div>`;
+  }
+
+  // Federation is summarised read-only (peer count + labels, NEVER tokens) with a
+  // link to its dedicated editor page. No inline JSON editor lives here (Q2).
+  function federationHTML(settings) {
+    const fed = settings.find((st) => st.key === 'federation_peers');
+    let count = 0;
+    let labels = [];
+    if (fed && fed.value) {
+      try {
+        const arr = JSON.parse(fed.value);
+        if (Array.isArray(arr)) {
+          count = arr.length;
+          labels = arr.map((p) => (p && p.label) ? String(p.label) : '').filter(Boolean);
+        }
+      } catch (_) { /* malformed → summarise as unknown */ }
+    }
+    const list = labels.length
+      ? `<div class="cfg-fed-labels">${labels.map((l) => `<span class="cfg-fed-peer">${esc(l)}</span>`).join('')}</div>`
       : '';
     return `<section class="cfg-group">
-      <h3 class="cfg-gtitle">${esc(name)}</h3>${note}
+      <h3 class="cfg-gtitle">${esc(GROUP_LABELS.federation)}</h3>
+      <div class="cfg-fields">
+        <div class="cfg-fed-summary">
+          <span class="cfg-fed-count">${count} peer${count === 1 ? '' : 's'} configured</span>
+          ${list}
+          <a class="cfg-fed-link" href="#/federation">Manage federation peers →</a>
+        </div>
+      </div>
+    </section>`;
+  }
+
+  function groupHTML(gid, settings) {
+    if (gid === 'federation') return federationHTML(settings);
+    const rows = settings.filter((st) => st.group === gid).map(rowHTML).join('');
+    if (!rows) return '';
+    return `<section class="cfg-group">
+      <h3 class="cfg-gtitle">${esc(GROUP_LABELS[gid] || gid)}</h3>
       <div class="cfg-fields">${rows}</div>
     </section>`;
   }
 
-  // The Boards group: a project picker + one row per active board with an
-  // Archive button and an inline slot for a verbatim server refusal. No force
-  // control is rendered and no retry is performed — the row is removed only when
-  // the server returns 200 (loadBoards refetches the active set).
+  // ---- Boards group (unchanged from S7b) ----------------------------------
+
   function boardsGroupHTML() {
     const projs = (ctx.projects || []).map((p) => p.name);
     if (boardsProject == null) {
@@ -177,8 +268,6 @@ export function initSettings(el, ctx) {
           await api.archiveBoard(boardsProject, id);
           await loadBoards();                 // 200 → row gone from the active set
         } catch (e) {
-          // Verbatim server refusal. Keep the row and the button (a human may act
-          // and click again); no automatic retry, no force/override path.
           if (msgEl) { msgEl.textContent = e.message; msgEl.className = 'cfg-note cfg-note-err'; }
           btn.disabled = false;
           await showOffenders(id, msgEl);
@@ -187,22 +276,26 @@ export function initSettings(el, ctx) {
     });
   }
 
+  // ---- render + save ------------------------------------------------------
+
   function render() {
     const banner = msg
       ? `<div class="cfg-note ${msg.kind === 'err' ? 'cfg-note-err' : 'cfg-note-ok'}" role="status">${esc(msg.text)}</div>`
+      : '';
+    const groups = loaded()
+      ? s.groups.map((gid) => groupHTML(gid, s.settings)).join('')
       : '';
     el.innerHTML = `
       <section class="cfg-wrap">
         <header class="cfg-head">
           <h2>Configuration</h2>
-          <p class="cfg-sub">Writable relay settings. Federation peers live on their own page.</p>
+          <p class="cfg-sub">The full relay configuration surface. Read-only rows are pinned by env or compiled in.</p>
         </header>
         ${banner}
-        ${groupHTML('Console')}
-        ${groupHTML('Linear')}
+        ${groups}
         ${boardsGroupHTML()}
         <div class="cfg-actions">
-          ${s
+          ${loaded()
             ? `<button class="cfg-save" id="cfgSave">Save</button>`
             : `<button class="cfg-save" id="cfgRetry">Retry load</button>`}
         </div>
@@ -210,54 +303,113 @@ export function initSettings(el, ctx) {
     wire();
   }
 
-  // Build the PUT body from the current field values. Keys come only from FIELDS
-  // (all allowlist entries). Secrets/JSON are omitted when blank ("keep current").
-  // Returns { body } or { error } if a JSON field is malformed.
+  // Build the PUT body from the current writable fields. Federation is skipped
+  // (its own page), locked rows are skipped (env/non-writable), a blank secret
+  // replace is OMITTED (blank = unchanged, never sends ""). Returns { body } or
+  // { error } if a JSON field is malformed.
   function collect() {
     const body = {};
-    for (const f of FIELDS) {
-      if (f.linear && linearLocked()) continue;         // env-pinned → never write
-      const node = el.querySelector(`[data-key="${f.key}"]`);
+    for (const st of s.settings) {
+      if (st.group === 'federation') continue;    // summarised, not edited here
+      if (isLocked(st)) continue;                 // env-pinned / non-writable
+      const node = el.querySelector(`[data-key="${st.key}"]`);
       if (!node) continue;
-      if (f.type === 'check') { body[f.key] = node.checked ? '1' : '0'; continue; }
+      if (st.kind === 'bool') { body[st.key] = node.checked ? '1' : '0'; continue; }
       const raw = (node.value || '').trim();
-      if (f.type === 'secret') { if (raw) body[f.key] = raw; continue; }   // blank = keep
-      if (f.type === 'json') {
-        if (!raw) continue;                             // blank = keep
-        try { JSON.parse(raw); } catch (_) { return { error: `${f.label}: not valid JSON` }; }
-        body[f.key] = raw; continue;
+      if (st.kind === 'secret') { if (raw) body[st.key] = raw; continue; }  // blank = keep
+      if (st.kind === 'json') {
+        if (!raw) { body[st.key] = ''; continue; }
+        try { JSON.parse(raw); } catch (_) { return { error: { key: st.key, detail: 'not valid JSON' } }; }
+        body[st.key] = raw; continue;
       }
-      body[f.key] = raw;                                // plain text
+      body[st.key] = raw;                          // string / int / duration / enum
     }
     return { body };
   }
 
+  // Whole-request PUT. On a 400 the server returns {error, key, detail}; we keep
+  // the structured body so the detail can be rendered next to the offending key.
+  // 403 (unknown/non-writable) and other errors surface via j.detail || j.error.
+  async function putSettings(body) {
+    const res = await fetch('/api/settings', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+      body: JSON.stringify(body),
+    });
+    if (res.ok) return res.status === 204 ? null : res.json();
+    let j = {};
+    try { j = await res.json(); } catch (_) { /* non-JSON error */ }
+    const err = new Error(j.detail || j.error || `${res.status}`);
+    err.status = res.status;
+    err.key = j.key || '';
+    err.detail = j.detail || j.error || '';
+    throw err;
+  }
+
+  function clearFieldErrors() {
+    el.querySelectorAll('.cfg-err[data-err-key]').forEach((n) => {
+      n.textContent = '';
+      n.hidden = true;
+    });
+  }
+
+  // Render a validation detail inline next to its key WITHOUT re-rendering, so the
+  // user's in-progress form state is preserved (AC3).
+  function showFieldError(key, detail) {
+    const slot = el.querySelector(`.cfg-err[data-err-key="${key}"]`);
+    if (slot) { slot.textContent = detail; slot.hidden = false; }
+  }
+
   function wire() {
     // The Boards group is independent of the settings snapshot — wire it first so
-    // it stays live even when the config load failed (s === null).
+    // it stays live even when the config load failed.
     wireBoards();
-    // Failed load: no settings snapshot, so bind ONLY the Retry button and
-    // return before any save handler exists — collect()/PUT is unreachable, so a
-    // click cannot wipe the stored config.
-    if (!s) {
+    // Failed load: no snapshot, so bind ONLY the Retry button and return before
+    // any save handler exists — collect()/PUT is unreachable, so a click cannot
+    // wipe the stored config.
+    if (!loaded()) {
       const retry = el.querySelector('#cfgRetry');
       if (retry) retry.onclick = () => { msg = null; load(); };
       return;
     }
+    // Per-secret 'clear': send an explicit JSON null for that one key.
+    el.querySelectorAll('.cfg-clear[data-clear]').forEach((btn) => {
+      btn.onclick = async () => {
+        const key = btn.dataset.clear;
+        clearFieldErrors();
+        btn.disabled = true;
+        try {
+          await putSettings({ [key]: null });     // JSON null = explicit clear
+          msg = { kind: 'ok', text: 'cleared' };
+          await load();
+        } catch (e) {
+          btn.disabled = false;
+          if (e.status === 400 && e.key) { showFieldError(e.key, e.detail); }
+          else { msg = { kind: 'err', text: `clear failed: ${e.message}` }; render(); }
+        }
+      };
+    });
     const save = el.querySelector('#cfgSave');
     if (!save) return;
     save.onclick = async () => {
+      clearFieldErrors();
       const { body, error } = collect();
-      if (error) { msg = { kind: 'err', text: error }; return render(); }
+      if (error) { showFieldError(error.key, error.detail); return; }
       save.disabled = true;
       try {
-        await api.saveSettings(body);
+        await putSettings(body);
         msg = { kind: 'ok', text: 'saved' };
-        await load();                                   // reload → reflect persisted values
+        await load();                             // reload → reflect persisted values
       } catch (e) {
-        // Surface the server's reason (e.g. a key the allowlist refused), don't swallow.
-        msg = { kind: 'err', text: `save failed: ${e.message}` };
-        render();
+        save.disabled = false;
+        if (e.status === 400 && e.key) {
+          // Validation refusal: place the detail next to the key, keep form state.
+          showFieldError(e.key, e.detail);
+        } else {
+          // 403 / other: surface the server's reason (j.detail || j.error).
+          msg = { kind: 'err', text: `save failed: ${e.message}` };
+          render();
+        }
       }
     };
   }

--- a/internal/web/static/v2/v2.css
+++ b/internal/web/static/v2/v2.css
@@ -1278,6 +1278,40 @@ button { font-family: inherit; }
 .cfg-note-ok { background: rgba(74,222,128,.10); color: var(--accent); border: 1px solid var(--accent-dim); }
 .cfg-note-err { background: rgba(248,113,113,.10); color: #f87171; border: 1px solid rgba(248,113,113,.35); }
 .cfg-note-warn { background: rgba(234,179,8,.08); color: #eab308; border: 1px solid rgba(234,179,8,.30); }
+
+/* ---- metadata-driven rows (T2c): source badges, locks, notes, inline errors ---- */
+.cfg-tags { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 2px; align-items: center; }
+.cfg-ctl { display: flex; flex-direction: column; gap: 6px; min-width: 0; }
+.cfg-badge { font-size: 10px; font-weight: 600; letter-spacing: 0.3px; text-transform: uppercase;
+  padding: 1px 6px; border-radius: 999px; border: 1px solid var(--border); color: var(--text-dim);
+  background: var(--bg-elev); white-space: nowrap; }
+.cfg-badge-env { color: #eab308; border-color: rgba(234,179,8,.35); background: rgba(234,179,8,.08); }
+.cfg-badge-setting { color: var(--accent); border-color: var(--accent-dim); background: rgba(74,222,128,.08); }
+.cfg-badge-default { color: var(--text-dim); }
+.cfg-badge-code { color: #60a5fa; border-color: rgba(96,165,250,.35); background: rgba(96,165,250,.08); text-transform: none; }
+.cfg-lock { font-size: 10px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.3px;
+  color: var(--text-dim); padding: 1px 6px; border-radius: 999px; border: 1px dashed var(--border); }
+.cfg-note-row { font-size: 11.5px; color: var(--text-dim); line-height: 1.4; }
+.cfg-err { font-size: 12px; color: #f87171; line-height: 1.4; }
+/* secret: set/unset pill + never-prefilled replace input + clear action */
+.cfg-secret-wrap { display: flex; flex-wrap: wrap; gap: 8px; align-items: center; }
+.cfg-secret-wrap .cfg-secret { flex: 1 1 160px; }
+.cfg-pill { font-size: 10px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.3px;
+  padding: 2px 8px; border-radius: 999px; border: 1px solid var(--border); }
+.cfg-pill-set { color: var(--accent); border-color: var(--accent-dim); background: rgba(74,222,128,.10); }
+.cfg-pill-unset { color: var(--text-dim); }
+.cfg-clear { background: transparent; color: #f87171; border: 1px solid rgba(248,113,113,.35);
+  border-radius: var(--radius-sm); padding: 5px 10px; font-size: 12px; cursor: pointer; }
+.cfg-clear:hover { background: rgba(248,113,113,.10); }
+/* federation: read-only summary + link to the dedicated editor page */
+.cfg-fed-summary { display: flex; flex-direction: column; gap: 8px; }
+.cfg-fed-count { font-size: 13px; color: var(--text); }
+.cfg-fed-labels { display: flex; flex-wrap: wrap; gap: 6px; }
+.cfg-fed-peer { font-size: 11.5px; color: var(--text-dim); padding: 1px 8px; border-radius: 999px;
+  border: 1px solid var(--border); background: var(--bg-elev); }
+.cfg-fed-link { font-size: 12.5px; color: var(--accent); text-decoration: none; align-self: flex-start; }
+.cfg-fed-link:hover { text-decoration: underline; }
+
 @media (max-width: 560px) {
   .cfg-row, .cfg-check { grid-template-columns: 1fr; gap: 6px; }
   .cfg-lbl { padding-top: 0; }


### PR DESCRIPTION
### niwa Q&A gate

An adversarial reviewer is reading this diff right now. Its verdict lands on this PR as a review (or a comment when the gate and the author share one GitHub account), and the merge waits for this repository's own checks to go green.

*Opened automatically — a rejected round comes back to the author, who pushes fixes to the same branch.*

## What & why

- **docs(scribe): provenance for wraith-console-t2c-v2-config-panel-renders-the-full-surface-from-get-api-setting**
- **feat: [wraith/console] T2c v2 config panel renders full surface from GET /api/settings metadata**
  <details><summary>details</summary>

  Metadata-driven config panel on the frozen T2a contract (settings_spec.go).
  Replaces the hardcoded FIELDS list with rendering from GET /api/settings
  {groups, settings}: one section per group in server order (Console/Linear/
  Federation/Server/Operational/Timing), per-key source badge (env/setting/
  default/compile-time (code)), read-only lock when !writable || source=env,
  per-row note, and inline 400 {error,key,detail} rendered next to the offending
  key (data-err-key) with form state preserved. Kind-aware inputs (bool/enum/int/
  duration/json/string/secret). Secrets: set/unset pill + never-prefilled replace
  input + clear (JSON null); empty replace omitted from PUT. Federation = RO
  summary + link to its own page, no inline editor, tokens never shown.
  
  Ruling A5: the editable set is derived from the real spec (writableKeys() minus
  federation_peers = 23), never from writableSettings. Ruling A6: 403
  'not writable: <key>' / 400 'invalid value: <key>' + detail; v1-compat GET flat
  fields (linear_mode, linear{}) are ignored by the panel. v1 assets untouched.
  
  Tests (internal/relay/console_v2_config_panel_test.go, one per AC; live handler
  via httptest where possible):
  - TestV2ConfigPanelLabelsSubsetOfSpec        (AC1)
  - TestV2ConfigPanelSourceBadgesAndLock       (AC2)
  - TestV2ConfigPanelInlineValidationError     (AC3)
  - TestV2ConfigPanelSecretSetUnsetClear       (AC4)
  - TestV2ConfigPanelFederationSummaryAndScope (AC5)
  
  Task: 2abc3bef-c6e8-403f-bc70-26e84b3f4c75
  Claude-Session: https://claude.ai/code/session_01XbzhXo1kXCNX9qC6jaZ6pp

  </details>

## Changes

<details><summary>Files changed (git diff --stat)</summary>

```
...enders-the-full-surface-from-get-api-setting.md | 118 +++++
 internal/relay/console_v2_config_panel_test.go     | 522 ++++++++++++---------
 internal/web/static/v2/settings.js                 | 378 ++++++++++-----
 internal/web/static/v2/v2.css                      |  34 ++
 4 files changed, 722 insertions(+), 330 deletions(-)
```

</details>

## Module graph

```mermaid
graph TD
  n0["features/wraith-console-t2c-v2-config-panel-renders-the-full-surface-from-get-api-setting.md"]
  n1["internal/relay"]
  n2["internal/web"]
  n1 --- n2
```

## Acceptance criteria

- [x] AC1 named test: settings.js renders sections from the response groups array in server order and has NO hardcoded writable key list (no `key: '` FIELDS literals); the LABELS map keys are a subset of the frozen-contract fixture keys and every writable fixture key has a label
- [x] AC2 named test: settings.js contains the badge text map with exactly the four texts env / setting / default / compile-time (code), and the lock condition covers both writable=false and source=env
- [x] AC3 named test: on a 400 response settings.js renders the detail next to the offending key (data-err-key attribute path present) and keeps the existing 403 path via j.detail || j.error in v2/api.js
- [x] AC4 named test: for kind=secret the panel renders a set/unset pill and a replace input with no value attribute, the clear action sends JSON null, an empty replace input omits the key from the PUT body, and no asset contains console.log or a fixture secret string
- [x] AC5 named smoke test: the federation group renders as a read-only summary with a link to the federation page (no inline JSON editor), the Timing rows render note text when present, and no new v2 id/class leaks into v1 assets; scope: diff touches exactly internal/web/static/v2/settings.js, internal/web/static/v2/v2.css, internal/relay/console_v2_config_panel_test.go; go test -tags fts5 ./internal/relay/... green
## Provenance

📄 [Root cause, decisions &amp; QA log — `features/wraith-console-t2c-v2-config-panel-renders-the-full-surface-from-get-api-setting.md`](https://github.com/TsukumoHQ/WRAI.TH/blob/wraith-engine-2/t2c-config-panel/features/wraith-console-t2c-v2-config-panel-renders-the-full-surface-from-get-api-setting.md)

## Gate verdict

**✅ APPROVED** · round 1 · reviewer `review-2abc3bef-c6e8-403f-bc70-26e84b3f4c75`

## review-wraith verdict: SHIP
Scope: internal/web/static/v2/settings.js, internal/web/static/v2/v2.css,
internal/relay/console_v2_config_panel_test.go
Gate: build -tags fts5 OK / vet OK / gofmt OK / test -tags fts5 OK (471 passed)

BLOCKERS (must fix before merge):
- none

NITS (non-blocking):
- none

Notes: no DB writer / schema / migration / messaging / dispatch / SSE / updater
surface touched — the fleet-backbone thesis (SSOT, single-writer, backward-compat)
is not in scope. The test's live-handler use is GET (read) + PUT validation only,
no new writer. Secrets never leave the server (live GET asserts masked). v1 assets
byte-identical (AC5 asserts no v2-token leak). Federation tokens never rendered.
## review-wraith verdict: SHIP
Scope: internal/web/static/v2/settings.js, internal/web/static/v2/v2.css,
internal/relay/console_v2_config_panel_test.go
Gate: build -tags fts5 OK / vet OK / gofmt OK / test -tags fts5 OK (471 passed)

BLOCKERS (must fix before merge):
- none

NITS (non-blocking):
- none

Notes: no DB writer / schema / migration / messaging / dispatch / SSE / updater
surface touched — the fleet-backbone thesis (SSOT, single-writer, backward-compat)
is not in scope. The test's live-handler use is GET (read) + PUT validation only,
no new writer. Secrets never leave the server (live GET asserts masked). v1 assets
byte-identical (AC5 asserts no v2-token leak). Federation tokens never rendered.

---
<sub>Authored by agent `wraith-engine-2` · branch `wraith-engine-2/t2c-config-panel` → `main` · reviewed by niwa-gate and merged when this repo's checks pass.</sub>

## Schéma

```mermaid
flowchart TD
    A["GET /api/settings\ngroups and settings metadata"]
    B["settings.js"]
    C["Process groups array"]
    D["Render per-setting row"]
    E1["add SOURCE_BADGE\nenv/setting/default/code"]
    E2["apply Lock logic\n!writable OR source=env"]
    E3["render kind input\nsecret/bool/enum/int/json"]
    E4["handle 400 errors\ndata-err-key and detail"]
    F["v2.css styling"]
    G["v2 Config Panel"]
    H["console_v2_config_panel_test.go\nAC1-AC5 tests"]
    
    A -->|"fetch"| B
    B -->|"iterate"| C
    C -->|"render"| D
    D --> E1
    D --> E2
    D --> E3
    D --> E4
    E1 --> F
    E2 --> F
    E3 --> F
    E4 --> F
    F -->|"display"| G
    H -.->|"validates"| B
```

```mermaid
flowchart LR
    OLD["OLD: Hardcoded\nsettings.js FIELDS\n8 keys\nsun_type and 7 Linear"]
    
    NEW["NEW: Metadata-driven\nGET /api/settings\n23 writable\n6 secret\n6 groups\nbadges, locks, errors, notes"]
    
    OLD -->|"T2c rewrite"| NEW
```
