### PR TITLE
[wraith/db+relay] T2b Operational knobs read at tick time: SettingDuration/SettingInt accessors (clamp+default+one WARN) + cleanup.go reads every Operational key inside the tick, env twins keep precedence

### DIFF
--- a/features/wraith-db-relay-t2b-operational-knobs-read-at-tick-time-settingduration-settingi.md
+++ b/features/wraith-db-relay-t2b-operational-knobs-read-at-tick-time-settingduration-settingi.md
@@ -3,7 +3,7 @@
 ## Team : wraith-backend-2 (tsukumo)
 ## Branch : wraith-backend-2/t2b-tick-reads (from main)
 ## Relay task : 1c3324e2-fa0b-4de3-8c2f-df859557031f
-## Status : 🔵 IN REVIEW
+## Status : 🔵 SUBMITTED
 
 ## 1. Product Brief
 
@@ -49,11 +49,11 @@ NITS (non-blocking):
 ## 3. Files changed
 
 ```
-...s-read-at-tick-time-settingduration-settingi.md |  66 ++++
+...s-read-at-tick-time-settingduration-settingi.md |  73 +++++
  internal/db/projects.go                            |  67 ++++
  internal/relay/cleanup.go                          | 320 +++++++++++-------
  internal/relay/cleanup_test.go                     | 359 +++++++++++++++++++++
- 4 files changed, 688 insertions(+), 124 deletions(-)
+ 4 files changed, 695 insertions(+), 124 deletions(-)
 ```
 
 ## 4. QA Log
@@ -68,6 +68,10 @@ NITS (non-blocking):
 ## 5. Timeline
 
 - round 1 → **approve** (review-1c3324e2-fa0b-4de3-8c2f-df859557031f)
+
+**Approve-with-findings (follow-up):** go test -tags fts5 ./internal/relay/... = 479 passed; 5 named AC tests all pass; accessors clamp+dedupe-warn, runCleanupTick reads every Operational key at tick, env twins keep precedence, token_days drives purge+rollup, empty table == consts + spec defaults align
+
+- **notice** `features/wraith-db-relay-t2b-operational-knobs-read-at-tick-time-settingduration-settingi.md:1` — scope says exactly 3 Go files; diffstat shows a 4th file (auto-generated scribe provenance .md). No code impact — proceed.
 
 ---
 _Auto-assembled by the niwa scribe from the Q&A gate. Task `1c3324e2-fa0b-4de3-8c2f-df859557031f`._

--- a/features/wraith-db-relay-t2b-operational-knobs-read-at-tick-time-settingduration-settingi.md
+++ b/features/wraith-db-relay-t2b-operational-knobs-read-at-tick-time-settingduration-settingi.md
@@ -1,0 +1,66 @@
+# [wraith/db+relay] T2b Operational knobs read at tick time: SettingDuration/SettingInt accessors (clamp+default+one WARN) + cleanup.go reads every Operational key inside the tick, env twins keep precedence
+
+## Team : wraith-backend-2 (tsukumo)
+## Branch : wraith-backend-2/t2b-tick-reads (from main)
+## Relay task : 1c3324e2-fa0b-4de3-8c2f-df859557031f
+## Status : 🔵 SUBMITTED
+
+## 1. Product Brief
+
+### Acceptance Criteria
+- [ ] 1. AC1 named test: SettingDuration/SettingInt return def on unset, the stored value when inside [min,max], the clamped bound when outside (test both sides), def on unparsable; the WARN line for an unparsable/out-of-range key is emitted exactly once across 3 consecutive reads of the same key (captured log)
+- [ ] 2. AC2 named test: with the tick body driven directly, a PUT-equivalent SetSetting(message_retention, 48h) between two ticks changes the purge cutoff used by the second tick (rows aged 3d are purged on tick 2 but not on tick 1 at 7d) with no restart and no new StartCleanup call
+- [ ] 3. AC3 named test: with RELAY_BACKUP_KEEP=5 and stored backup_keep=9 the tick uses 5; with the env unset and backup_keep=9 it uses 9; same pair for RELAY_REVIEWER_TTL_DAYS / reviewer_ttl_days; an invalid env value falls to the stored setting, then to the const
+- [ ] 4. AC4 named test: token_usage_retention_days=3 stored makes the tick purge token_usage rows older than 3d AND run the rollup over a 3-day window (both cutoffs derived from the one key); default 14 with an empty table
+- [ ] 5. AC5 named smoke test: with an EMPTY settings table every value the tick reads equals the pre-T2b const (AgentMaxAge, MessageRetention, AuditLogRetention, DeadletterShortRetention, DeadletterLongRetention, TokenUsageRetention(Days), AckNotifyAge, AckEscalateAge, DefaultBackupKeep, DefaultReviewerTTL, ForeignBackupMinAge) and for every Operational key in settingSpecs the spec `default` string equals that const's encoding; scope: diff touches exactly internal/db/projects.go, internal/relay/cleanup.go, internal/relay/cleanup_test.go; go test -tags fts5 ./internal/relay/... green
+
+## 2. Root cause & decisions
+
+# T2b — Operational knobs read at tick time
+
+ROOT_CAUSE: The Operational retention/lifecycle knobs T2a promoted to the settings panel (message_retention, audit_log_retention, token_usage_retention_days, agent_max_age, ack_notify/escalate_age, deadletter_short/long_retention, backup_keep, reviewer_ttl_days, foreign_backup_min_age) were only ever read as compile-time consts (or once at StartCleanup boot for backup_keep/reviewer_ttl). A PUT to the settings table therefore did nothing until the relay was restarted — the panel could set values that the cleanup loop never honored.
+
+## Decision
+- Add two clamped accessors on `*DB` (internal/db/projects.go): `SettingDuration(key,def,min,max)` and `SettingInt(key,def,min,max)` = `GetSetting` (RO pool) + parse + clamp. Contract: empty/unset -> def silently; unparsable -> def; out-of-range -> nearest bound; one WARN per key per process (sync.Map dedupe, never per-tick spam).
+- Extract the per-tick body of `StartCleanup` into `runCleanupTick(database, *cleanupState)` (internal/relay/cleanup.go). Every Operational knob is read inside the tick via the accessor with the pre-T2b const as `def` and the D2 spec bounds as `[min,max]`, so a PUT takes effect on the next 5-min tick with no restart. Ticker intervals stay consts.
+- `token_usage_retention_days` drives BOTH the raw-purge duration and the rollup window off the one key (they stay matched, as the rollup invariant requires).
+- Env twins keep precedence: `resolveBackupKeep()/resolveReviewerTTL()` keep their env-or-const signatures (and their existing tests) via extracted `envBackupKeep()/envReviewerTTL()` probes; new `tickBackupKeep(db)/tickReviewerTTL(db)` layer the DB setting in as env > setting > const.
+- An empty settings table reads byte-identically to today's consts (AC5 asserts both the accessor reads and that every T2b Operational spec `default` equals its const encoding — no drift).
+
+## Rejected alternatives
+- Change `resolveBackupKeep/resolveReviewerTTL` signatures to take `*db.DB`: rejected (cto ruling) — it breaks the existing `cleanup_backup_test.go`, a 4th file, contradicting the 3-file scope. Wrapper split keeps the diff at exactly 3 files.
+- Add an exported test-only DB seam (`SetMessageExpiredAt`) to backdate `messages.expired_at` for AC2: rejected (cto ruling) — no test-only surface in production. AC2 instead backdates via a second `sql.Open("sqlite3", path)` handle in the test only (closed before the tick; go-sqlite3 is registered as driver `sqlite3`).
+- Editing `settings_spec.go` to reconcile a spec/const default mismatch: not needed — spec defaults verified == consts; AC5 would fail and the drift be reported to wraith-cto rather than silently "fixed".
+
+## Verify
+`go test -tags fts5 ./internal/relay/...` green (479, +5 AC tests); `go test -tags fts5 ./...` green (880). Diff touches exactly internal/db/projects.go, internal/relay/cleanup.go, internal/relay/cleanup_test.go.
+
+## review-wraith verdict: SHIP
+Scope: internal/db/projects.go (SettingDuration/SettingInt accessors), internal/relay/cleanup.go (runCleanupTick extraction + tick-time knob reads + env/tick resolvers), internal/relay/cleanup_test.go (5 AC tests)
+Gate: build -tags fts5 OK / vet OK / gofmt OK / test -tags fts5 OK (relay 479, repo 880)
+
+BLOCKERS (must fix before merge):
+- none
+
+NITS (non-blocking):
+- AC2 test opens a second sql.Open("sqlite3", path) handle to backdate messages.expired_at. Test-only, on a t.TempDir DB, closed before the tick fires (no concurrent production writer). Chosen per cto ruling over adding a test-only exported DB seam.
+- TokenUsageRetention (exported const) is now unused by production (the tick derives the window from token_usage_retention_days); kept intentionally per the ticket ("keep every const"), exported so the unused linter does not flag it.
+
+## 3. Files changed
+
+```
+internal/db/projects.go        |  67 ++++++++
+ internal/relay/cleanup.go      | 320 ++++++++++++++++++++++--------------
+ internal/relay/cleanup_test.go | 359 +++++++++++++++++++++++++++++++++++++++++
+ 3 files changed, 622 insertions(+), 124 deletions(-)
+```
+
+## 4. QA Log
+
+_(no review round yet)_
+
+## 5. Timeline
+
+
+---
+_Auto-assembled by the niwa scribe from the Q&A gate. Task `1c3324e2-fa0b-4de3-8c2f-df859557031f`._

--- a/features/wraith-db-relay-t2b-operational-knobs-read-at-tick-time-settingduration-settingi.md
+++ b/features/wraith-db-relay-t2b-operational-knobs-read-at-tick-time-settingduration-settingi.md
@@ -3,7 +3,7 @@
 ## Team : wraith-backend-2 (tsukumo)
 ## Branch : wraith-backend-2/t2b-tick-reads (from main)
 ## Relay task : 1c3324e2-fa0b-4de3-8c2f-df859557031f
-## Status : 🔵 SUBMITTED
+## Status : 🔵 IN REVIEW
 
 ## 1. Product Brief
 
@@ -49,18 +49,25 @@ NITS (non-blocking):
 ## 3. Files changed
 
 ```
-internal/db/projects.go        |  67 ++++++++
- internal/relay/cleanup.go      | 320 ++++++++++++++++++++++--------------
- internal/relay/cleanup_test.go | 359 +++++++++++++++++++++++++++++++++++++++++
- 3 files changed, 622 insertions(+), 124 deletions(-)
+...s-read-at-tick-time-settingduration-settingi.md |  66 ++++
+ internal/db/projects.go                            |  67 ++++
+ internal/relay/cleanup.go                          | 320 +++++++++++-------
+ internal/relay/cleanup_test.go                     | 359 +++++++++++++++++++++
+ 4 files changed, 688 insertions(+), 124 deletions(-)
 ```
 
 ## 4. QA Log
 
-_(no review round yet)_
+### Round 1 — ✅ APPROVED by review-1c3324e2-fa0b-4de3-8c2f-df859557031f @ `771c510fb`
+- 🟢 AC1: Test pin every contract clause including the warn-dedup via captureLog — evidence: internal/db/projects.go:154-211 adds SettingDuration/SettingInt + warnSettingOnce with sync.Map dedupe — test: TestSettingAccessorsClampDefaultWarnOnce internal/relay/cleanup_test.go:42 (unset→def, in-range→stored, both-side clamp, unparsable→def, 3 reads = 1 WARN)
+- 🟢 AC2: Direct tick driver + observed row count delta on the same DB; second sql.Open handle for backdating is closed before tick — evidence: internal/relay/cleanup.go:194-299 extracts runCleanupTick(database,*cleanupState); internal/relay/cleanup_test.go:115-163 inserts+backdates expired_at 3d ago, ticks 1 (default 7d) keeps, SetSetting(48h), tick 2 purges with no StartCleanup — test: TestTickRereadsMessageRetentionNoRestart internal/relay/cleanup_test.go:115
+- 🟢 AC3: All 4 precedence branches exercised — evidence: internal/relay/cleanup.go:102-107 tickBackupKeep + 135-141 tickReviewerTTL: env wins if envBackupKeep/envReviewerTTL ok else SettingInt — test: TestTickEnvTwinsBeatStoredBackupReviewer internal/relay/cleanup_test.go:173 (env=5 → 5, env=stored=9, env=invalid → stored=9, no env no stored → const)
+- 🟢 AC4: Behavioral assertion on both raw row count + rollup daily count, single key coupling verified — evidence: internal/relay/cleanup.go:231-250 tokenDays drives BOTH RollupTokenUsage(tokenDays) and PurgeOldTokenUsage(tokenDays*24h) — test: TestTickTokenUsageRetentionDaysDrivesPurgeAndRollup internal/relay/cleanup_test.go:224 (default=5d kept+rolled; stored=3 → 5d row purged and excluded from rollup)
+- 🟢 AC5: Hard gate: 479 passed in internal/relay; scope drift is .md-only (scribe provenance), see notice above — evidence: internal/relay/cleanup.go consts match settingSpecs defaults (settings_spec.go:98-108 use dur(...) which equals d.String() the same encoding the test builds via dur(constValue)) — test: TestTickEmptySettingsMatchConstsAndSpecDefaults internal/relay/cleanup_test.go:286 (11 consts + spec default == dur(const) for every Operational key in settingSpecs)
 
 ## 5. Timeline
 
+- round 1 → **approve** (review-1c3324e2-fa0b-4de3-8c2f-df859557031f)
 
 ---
 _Auto-assembled by the niwa scribe from the Q&A gate. Task `1c3324e2-fa0b-4de3-8c2f-df859557031f`._

--- a/internal/db/projects.go
+++ b/internal/db/projects.go
@@ -5,8 +5,11 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"log"
 	"math/rand"
+	"strconv"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -139,6 +142,70 @@ func (d *DB) GetSetting(key string) string {
 // SetSetting upserts a setting.
 func (d *DB) SetSetting(key, value string) {
 	_, _ = d.writerExec("INSERT INTO settings (key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value = ?", key, value, value)
+}
+
+// settingWarnedKeys dedupes the invalid-setting WARN to one line per key per
+// process. The cleanup tick reads these accessors every PurgeInterval, so
+// without the guard a single bad stored value would re-log on every tick.
+var settingWarnedKeys sync.Map // key string -> struct{}{}
+
+// warnSettingOnce logs one WARN for an unparsable/out-of-range setting the first
+// time key is seen this process; subsequent calls for the same key are silent.
+func warnSettingOnce(key, raw, reason string, using interface{}) {
+	if _, seen := settingWarnedKeys.LoadOrStore(key, struct{}{}); seen {
+		return
+	}
+	log.Printf("setting %q=%q %s; using %v", key, raw, reason, using)
+}
+
+// SettingDuration reads a duration setting by key. An empty/unset value returns
+// def silently; an unparsable value returns def; a value outside [min,max] is
+// clamped to the nearest bound. Any unparsable/out-of-range value logs exactly
+// one WARN per key per process. Bounds and def come from the caller (the D2
+// Operational spec), so a PUT takes effect on the next read with no restart.
+func (d *DB) SettingDuration(key string, def, min, max time.Duration) time.Duration {
+	raw := d.GetSetting(key)
+	if raw == "" {
+		return def
+	}
+	v, err := time.ParseDuration(raw)
+	if err != nil {
+		warnSettingOnce(key, raw, "unparsable as duration", def)
+		return def
+	}
+	if v < min {
+		warnSettingOnce(key, raw, fmt.Sprintf("below min %s", min), min)
+		return min
+	}
+	if v > max {
+		warnSettingOnce(key, raw, fmt.Sprintf("above max %s", max), max)
+		return max
+	}
+	return v
+}
+
+// SettingInt reads an integer setting by key with the same empty->def,
+// unparsable->def, out-of-range->clamp, one-WARN-per-key-per-process contract as
+// SettingDuration.
+func (d *DB) SettingInt(key string, def, min, max int) int {
+	raw := d.GetSetting(key)
+	if raw == "" {
+		return def
+	}
+	v, err := strconv.Atoi(raw)
+	if err != nil {
+		warnSettingOnce(key, raw, "unparsable as int", def)
+		return def
+	}
+	if v < min {
+		warnSettingOnce(key, raw, fmt.Sprintf("below min %d", min), min)
+		return min
+	}
+	if v > max {
+		warnSettingOnce(key, raw, fmt.Sprintf("above max %d", max), max)
+		return max
+	}
+	return v
 }
 
 // DeleteProject removes a project and all its associated data (cascade delete).

--- a/internal/relay/cleanup.go
+++ b/internal/relay/cleanup.go
@@ -70,37 +70,81 @@ const (
 	TokenUsageRetentionDays = 14
 )
 
-// resolveBackupKeep returns the rotated-snapshot retention count, from
-// RELAY_BACKUP_KEEP when set to a positive integer, else DefaultBackupKeep. A
-// non-positive or unparseable value falls back to the default (never 0, which
-// would leave no recovery point).
+// envBackupKeep parses the RELAY_BACKUP_KEEP env twin. ok is false when the env
+// is unset OR invalid (non-positive / unparseable); an invalid value logs one
+// line (the pre-existing message) before falling through.
+func envBackupKeep() (int, bool) {
+	v := os.Getenv("RELAY_BACKUP_KEEP")
+	if v == "" {
+		return 0, false
+	}
+	if n, err := strconv.Atoi(v); err == nil && n > 0 {
+		return n, true
+	}
+	log.Printf("RELAY_BACKUP_KEEP=%q invalid; using default %d", v, DefaultBackupKeep)
+	return 0, false
+}
+
+// resolveBackupKeep returns the rotated-snapshot retention count: the env twin
+// when valid, else DefaultBackupKeep (never 0, which would leave no recovery
+// point). Env-or-const only — used at boot-independent call sites and by the
+// standing tests; the tick uses tickBackupKeep to layer the DB setting in.
 func resolveBackupKeep() int {
-	if v := os.Getenv("RELAY_BACKUP_KEEP"); v != "" {
-		if n, err := strconv.Atoi(v); err == nil && n > 0 {
-			return n
-		}
-		log.Printf("RELAY_BACKUP_KEEP=%q invalid; using default %d", v, DefaultBackupKeep)
+	if n, ok := envBackupKeep(); ok {
+		return n
 	}
 	return DefaultBackupKeep
 }
 
-// resolveReviewerTTL returns the standing reviewer-reaper TTL, from
-// RELAY_REVIEWER_TTL_DAYS when set to a positive integer (days), else
-// DefaultReviewerTTL. An invalid or non-positive value falls back to the default.
+// tickBackupKeep is the tick-time resolver: env twin wins when valid, else the
+// backup_keep DB setting (read now, clamped to its D2 bounds), else the const —
+// so a PUT takes effect on the next tick while the env override still wins.
+func tickBackupKeep(database *db.DB) int {
+	if n, ok := envBackupKeep(); ok {
+		return n
+	}
+	return database.SettingInt("backup_keep", DefaultBackupKeep, 1, 24)
+}
+
+// envReviewerTTL parses the RELAY_REVIEWER_TTL_DAYS env twin (days). ok is false
+// when unset OR invalid; an invalid value logs one line before falling through.
+func envReviewerTTL() (time.Duration, bool) {
+	v := os.Getenv("RELAY_REVIEWER_TTL_DAYS")
+	if v == "" {
+		return 0, false
+	}
+	if n, err := strconv.Atoi(v); err == nil && n > 0 {
+		return time.Duration(n) * 24 * time.Hour, true
+	}
+	log.Printf("RELAY_REVIEWER_TTL_DAYS=%q invalid; using default %s", v, DefaultReviewerTTL)
+	return 0, false
+}
+
+// resolveReviewerTTL returns the standing reviewer-reaper TTL: the env twin when
+// valid, else DefaultReviewerTTL. Env-or-const only; the tick uses
+// tickReviewerTTL to layer the DB setting in.
 func resolveReviewerTTL() time.Duration {
-	if v := os.Getenv("RELAY_REVIEWER_TTL_DAYS"); v != "" {
-		if n, err := strconv.Atoi(v); err == nil && n > 0 {
-			return time.Duration(n) * 24 * time.Hour
-		}
-		log.Printf("RELAY_REVIEWER_TTL_DAYS=%q invalid; using default %s", v, DefaultReviewerTTL)
+	if ttl, ok := envReviewerTTL(); ok {
+		return ttl
 	}
 	return DefaultReviewerTTL
 }
 
+// tickReviewerTTL is the tick-time resolver: env twin wins when valid, else the
+// reviewer_ttl_days DB setting (days, clamped to its D2 bounds), else the const.
+func tickReviewerTTL(database *db.DB) time.Duration {
+	if ttl, ok := envReviewerTTL(); ok {
+		return ttl
+	}
+	days := database.SettingInt("reviewer_ttl_days", int(DefaultReviewerTTL/(24*time.Hour)), 1, 90)
+	return time.Duration(days) * 24 * time.Hour
+}
+
 // pruneStaleBackups runs the data-dir backup GC and logs what it reclaimed.
-// Non-fatal: a prune failure never disrupts the cleanup loop.
-func pruneStaleBackups(database *db.DB, keep int) {
-	removed, err := database.PruneStaleBackups(keep, ForeignBackupMinAge)
+// Non-fatal: a prune failure never disrupts the cleanup loop. minAge is the
+// foreign_backup_min_age knob, read at call time by the caller.
+func pruneStaleBackups(database *db.DB, keep int, minAge time.Duration) {
+	removed, err := database.PruneStaleBackups(keep, minAge)
 	if err != nil {
 		log.Printf("prune stale backups error: %v", err)
 		return
@@ -110,124 +154,148 @@ func pruneStaleBackups(database *db.DB, keep int) {
 	}
 }
 
+// cleanupState carries the mutable state a StartCleanup tick advances across
+// ticks. Extracting it (with runCleanupTick) lets tests drive one tick body
+// directly without a running goroutine or a real ticker.
+type cleanupState struct {
+	lastBackup        time.Time // first snapshot fires BackupInterval after this
+	lastRollupCatchup string    // UTC day of the last full-window rollup ("" => run next tick)
+}
+
 // StartCleanup runs a background goroutine that marks stale agents as inactive.
 // It stops when the done channel is closed.
 func StartCleanup(database *db.DB, done <-chan struct{}) {
 	ticker := time.NewTicker(PurgeInterval)
-	lastBackup := time.Now() // first snapshot fires BackupInterval after boot
-	backupKeep := resolveBackupKeep()
-	reviewerTTL := resolveReviewerTTL()
-	lastRollupCatchup := "" // UTC day of the last full-window rollup catch-up ("" => run on first tick)
+	st := &cleanupState{lastBackup: time.Now()}
 	go func() {
 		defer ticker.Stop()
 		// A healthy boot is the post-upgrade verification the updater lacks: prune
 		// stale backups (superseded snapshots + aged one-off updater backups) once
 		// at startup so a host that just auto-upgraded reclaims disk without manual
 		// cleanup. Never touches the live DB or the newest known-good backup.
-		pruneStaleBackups(database, backupKeep)
+		pruneStaleBackups(database, tickBackupKeep(database),
+			database.SettingDuration("foreign_backup_min_age", ForeignBackupMinAge, time.Hour, 30*24*time.Hour))
 		for {
 			select {
 			case <-done:
 				return
 			case <-ticker.C:
-				n, err := database.MarkStaleAgentsInactive(AgentMaxAge)
-				if err != nil {
-					log.Printf("cleanup error: %v", err)
-				} else if n > 0 {
-					log.Printf("marked %d stale agent(s) inactive", n)
-				}
-				if expired, err := database.ExpireMessages(); err != nil {
-					log.Printf("expire messages error: %v", err)
-				} else if expired > 0 {
-					log.Printf("expired %d message(s)", expired)
-				}
-				if expired, err := database.ExpireDeliveries(); err != nil {
-					log.Printf("expire deliveries error: %v", err)
-				} else if expired > 0 {
-					log.Printf("expired %d delivery(ies)", expired)
-				}
-				if expired, err := database.ExpireFileLocks(); err != nil {
-					log.Printf("expire file locks error: %v", err)
-				} else if expired > 0 {
-					log.Printf("expired %d file lock(s)", expired)
-				}
-				if expired, err := database.ExpireElevations(); err != nil {
-					log.Printf("expire elevations error: %v", err)
-				} else if expired > 0 {
-					log.Printf("expired %d elevation(s)", expired)
-				}
-				// Standing TTL reaper: soft-delete dead ephemeral reviewer agents
-				// (review-*) that the gate never tears down, once inactive past the
-				// TTL, skipping any still holding a live task. Backstop so the roster
-				// backlog never re-accumulates (DEC-niwa-reviewer-lifecycle-1).
-				if res, err := database.PurgeStaleReviewers(false, reviewerTTL); err != nil {
-					log.Printf("reap stale reviewers error: %v", err)
-				} else if res.Purged > 0 {
-					log.Printf("reaped %d stale review-* reviewer(s)", res.Purged)
-				}
-				// Refresh the daily rollup BEFORE pruning raw rows, so shortening the
-				// raw window never drops aggregate history the dashboards still show.
-				// Routine tick: only days that can still change (yesterday 00:00Z on).
-				if err := database.RollupTokenUsageRoutine(); err != nil {
-					log.Printf("token usage rollup error: %v", err)
-				}
-				// Once per UTC day, re-sum the full retention window to fold in rows
-				// that arrived for older days after the routine window passed them.
-				if today := time.Now().UTC().Format("2006-01-02"); today != lastRollupCatchup {
-					if err := database.RollupTokenUsage(TokenUsageRetentionDays); err != nil {
-						log.Printf("token usage rollup (daily catch-up) error: %v", err)
-					} else {
-						lastRollupCatchup = today
-					}
-				}
-				if purged, err := database.PurgeOldTokenUsage(TokenUsageRetention); err != nil {
-					log.Printf("purge token usage error: %v", err)
-				} else if purged > 0 {
-					log.Printf("purged %d old token usage record(s)", purged)
-				}
-				// Hard-reclaim soft-expired messages (+ their deliveries/reads) and
-				// stale audit rows so the tables stay bounded (TSU-127).
-				if purged, err := database.PurgeExpiredMessages(MessageRetention); err != nil {
-					log.Printf("purge expired messages error: %v", err)
-				} else if purged > 0 {
-					log.Printf("purged %d expired message(s)", purged)
-				}
-				if purged, err := database.PurgeOldAuditLog(AuditLogRetention); err != nil {
-					log.Printf("purge audit log error: %v", err)
-				} else if purged > 0 {
-					log.Printf("purged %d old audit log record(s)", purged)
-				}
-				// Bound the durable deadletter journal: reclaim aged non-P0/P1 rows,
-				// keep P0/P1 far longer (self-GC follow-up to the T6 deadletter).
-				if purged, err := database.PurgeOldDeadletter(DeadletterShortRetention, DeadletterLongRetention); err != nil {
-					log.Printf("purge deadletter error: %v", err)
-				} else if purged > 0 {
-					log.Printf("purged %d old deadletter record(s)", purged)
-				}
-				database.Optimize()
-
-				if time.Since(lastBackup) >= BackupInterval {
-					if path, err := database.Backup(backupKeep); err != nil {
-						log.Printf("db backup error: %v", err)
-					} else {
-						lastBackup = time.Now()
-						// Verified-restore drill: confirm the snapshot is sound +
-						// non-empty before we rely on it (runs on the snapshot file,
-						// not the live DB, so it never locks the writer) — TSU-137.
-						if counts, verr := db.VerifyDBFile(path); verr != nil {
-							log.Printf("db snapshot VERIFY FAILED %s: %v", path, verr)
-						} else {
-							log.Printf("db snapshot written + verified: %s (agents=%d messages=%d tasks=%d)",
-								path, counts["agents"], counts["messages"], counts["tasks"])
-						}
-						// Prune after a successful new snapshot so numbered slots
-						// beyond keep and aged one-off backups don't accumulate.
-						pruneStaleBackups(database, backupKeep)
-					}
-				}
+				runCleanupTick(database, st)
 			}
 		}
 	}()
+}
+
+// runCleanupTick is one cleanup pass. Every Operational knob is read here (not
+// hoisted to StartCleanup), so a PUT to the settings table takes effect on the
+// next tick with no restart; the const is the default and the D2 spec bounds are
+// the clamp. Env twins (backup_keep, reviewer_ttl_days) keep precedence via the
+// resolve* helpers. An empty settings table reads byte-identically to the consts.
+func runCleanupTick(database *db.DB, st *cleanupState) {
+	agentMaxAge := database.SettingDuration("agent_max_age", AgentMaxAge, 5*time.Minute, 24*time.Hour)
+	if n, err := database.MarkStaleAgentsInactive(agentMaxAge); err != nil {
+		log.Printf("cleanup error: %v", err)
+	} else if n > 0 {
+		log.Printf("marked %d stale agent(s) inactive", n)
+	}
+	if expired, err := database.ExpireMessages(); err != nil {
+		log.Printf("expire messages error: %v", err)
+	} else if expired > 0 {
+		log.Printf("expired %d message(s)", expired)
+	}
+	if expired, err := database.ExpireDeliveries(); err != nil {
+		log.Printf("expire deliveries error: %v", err)
+	} else if expired > 0 {
+		log.Printf("expired %d delivery(ies)", expired)
+	}
+	if expired, err := database.ExpireFileLocks(); err != nil {
+		log.Printf("expire file locks error: %v", err)
+	} else if expired > 0 {
+		log.Printf("expired %d file lock(s)", expired)
+	}
+	if expired, err := database.ExpireElevations(); err != nil {
+		log.Printf("expire elevations error: %v", err)
+	} else if expired > 0 {
+		log.Printf("expired %d elevation(s)", expired)
+	}
+	// Standing TTL reaper: soft-delete dead ephemeral reviewer agents
+	// (review-*) that the gate never tears down, once inactive past the
+	// TTL, skipping any still holding a live task. Backstop so the roster
+	// backlog never re-accumulates (DEC-niwa-reviewer-lifecycle-1).
+	if res, err := database.PurgeStaleReviewers(false, tickReviewerTTL(database)); err != nil {
+		log.Printf("reap stale reviewers error: %v", err)
+	} else if res.Purged > 0 {
+		log.Printf("reaped %d stale review-* reviewer(s)", res.Purged)
+	}
+	// token_usage_retention_days drives BOTH the rollup window (days) and the
+	// raw purge window (days as a duration) — one key, two derived cutoffs.
+	tokenDays := database.SettingInt("token_usage_retention_days", TokenUsageRetentionDays, 1, 90)
+	// Refresh the daily rollup BEFORE pruning raw rows, so shortening the
+	// raw window never drops aggregate history the dashboards still show.
+	// Routine tick: only days that can still change (yesterday 00:00Z on).
+	if err := database.RollupTokenUsageRoutine(); err != nil {
+		log.Printf("token usage rollup error: %v", err)
+	}
+	// Once per UTC day, re-sum the full retention window to fold in rows
+	// that arrived for older days after the routine window passed them.
+	if today := time.Now().UTC().Format("2006-01-02"); today != st.lastRollupCatchup {
+		if err := database.RollupTokenUsage(tokenDays); err != nil {
+			log.Printf("token usage rollup (daily catch-up) error: %v", err)
+		} else {
+			st.lastRollupCatchup = today
+		}
+	}
+	if purged, err := database.PurgeOldTokenUsage(time.Duration(tokenDays) * 24 * time.Hour); err != nil {
+		log.Printf("purge token usage error: %v", err)
+	} else if purged > 0 {
+		log.Printf("purged %d old token usage record(s)", purged)
+	}
+	// Hard-reclaim soft-expired messages (+ their deliveries/reads) and
+	// stale audit rows so the tables stay bounded (TSU-127).
+	messageRetention := database.SettingDuration("message_retention", MessageRetention, 24*time.Hour, 90*24*time.Hour)
+	if purged, err := database.PurgeExpiredMessages(messageRetention); err != nil {
+		log.Printf("purge expired messages error: %v", err)
+	} else if purged > 0 {
+		log.Printf("purged %d expired message(s)", purged)
+	}
+	auditRetention := database.SettingDuration("audit_log_retention", AuditLogRetention, 7*24*time.Hour, 365*24*time.Hour)
+	if purged, err := database.PurgeOldAuditLog(auditRetention); err != nil {
+		log.Printf("purge audit log error: %v", err)
+	} else if purged > 0 {
+		log.Printf("purged %d old audit log record(s)", purged)
+	}
+	// Bound the durable deadletter journal: reclaim aged non-P0/P1 rows,
+	// keep P0/P1 far longer (self-GC follow-up to the T6 deadletter).
+	deadletterShort := database.SettingDuration("deadletter_short_retention", DeadletterShortRetention, 24*time.Hour, 180*24*time.Hour)
+	deadletterLong := database.SettingDuration("deadletter_long_retention", DeadletterLongRetention, 24*time.Hour, 730*24*time.Hour)
+	if purged, err := database.PurgeOldDeadletter(deadletterShort, deadletterLong); err != nil {
+		log.Printf("purge deadletter error: %v", err)
+	} else if purged > 0 {
+		log.Printf("purged %d old deadletter record(s)", purged)
+	}
+	database.Optimize()
+
+	if time.Since(st.lastBackup) >= BackupInterval {
+		backupKeep := tickBackupKeep(database)
+		if path, err := database.Backup(backupKeep); err != nil {
+			log.Printf("db backup error: %v", err)
+		} else {
+			st.lastBackup = time.Now()
+			// Verified-restore drill: confirm the snapshot is sound +
+			// non-empty before we rely on it (runs on the snapshot file,
+			// not the live DB, so it never locks the writer) — TSU-137.
+			if counts, verr := db.VerifyDBFile(path); verr != nil {
+				log.Printf("db snapshot VERIFY FAILED %s: %v", path, verr)
+			} else {
+				log.Printf("db snapshot written + verified: %s (agents=%d messages=%d tasks=%d)",
+					path, counts["agents"], counts["messages"], counts["tasks"])
+			}
+			// Prune after a successful new snapshot so numbered slots
+			// beyond keep and aged one-off backups don't accumulate.
+			pruneStaleBackups(database, backupKeep,
+				database.SettingDuration("foreign_backup_min_age", ForeignBackupMinAge, time.Hour, 30*24*time.Hour))
+		}
+	}
 }
 
 // StartACKChecker runs a background goroutine that checks for unacknowledged tasks.
@@ -248,8 +316,12 @@ func StartACKChecker(database *db.DB, registry *SessionRegistry, done <-chan str
 }
 
 func checkUnackedTasks(database *db.DB, registry *SessionRegistry) {
-	// Get tasks pending for at least 15 minutes
-	tasks, err := database.GetUnackedTasks(ACKNotifyAge)
+	// Read the ack knobs at check time so a PUT takes effect on the next ACK
+	// tick without restart (const default, D2 bounds clamp).
+	notifyAge := database.SettingDuration("ack_notify_age", ACKNotifyAge, time.Minute, 24*time.Hour)
+	escalateAge := database.SettingDuration("ack_escalate_age", ACKEscalateAge, time.Minute, 24*time.Hour)
+	// Get tasks pending for at least the notify age
+	tasks, err := database.GetUnackedTasks(notifyAge)
 	if err != nil {
 		log.Printf("ACK checker error: %v", err)
 		return
@@ -263,7 +335,7 @@ func checkUnackedTasks(database *db.DB, registry *SessionRegistry) {
 		}
 		age := now.Sub(dispatchedAt)
 
-		if age >= ACKEscalateAge && task.AckEscalatedAt == nil {
+		if age >= escalateAge && task.AckEscalatedAt == nil {
 			// CAS-guarded mark FIRST: the batch read above can be stale by the time
 			// we get here (a run container claimed run_state, or the task moved off
 			// 'pending', or a concurrent tick already marked it). ok=false means one
@@ -281,7 +353,7 @@ func checkUnackedTasks(database *db.DB, registry *SessionRegistry) {
 				fmt.Sprintf("ESCALATED: Task '%s' no ACK for %dmin. Consider re-dispatching.", task.Title, int(age.Minutes())),
 				task.ID)
 			log.Printf("ACK escalated: task %s (%s) — %dmin", task.ID, task.Title, int(age.Minutes()))
-		} else if age >= ACKNotifyAge && task.AckNotifiedAt == nil {
+		} else if age >= notifyAge && task.AckNotifiedAt == nil {
 			ok, err := database.MarkTaskAckNotified(task.ID)
 			if err != nil {
 				log.Printf("ACK notify mark error: task %s: %v", task.ID, err)

--- a/internal/relay/cleanup_test.go
+++ b/internal/relay/cleanup_test.go
@@ -1,0 +1,359 @@
+package relay
+
+import (
+	"bytes"
+	"database/sql"
+	"log"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"agent-relay/internal/db"
+)
+
+// newCleanupTestDB opens an isolated on-disk relay DB for the cleanup tests.
+func newCleanupTestDB(t *testing.T) *db.DB {
+	t.Helper()
+	database, err := db.NewTestDB(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("create test db: %v", err)
+	}
+	t.Cleanup(func() { _ = database.Close() })
+	return database
+}
+
+// captureLog redirects the standard logger to a buffer for the duration of fn and
+// returns everything it wrote, so a WARN line can be counted.
+func captureLog(fn func()) string {
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+	defer log.SetOutput(os.Stderr)
+	fn()
+	return buf.String()
+}
+
+// TestSettingAccessorsClampDefaultWarnOnce is AC1: SettingDuration/SettingInt
+// return def on unset, the stored value inside [min,max], the clamped bound when
+// outside (both sides), def on unparsable — and the WARN for an unparsable/out-of-
+// range key is emitted exactly once across three consecutive reads of that key.
+func TestSettingAccessorsClampDefaultWarnOnce(t *testing.T) {
+	d := newCleanupTestDB(t)
+	const (
+		durDef, durMin, durMax = time.Hour, time.Minute, 24 * time.Hour
+		intDef, intMin, intMax = 10, 1, 100
+	)
+
+	// Unset → def, silently (no WARN).
+	if out := captureLog(func() {
+		if got := d.SettingDuration("ac1_unset", durDef, durMin, durMax); got != durDef {
+			t.Fatalf("unset duration: got %s want %s", got, durDef)
+		}
+		if got := d.SettingInt("ac1_unset_i", intDef, intMin, intMax); got != intDef {
+			t.Fatalf("unset int: got %d want %d", got, intDef)
+		}
+	}); out != "" {
+		t.Fatalf("unset must not WARN, got: %q", out)
+	}
+
+	// In-range stored → the stored value.
+	d.SetSetting("ac1_ok", "2h")
+	if got := d.SettingDuration("ac1_ok", durDef, durMin, durMax); got != 2*time.Hour {
+		t.Fatalf("in-range duration: got %s want 2h", got)
+	}
+	d.SetSetting("ac1_ok_i", "42")
+	if got := d.SettingInt("ac1_ok_i", intDef, intMin, intMax); got != 42 {
+		t.Fatalf("in-range int: got %d want 42", got)
+	}
+
+	// Below/above range → clamped to the nearest bound (both sides, both kinds).
+	d.SetSetting("ac1_lo", "10s") // < 1m
+	if got := d.SettingDuration("ac1_lo", durDef, durMin, durMax); got != durMin {
+		t.Fatalf("below-min duration: got %s want %s", got, durMin)
+	}
+	d.SetSetting("ac1_hi", "48h") // > 24h
+	if got := d.SettingDuration("ac1_hi", durDef, durMin, durMax); got != durMax {
+		t.Fatalf("above-max duration: got %s want %s", got, durMax)
+	}
+	d.SetSetting("ac1_lo_i", "0") // < 1
+	if got := d.SettingInt("ac1_lo_i", intDef, intMin, intMax); got != intMin {
+		t.Fatalf("below-min int: got %d want %d", got, intMin)
+	}
+	d.SetSetting("ac1_hi_i", "999") // > 100
+	if got := d.SettingInt("ac1_hi_i", intDef, intMin, intMax); got != intMax {
+		t.Fatalf("above-max int: got %d want %d", got, intMax)
+	}
+
+	// Unparsable → def.
+	d.SetSetting("ac1_bad", "not-a-duration")
+	if got := d.SettingDuration("ac1_bad", durDef, durMin, durMax); got != durDef {
+		t.Fatalf("unparsable duration: got %s want %s", got, durDef)
+	}
+	d.SetSetting("ac1_bad_i", "not-an-int")
+	if got := d.SettingInt("ac1_bad_i", intDef, intMin, intMax); got != intDef {
+		t.Fatalf("unparsable int: got %d want %d", got, intDef)
+	}
+
+	// WARN dedupe: three reads of one bad key emit exactly one WARN line for it.
+	d.SetSetting("ac1_warnonce", "1000h") // > 24h, out of range
+	out := captureLog(func() {
+		for i := 0; i < 3; i++ {
+			_ = d.SettingDuration("ac1_warnonce", durDef, durMin, durMax)
+		}
+	})
+	if n := strings.Count(out, "ac1_warnonce"); n != 1 {
+		t.Fatalf("expected exactly 1 WARN for ac1_warnonce across 3 reads, got %d\nlog:\n%s", n, out)
+	}
+}
+
+// TestTickRereadsMessageRetentionNoRestart is AC2: a PUT-equivalent
+// SetSetting(message_retention, 48h) between two ticks changes the purge cutoff
+// the next tick uses — a message soft-expired 3 days ago survives tick 1 at the
+// 7d default but is purged on tick 2 — with no restart and no new StartCleanup.
+func TestTickRereadsMessageRetentionNoRestart(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	database, err := db.NewTestDB(dbPath)
+	if err != nil {
+		t.Fatalf("create test db: %v", err)
+	}
+	t.Cleanup(func() { _ = database.Close() })
+
+	msg, err := database.InsertMessage("p-ac2", "a", "b", "notification", "s", "c", "{}", "P2", 60, nil, nil)
+	if err != nil {
+		t.Fatalf("insert message: %v", err)
+	}
+	// Backdate expired_at to 3 days ago through a second "sqlite3" handle (the
+	// go-sqlite3 driver is registered by the db package's blank import). The tick
+	// reads/purges through the primary DB; a WAL commit here is visible to it.
+	threeDaysAgo := time.Now().UTC().AddDate(0, 0, -3).Format("2006-01-02T15:04:05.000000Z")
+	raw, err := sql.Open("sqlite3", dbPath+"?_busy_timeout=5000")
+	if err != nil {
+		t.Fatalf("open raw handle: %v", err)
+	}
+	if _, err := raw.Exec("UPDATE messages SET expired_at = ? WHERE id = ?", threeDaysAgo, msg.ID); err != nil {
+		t.Fatalf("backdate expired_at: %v", err)
+	}
+	_ = raw.Close()
+
+	count := func() int {
+		r, err := sql.Open("sqlite3", dbPath+"?_busy_timeout=5000")
+		if err != nil {
+			t.Fatalf("open count handle: %v", err)
+		}
+		defer func() { _ = r.Close() }()
+		var n int
+		if err := r.QueryRow("SELECT COUNT(*) FROM messages WHERE id = ?", msg.ID).Scan(&n); err != nil {
+			t.Fatalf("count: %v", err)
+		}
+		return n
+	}
+
+	st := &cleanupState{lastBackup: time.Now()} // lastBackup=now → no snapshot fires
+
+	// Tick 1 at the 7d default: a 3-day-old expiry is inside the window → kept.
+	runCleanupTick(database, st)
+	if count() != 1 {
+		t.Fatalf("tick 1 (default 7d) must keep the 3-day-old expired message")
+	}
+
+	// PUT message_retention=48h, then tick 2: 3-day-old expiry now past the
+	// window → purged, with no restart and no new StartCleanup call.
+	database.SetSetting("message_retention", "48h")
+	runCleanupTick(database, st)
+	if count() != 0 {
+		t.Fatalf("tick 2 (48h, post-PUT) must purge the 3-day-old expired message")
+	}
+}
+
+// TestTickEnvTwinsBeatStoredBackupReviewer is AC3: for backup_keep and
+// reviewer_ttl_days the env twin wins when valid, else the stored setting, else
+// the const — and an invalid env falls through to the setting.
+func TestTickEnvTwinsBeatStoredBackupReviewer(t *testing.T) {
+	d := newCleanupTestDB(t)
+	d.SetSetting("backup_keep", "9")
+	d.SetSetting("reviewer_ttl_days", "9")
+
+	// Valid env wins over the stored setting.
+	t.Setenv("RELAY_BACKUP_KEEP", "5")
+	t.Setenv("RELAY_REVIEWER_TTL_DAYS", "5")
+	if got := tickBackupKeep(d); got != 5 {
+		t.Fatalf("valid env backup_keep: got %d want 5", got)
+	}
+	if got := tickReviewerTTL(d); got != 5*24*time.Hour {
+		t.Fatalf("valid env reviewer_ttl: got %s want 120h", got)
+	}
+
+	// Env unset → the stored setting.
+	t.Setenv("RELAY_BACKUP_KEEP", "")
+	t.Setenv("RELAY_REVIEWER_TTL_DAYS", "")
+	if got := tickBackupKeep(d); got != 9 {
+		t.Fatalf("stored backup_keep: got %d want 9", got)
+	}
+	if got := tickReviewerTTL(d); got != 9*24*time.Hour {
+		t.Fatalf("stored reviewer_ttl: got %s want 216h", got)
+	}
+
+	// Invalid env → falls through to the stored setting.
+	t.Setenv("RELAY_BACKUP_KEEP", "nope")
+	t.Setenv("RELAY_REVIEWER_TTL_DAYS", "nope")
+	if got := tickBackupKeep(d); got != 9 {
+		t.Fatalf("invalid env backup_keep falls to setting: got %d want 9", got)
+	}
+	if got := tickReviewerTTL(d); got != 9*24*time.Hour {
+		t.Fatalf("invalid env reviewer_ttl falls to setting: got %s want 216h", got)
+	}
+
+	// No env, no stored setting → the const default.
+	fresh := newCleanupTestDB(t)
+	t.Setenv("RELAY_BACKUP_KEEP", "")
+	t.Setenv("RELAY_REVIEWER_TTL_DAYS", "")
+	if got := tickBackupKeep(fresh); got != DefaultBackupKeep {
+		t.Fatalf("empty backup_keep: got %d want const %d", got, DefaultBackupKeep)
+	}
+	if got := tickReviewerTTL(fresh); got != DefaultReviewerTTL {
+		t.Fatalf("empty reviewer_ttl: got %s want const %s", got, DefaultReviewerTTL)
+	}
+}
+
+// TestTickTokenUsageRetentionDaysDrivesPurgeAndRollup is AC4: the one key
+// token_usage_retention_days drives BOTH the raw-purge window and the rollup
+// window. A 5-day-old row survives + is rolled up at the default (14) but is
+// purged + excluded from the rollup at 3.
+func TestTickTokenUsageRetentionDaysDrivesPurgeAndRollup(t *testing.T) {
+	const project = "p-ac4"
+	fiveDaysAgo := time.Now().UTC().AddDate(0, 0, -5)
+	fiveDayRow := []db.TokenRecord{{
+		Project: project, Agent: "a1", Input: 1000, CreatedAt: fiveDaysAgo.Format(time.RFC3339),
+	}}
+	// lastBackup=now so the tick never attempts a snapshot; lastRollupCatchup=""
+	// so the once-per-day full-window rollup fires on this tick.
+	newState := func() *cleanupState { return &cleanupState{lastBackup: time.Now()} }
+
+	rawRows := func(d *db.DB) int64 {
+		sums, err := d.GetTokenUsageByProject("1970-01-01T00:00:00Z")
+		if err != nil {
+			t.Fatalf("GetTokenUsageByProject: %v", err)
+		}
+		var n int64
+		for _, s := range sums {
+			n += s.CallCount
+		}
+		return n
+	}
+	rolledUp := func(d *db.DB) bool {
+		sums, err := d.GetTokenUsageDailyByProject(fiveDaysAgo.Format("2006-01-02"))
+		if err != nil {
+			t.Fatalf("GetTokenUsageDailyByProject: %v", err)
+		}
+		return len(sums) > 0
+	}
+
+	// Default (empty settings → 14 days): the 5-day row survives and is rolled up.
+	def := newCleanupTestDB(t)
+	if err := def.InsertTokenUsageBatch(fiveDayRow); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	runCleanupTick(def, newState())
+	if got := rawRows(def); got != 1 {
+		t.Fatalf("default 14d must keep the 5-day raw row, got %d rows", got)
+	}
+	if !rolledUp(def) {
+		t.Fatalf("default 14d must roll up the 5-day row")
+	}
+
+	// token_usage_retention_days=3: the 5-day row is purged and excluded from the
+	// rollup — both cutoffs move together off the one key.
+	short := newCleanupTestDB(t)
+	short.SetSetting("token_usage_retention_days", "3")
+	if err := short.InsertTokenUsageBatch(fiveDayRow); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	runCleanupTick(short, newState())
+	if got := rawRows(short); got != 0 {
+		t.Fatalf("3d must purge the 5-day raw row, got %d rows", got)
+	}
+	if rolledUp(short) {
+		t.Fatalf("3d must exclude the 5-day row from the rollup window")
+	}
+}
+
+// TestTickEmptySettingsMatchConstsAndSpecDefaults is AC5: with an empty settings
+// table every knob the tick reads equals its pre-T2b const, and for each T2b
+// Operational key the settingSpecs default string equals that const's encoding —
+// so promoting the knobs to the panel introduced no behavior drift.
+func TestTickEmptySettingsMatchConstsAndSpecDefaults(t *testing.T) {
+	d := newCleanupTestDB(t)
+	t.Setenv("RELAY_BACKUP_KEEP", "")
+	t.Setenv("RELAY_REVIEWER_TTL_DAYS", "")
+
+	// Empty table → the accessor calls the tick makes read back the consts.
+	if got := d.SettingDuration("agent_max_age", AgentMaxAge, 5*time.Minute, 24*time.Hour); got != AgentMaxAge {
+		t.Errorf("agent_max_age: got %s want %s", got, AgentMaxAge)
+	}
+	if got := d.SettingDuration("message_retention", MessageRetention, 24*time.Hour, 90*24*time.Hour); got != MessageRetention {
+		t.Errorf("message_retention: got %s want %s", got, MessageRetention)
+	}
+	if got := d.SettingDuration("audit_log_retention", AuditLogRetention, 7*24*time.Hour, 365*24*time.Hour); got != AuditLogRetention {
+		t.Errorf("audit_log_retention: got %s want %s", got, AuditLogRetention)
+	}
+	if got := d.SettingDuration("deadletter_short_retention", DeadletterShortRetention, 24*time.Hour, 180*24*time.Hour); got != DeadletterShortRetention {
+		t.Errorf("deadletter_short_retention: got %s want %s", got, DeadletterShortRetention)
+	}
+	if got := d.SettingDuration("deadletter_long_retention", DeadletterLongRetention, 24*time.Hour, 730*24*time.Hour); got != DeadletterLongRetention {
+		t.Errorf("deadletter_long_retention: got %s want %s", got, DeadletterLongRetention)
+	}
+	if got := d.SettingInt("token_usage_retention_days", TokenUsageRetentionDays, 1, 90); got != TokenUsageRetentionDays {
+		t.Errorf("token_usage_retention_days: got %d want %d", got, TokenUsageRetentionDays)
+	}
+	if got := d.SettingDuration("ack_notify_age", ACKNotifyAge, time.Minute, 24*time.Hour); got != ACKNotifyAge {
+		t.Errorf("ack_notify_age: got %s want %s", got, ACKNotifyAge)
+	}
+	if got := d.SettingDuration("ack_escalate_age", ACKEscalateAge, time.Minute, 24*time.Hour); got != ACKEscalateAge {
+		t.Errorf("ack_escalate_age: got %s want %s", got, ACKEscalateAge)
+	}
+	if got := d.SettingDuration("foreign_backup_min_age", ForeignBackupMinAge, time.Hour, 30*24*time.Hour); got != ForeignBackupMinAge {
+		t.Errorf("foreign_backup_min_age: got %s want %s", got, ForeignBackupMinAge)
+	}
+	if got := tickBackupKeep(d); got != DefaultBackupKeep {
+		t.Errorf("tickBackupKeep: got %d want %d", got, DefaultBackupKeep)
+	}
+	if got := tickReviewerTTL(d); got != DefaultReviewerTTL {
+		t.Errorf("tickReviewerTTL: got %s want %s", got, DefaultReviewerTTL)
+	}
+
+	// Each T2b Operational key's spec default equals its const's encoding.
+	wantDefault := map[string]string{
+		"agent_max_age":              dur(AgentMaxAge),
+		"message_retention":          dur(MessageRetention),
+		"audit_log_retention":        dur(AuditLogRetention),
+		"deadletter_short_retention": dur(DeadletterShortRetention),
+		"deadletter_long_retention":  dur(DeadletterLongRetention),
+		"token_usage_retention_days": strconv.Itoa(TokenUsageRetentionDays),
+		"ack_notify_age":             dur(ACKNotifyAge),
+		"ack_escalate_age":           dur(ACKEscalateAge),
+		"backup_keep":                strconv.Itoa(DefaultBackupKeep),
+		"reviewer_ttl_days":          strconv.Itoa(int(DefaultReviewerTTL / (24 * time.Hour))),
+		"foreign_backup_min_age":     dur(ForeignBackupMinAge),
+	}
+	seen := map[string]bool{}
+	for _, s := range settingSpecs {
+		want, ok := wantDefault[s.Key]
+		if !ok {
+			continue
+		}
+		seen[s.Key] = true
+		if s.Group != groupOperational {
+			t.Errorf("spec %q: group %q want %q", s.Key, s.Group, groupOperational)
+		}
+		if s.Default != want {
+			t.Errorf("spec %q default %q != const encoding %q (drift — report to wraith-cto, do not edit the spec)", s.Key, s.Default, want)
+		}
+	}
+	for k := range wantDefault {
+		if !seen[k] {
+			t.Errorf("T2b key %q missing from settingSpecs", k)
+		}
+	}
+}


### PR DESCRIPTION
### niwa Q&A gate

An adversarial reviewer is reading this diff right now. Its verdict lands on this PR as a review (or a comment when the gate and the author share one GitHub account), and the merge waits for this repository's own checks to go green.

*Opened automatically — a rejected round comes back to the author, who pushes fixes to the same branch.*

## What & why

- **docs(scribe): provenance for wraith-db-relay-t2b-operational-knobs-read-at-tick-time-settingduration-settingi**
- **feat(cleanup): read Operational knobs at tick time (T2b)**
  <details><summary>details</summary>

  Every Operational key T2a promoted (agent_max_age, message_retention,
  audit_log_retention, deadletter_short/long_retention,
  token_usage_retention_days, ack_notify_age, ack_escalate_age,
  backup_keep, reviewer_ttl_days, foreign_backup_min_age) is now read from
  the settings table inside the cleanup tick through one clamped accessor,
  so a PUT takes effect on the next tick without a restart. Env twins
  (RELAY_BACKUP_KEEP, RELAY_REVIEWER_TTL_DAYS) keep precedence; an empty
  settings table behaves byte-identically to the pre-T2b consts.
  
  - internal/db/projects.go: SettingDuration/SettingInt = GetSetting +
    parse + clamp to [min,max]; empty/unparsable -> def; out-of-range ->
    nearest bound; one WARN per key per process (sync.Map dedupe).
  - internal/relay/cleanup.go: extract runCleanupTick + cleanupState from
    StartCleanup; read each knob via the accessor (const=def, D2 bounds);
    token_usage_retention_days drives both purge and rollup windows; ack
    ages read in checkUnackedTasks. resolve{BackupKeep,ReviewerTTL} keep
    their env-or-const signatures (+ existing tests); new tick{BackupKeep,
    ReviewerTTL} layer the DB setting in (env > setting > const).
  - cleanup_test.go: 5 AC tests (accessor clamp/def/one-WARN; message_
    retention re-read across ticks; env-twin precedence; token days drives
    purge+rollup; empty-table == consts + spec-default no-drift).
  
  Ticker intervals stay consts; no schema change; settings_spec.go/api.go
  untouched (spec defaults verified == consts).
  
  Claude-Session: https://claude.ai/code/session_01PrKgY1PpQX9DTAF7HGAsAB

  </details>

## Changes

<details><summary>Files changed (git diff --stat)</summary>

```
...enders-the-full-surface-from-get-api-setting.md | 118 -----
 ...s-read-at-tick-time-settingduration-settingi.md |  66 +++
 internal/db/projects.go                            |  67 +++
 internal/relay/cleanup.go                          | 320 ++++++++-----
 internal/relay/cleanup_test.go                     | 359 ++++++++++++++
 internal/relay/console_v2_config_panel_test.go     | 522 +++++++++------------
 internal/web/static/v2/settings.js                 | 378 +++++----------
 internal/web/static/v2/v2.css                      |  34 --
 8 files changed, 1018 insertions(+), 846 deletions(-)
```

</details>

## Module graph

```mermaid
graph TD
  n0["features/wraith-db-relay-t2b-operational-knobs-read-at-tick-time-settingduration-settingi.md"]
  n1["internal/db"]
  n2["internal/relay"]
  n1 --- n2
```

## Acceptance criteria

- [x] AC1 named test: SettingDuration/SettingInt return def on unset, the stored value when inside [min,max], the clamped bound when outside (test both sides), def on unparsable; the WARN line for an unparsable/out-of-range key is emitted exactly once across 3 consecutive reads of the same key (captured log)
- [x] AC2 named test: with the tick body driven directly, a PUT-equivalent SetSetting(message_retention, 48h) between two ticks changes the purge cutoff used by the second tick (rows aged 3d are purged on tick 2 but not on tick 1 at 7d) with no restart and no new StartCleanup call
- [x] AC3 named test: with RELAY_BACKUP_KEEP=5 and stored backup_keep=9 the tick uses 5; with the env unset and backup_keep=9 it uses 9; same pair for RELAY_REVIEWER_TTL_DAYS / reviewer_ttl_days; an invalid env value falls to the stored setting, then to the const
- [x] AC4 named test: token_usage_retention_days=3 stored makes the tick purge token_usage rows older than 3d AND run the rollup over a 3-day window (both cutoffs derived from the one key); default 14 with an empty table
- [x] AC5 named smoke test: with an EMPTY settings table every value the tick reads equals the pre-T2b const (AgentMaxAge, MessageRetention, AuditLogRetention, DeadletterShortRetention, DeadletterLongRetention, TokenUsageRetention(Days), AckNotifyAge, AckEscalateAge, DefaultBackupKeep, DefaultReviewerTTL, ForeignBackupMinAge) and for every Operational key in settingSpecs the spec `default` string equals that const's encoding; scope: diff touches exactly internal/db/projects.go, internal/relay/cleanup.go, internal/relay/cleanup_test.go; go test -tags fts5 ./internal/relay/... green
## Provenance

📄 [Root cause, decisions &amp; QA log — `features/wraith-db-relay-t2b-operational-knobs-read-at-tick-time-settingduration-settingi.md`](https://github.com/TsukumoHQ/WRAI.TH/blob/wraith-backend-2/t2b-tick-reads/features/wraith-db-relay-t2b-operational-knobs-read-at-tick-time-settingduration-settingi.md)

## Gate verdict

**✅ APPROVED** · round 2 · reviewer `review-1c3324e2-fa0b-4de3-8c2f-df859557031f`

## review-wraith verdict: SHIP
Scope: internal/db/projects.go (SettingDuration/SettingInt accessors), internal/relay/cleanup.go (runCleanupTick extraction + tick-time knob reads + env/tick resolvers), internal/relay/cleanup_test.go (5 AC tests)
Gate: build -tags fts5 OK / vet OK / gofmt OK / test -tags fts5 OK (relay 479, repo 880)

BLOCKERS (must fix before merge):
- none

NITS (non-blocking):
- AC2 test opens a second sql.Open("sqlite3", path) handle to backdate messages.expired_at. Test-only, on a t.TempDir DB, closed before the tick fires (no concurrent production writer). Chosen per cto ruling over adding a test-only exported DB seam.
- TokenUsageRetention (exported const) is now unused by production (the tick derives the window from token_usage_retention_days); kept intentionally per the ticket ("keep every const"), exported so the unused linter does not flag it.
## review-wraith verdict: SHIP
Scope: internal/db/projects.go (SettingDuration/SettingInt accessors), internal/relay/cleanup.go (runCleanupTick extraction + tick-time knob reads + env/tick resolvers), internal/relay/cleanup_test.go (5 AC tests)
Gate: build -tags fts5 OK / vet OK / gofmt OK / test -tags fts5 OK (relay 479, repo 880)

BLOCKERS (must fix before merge):
- none

NITS (non-blocking):
- AC2 test opens a second sql.Open("sqlite3", path) handle to backdate messages.expired_at. Test-only, on a t.TempDir DB, closed before the tick fires (no concurrent production writer). Chosen per cto ruling over adding a test-only exported DB seam.
- TokenUsageRetention (exported const) is now unused by production (the tick derives the window from token_usage_retention_days); kept intentionally per the ticket ("keep every const"), exported so the unused linter does not flag it.
## review-wraith verdict: SHIP
Scope: internal/db/projects.go (SettingDuration/SettingInt accessors), internal/relay/cleanup.go (runCleanupTick extraction + tick-time knob reads + env/tick resolvers), internal/relay/cleanup_test.go (5 AC tests)
Gate: build -tags fts5 OK / vet OK / gofmt OK / test -tags fts5 OK (relay 479, repo 880)

BLOCKERS (must fix before merge):
- none

NITS (non-blocking):
- AC2 test opens a second sql.Open("sqlite3", path) handle to backdate messages.expired_at. Test-only, on a t.TempDir DB, closed before the tick fires (no concurrent production writer). Chosen per cto ruling over adding a test-only exported DB seam.
- TokenUsageRetention (exported const) is now unused by production (the tick derives the window from token_usage_retention_days); kept intentionally per the ticket ("keep every const"), exported so the unused linter does not flag it.

---
<sub>Authored by agent `wraith-backend-2` · branch `wraith-backend-2/t2b-tick-reads` → `main` · reviewed by niwa-gate and merged when this repo's checks pass.</sub>
