### PR TITLE
[wraith/relay] T2d-b env-twin invalid-value WARN once per process: envBackupKeep/envReviewerTTL (cleanup.go:84/:119) now log on every 5-minute tick when RELAY_BACKUP_KEEP / RELAY_REVIEWER_TTL_DAYS is set but invalid

### DIFF
--- a/features/wraith-relay-t2d-b-env-twin-invalid-value-warn-once-per-process-envbackupkeep-en.md
+++ b/features/wraith-relay-t2d-b-env-twin-invalid-value-warn-once-per-process-envbackupkeep-en.md
@@ -1,0 +1,72 @@
+# [wraith/relay] T2d-b env-twin invalid-value WARN once per process: envBackupKeep/envReviewerTTL (cleanup.go:84/:119) now log on every 5-minute tick when RELAY_BACKUP_KEEP / RELAY_REVIEWER_TTL_DAYS is set but invalid
+
+## Team : wraith-backend-2 (tsukumo)
+## Branch : wraith-backend-2/t2d-b (from main)
+## Relay task : 65380b0b-a6ee-4087-a9e3-018d0269b478
+## Status : 🔵 SUBMITTED
+
+## 1. Product Brief
+
+### Acceptance Criteria
+- [ ] 1. AC1 named test: with RELAY_BACKUP_KEEP=abc and stored backup_keep=9, three consecutive tickBackupKeep(database) calls return 9 and the captured log contains the invalid line exactly once; same for RELAY_REVIEWER_TTL_DAYS=abc / reviewer_ttl_days with tickReviewerTTL; with a valid env the log stays empty and the env value wins
+- [ ] 2. AC2 named smoke test: TestResolveBackupKeep, TestResolveReviewerTTL and the 5 T2b tests still green; scope: diff touches exactly internal/relay/cleanup.go, internal/relay/cleanup_test.go; go test -tags fts5 ./internal/relay/... green
+
+## 2. Root cause & decisions
+
+# T2d-b — env-twin invalid-value WARN once per process
+
+## ROOT_CAUSE
+T2b ruling A7 moved the env probes `envBackupKeep()` / `envReviewerTTL()`
+(cleanup.go) into the cleanup tick, which runs every `PurgeInterval` (5 min).
+Their bare `log.Printf("RELAY_BACKUP_KEEP=%q invalid; using default …")` therefore
+re-logged on every tick whenever `RELAY_BACKUP_KEEP` / `RELAY_REVIEWER_TTL_DAYS`
+was set but unparsable — log spam. My own T2b gate finding (msg 3c5f6305).
+
+## CHANGE (2 files, behaviour change = WARN dedupe only)
+- `internal/relay/cleanup.go`: add package-level `var envWarnedKeys sync.Map`
+  (mirrors `db.settingWarnedKeys`, projects.go) + `warnEnvOnce(name, format, args…)`
+  that `LoadOrStore`s on the env name and `log.Printf`s only on first sight; add the
+  `sync` import; the two invalid-path `log.Printf` calls in `envBackupKeep` /
+  `envReviewerTTL` now go through `warnEnvOnce`. Return values (`ok=false` → stored
+  setting, else const) and the env>stored>const precedence are unchanged.
+- `internal/relay/cleanup_test.go`: NEW AC1 `TestEnvTwinInvalidValueWarnsOncePerProcess`
+  beside the T2b tests — resets the two `envWarnedKeys` entries for order-independence,
+  then asserts exactly one WARN line each across three `tickBackupKeep`/`tickReviewerTTL`
+  reads under an invalid env (returns stay 9 = stored), and empty log + env wins on a
+  valid env.
+
+`cleanup_backup_test.go` untouched (`TestResolveBackupKeep`/`TestResolveReviewerTTL`
+assert return values only, still green). Dedup keys on the env NAME per the ticket
+("LoadOrStore on the env name") — goal is one line per process, satisfied.
+
+## review-wraith verdict: SHIP
+Scope: internal/relay/cleanup.go, cleanup_test.go (log-dedupe in the cleanup tick's env probes).
+Gate: build -tags fts5 OK / vet OK / gofmt OK / test -tags fts5 OK (477 pass, +1 new test).
+
+BLOCKERS (must fix before merge):
+- none.
+
+NITS (non-blocking):
+- none.
+
+Not touched: sqlite writer/lock, schema/migrations, task transitions, deliveries/inbox,
+auth/middleware, MCP registry, ingest/SSE, updater/release. `envWarnedKeys` is a
+`sync.Map` (concurrency-safe); the tick is single-goroutine anyway.
+
+## 3. Files changed
+
+```
+internal/relay/cleanup.go      | 21 +++++++++++++++--
+ internal/relay/cleanup_test.go | 52 ++++++++++++++++++++++++++++++++++++++++++
+ 2 files changed, 71 insertions(+), 2 deletions(-)
+```
+
+## 4. QA Log
+
+_(no review round yet)_
+
+## 5. Timeline
+
+
+---
+_Auto-assembled by the niwa scribe from the Q&A gate. Task `65380b0b-a6ee-4087-a9e3-018d0269b478`._

--- a/internal/relay/cleanup.go
+++ b/internal/relay/cleanup.go
@@ -5,10 +5,27 @@ import (
 	"log"
 	"os"
 	"strconv"
+	"sync"
 	"time"
 
 	"agent-relay/internal/db"
 )
+
+// envWarnedKeys dedupes the invalid-env-twin WARN to one line per env name per
+// process. The cleanup tick calls envBackupKeep/envReviewerTTL every
+// PurgeInterval (ruling A7 moved the probes into the tick), so without the guard
+// a single bad env value would re-log on every tick. Mirrors
+// db.settingWarnedKeys (projects.go).
+var envWarnedKeys sync.Map // env name string -> struct{}{}
+
+// warnEnvOnce logs one WARN for an invalid env twin the first time name is seen
+// this process; subsequent calls for the same name are silent.
+func warnEnvOnce(name, format string, args ...interface{}) {
+	if _, seen := envWarnedKeys.LoadOrStore(name, struct{}{}); seen {
+		return
+	}
+	log.Printf(format, args...)
+}
 
 const (
 	// PurgeInterval is how often the cleanup runs.
@@ -81,7 +98,7 @@ func envBackupKeep() (int, bool) {
 	if n, err := strconv.Atoi(v); err == nil && n > 0 {
 		return n, true
 	}
-	log.Printf("RELAY_BACKUP_KEEP=%q invalid; using default %d", v, DefaultBackupKeep)
+	warnEnvOnce("RELAY_BACKUP_KEEP", "RELAY_BACKUP_KEEP=%q invalid; using default %d", v, DefaultBackupKeep)
 	return 0, false
 }
 
@@ -116,7 +133,7 @@ func envReviewerTTL() (time.Duration, bool) {
 	if n, err := strconv.Atoi(v); err == nil && n > 0 {
 		return time.Duration(n) * 24 * time.Hour, true
 	}
-	log.Printf("RELAY_REVIEWER_TTL_DAYS=%q invalid; using default %s", v, DefaultReviewerTTL)
+	warnEnvOnce("RELAY_REVIEWER_TTL_DAYS", "RELAY_REVIEWER_TTL_DAYS=%q invalid; using default %s", v, DefaultReviewerTTL)
 	return 0, false
 }
 

--- a/internal/relay/cleanup_test.go
+++ b/internal/relay/cleanup_test.go
@@ -217,6 +217,58 @@ func TestTickEnvTwinsBeatStoredBackupReviewer(t *testing.T) {
 	}
 }
 
+// TestEnvTwinInvalidValueWarnsOncePerProcess is AC1: an invalid RELAY_BACKUP_KEEP
+// / RELAY_REVIEWER_TTL_DAYS logs its invalid line exactly once across repeated
+// tick reads (the env>stored>const precedence is unchanged — the reads fall
+// through to the stored setting); a valid env logs nothing and wins.
+func TestEnvTwinInvalidValueWarnsOncePerProcess(t *testing.T) {
+	// envWarnedKeys is package-global: another test may already have warned these
+	// names this process, so reset for an order-independent count.
+	envWarnedKeys.Delete("RELAY_BACKUP_KEEP")
+	envWarnedKeys.Delete("RELAY_REVIEWER_TTL_DAYS")
+
+	d := newCleanupTestDB(t)
+	d.SetSetting("backup_keep", "9")
+	d.SetSetting("reviewer_ttl_days", "9")
+
+	// Invalid env → falls through to the stored setting; WARN once across 3 ticks.
+	t.Setenv("RELAY_BACKUP_KEEP", "abc")
+	t.Setenv("RELAY_REVIEWER_TTL_DAYS", "abc")
+	out := captureLog(func() {
+		for i := 0; i < 3; i++ {
+			if got := tickBackupKeep(d); got != 9 {
+				t.Fatalf("invalid env backup_keep tick %d: got %d want 9", i, got)
+			}
+			if got := tickReviewerTTL(d); got != 9*24*time.Hour {
+				t.Fatalf("invalid env reviewer_ttl tick %d: got %s want 216h", i, got)
+			}
+		}
+	})
+	if n := strings.Count(out, `RELAY_BACKUP_KEEP="abc" invalid`); n != 1 {
+		t.Errorf("RELAY_BACKUP_KEEP invalid WARN count = %d, want 1\nlog:\n%s", n, out)
+	}
+	if n := strings.Count(out, `RELAY_REVIEWER_TTL_DAYS="abc" invalid`); n != 1 {
+		t.Errorf("RELAY_REVIEWER_TTL_DAYS invalid WARN count = %d, want 1\nlog:\n%s", n, out)
+	}
+
+	// A valid env logs nothing and wins over the stored setting.
+	envWarnedKeys.Delete("RELAY_BACKUP_KEEP")
+	envWarnedKeys.Delete("RELAY_REVIEWER_TTL_DAYS")
+	t.Setenv("RELAY_BACKUP_KEEP", "5")
+	t.Setenv("RELAY_REVIEWER_TTL_DAYS", "5")
+	out = captureLog(func() {
+		if got := tickBackupKeep(d); got != 5 {
+			t.Fatalf("valid env backup_keep: got %d want 5", got)
+		}
+		if got := tickReviewerTTL(d); got != 5*24*time.Hour {
+			t.Fatalf("valid env reviewer_ttl: got %s want 120h", got)
+		}
+	})
+	if strings.TrimSpace(out) != "" {
+		t.Errorf("valid env should log nothing, got:\n%s", out)
+	}
+}
+
 // TestTickTokenUsageRetentionDaysDrivesPurgeAndRollup is AC4: the one key
 // token_usage_retention_days drives BOTH the raw-purge window and the rollup
 // window. A 5-day-old row survives + is rolled up at the default (14) but is


### PR DESCRIPTION
### niwa Q&A gate

An adversarial reviewer is reading this diff right now. Its verdict lands on this PR as a review (or a comment when the gate and the author share one GitHub account), and the merge waits for this repository's own checks to go green.

*Opened automatically — a rejected round comes back to the author, who pushes fixes to the same branch.*

## What & why

- **docs(scribe): provenance for wraith-relay-t2d-b-env-twin-invalid-value-warn-once-per-process-envbackupkeep-en**
- **chore: [wraith/relay] T2d-b env-twin invalid WARN once per process**
  <details><summary>details</summary>

  T2b ruling A7 moved envBackupKeep()/envReviewerTTL() into the cleanup tick, so an
  invalid RELAY_BACKUP_KEEP / RELAY_REVIEWER_TTL_DAYS re-logged the invalid line
  every PurgeInterval. Add a package-level envWarnedKeys sync.Map + warnEnvOnce
  helper (mirrors db.settingWarnedKeys) and route the two invalid-path log.Printf
  through it, so each env name warns exactly once per process. Return values and the
  env>stored>const precedence are unchanged; only the per-tick log spam is deduped.
  
  Test: NEW TestEnvTwinInvalidValueWarnsOncePerProcess (AC1) asserts one WARN line
  across three tick reads under an invalid env (returns fall through to the stored
  setting) and empty log + env wins on a valid env. cleanup_backup_test.go untouched.
  
  Claude-Session: https://claude.ai/code/session_01PrKgY1PpQX9DTAF7HGAsAB

  </details>

## Changes

<details><summary>Files changed (git diff --stat)</summary>

```
...value-warn-once-per-process-envbackupkeep-en.md | 72 ++++++++++++++++++++++
 internal/relay/cleanup.go                          | 21 ++++++-
 internal/relay/cleanup_test.go                     | 52 ++++++++++++++++
 3 files changed, 143 insertions(+), 2 deletions(-)
```

</details>

## Module graph

```mermaid
graph TD
  n0["features/wraith-relay-t2d-b-env-twin-invalid-value-warn-once-per-process-envbackupkeep-en.md"]
  n1["internal/relay"]
```

## Acceptance criteria

- [x] AC1 named test: with RELAY_BACKUP_KEEP=abc and stored backup_keep=9, three consecutive tickBackupKeep(database) calls return 9 and the captured log contains the invalid line exactly once; same for RELAY_REVIEWER_TTL_DAYS=abc / reviewer_ttl_days with tickReviewerTTL; with a valid env the log stays empty and the env value wins
- [x] AC2 named smoke test: TestResolveBackupKeep, TestResolveReviewerTTL and the 5 T2b tests still green; scope: diff touches exactly internal/relay/cleanup.go, internal/relay/cleanup_test.go; go test -tags fts5 ./internal/relay/... green
## Provenance

📄 [Root cause, decisions &amp; QA log — `features/wraith-relay-t2d-b-env-twin-invalid-value-warn-once-per-process-envbackupkeep-en.md`](https://github.com/TsukumoHQ/WRAI.TH/blob/wraith-backend-2/t2d-b/features/wraith-relay-t2d-b-env-twin-invalid-value-warn-once-per-process-envbackupkeep-en.md)

## Gate verdict

**✅ APPROVED** · round 1 · reviewer `review-65380b0b-a6ee-4087-a9e3-018d0269b478`

## review-wraith verdict: SHIP
Scope: internal/relay/cleanup.go, cleanup_test.go (log-dedupe in the cleanup tick's env probes).
Gate: build -tags fts5 OK / vet OK / gofmt OK / test -tags fts5 OK (477 pass, +1 new test).

BLOCKERS (must fix before merge):
- none.

NITS (non-blocking):
- none.

Not touched: sqlite writer/lock, schema/migrations, task transitions, deliveries/inbox,
auth/middleware, MCP registry, ingest/SSE, updater/release. `envWarnedKeys` is a
`sync.Map` (concurrency-safe); the tick is single-goroutine anyway.
## review-wraith verdict: SHIP
Scope: internal/relay/cleanup.go, cleanup_test.go (log-dedupe in the cleanup tick's env probes).
Gate: build -tags fts5 OK / vet OK / gofmt OK / test -tags fts5 OK (477 pass, +1 new test).

BLOCKERS (must fix before merge):
- none.

NITS (non-blocking):
- none.

Not touched: sqlite writer/lock, schema/migrations, task transitions, deliveries/inbox,
auth/middleware, MCP registry, ingest/SSE, updater/release. `envWarnedKeys` is a
`sync.Map` (concurrency-safe); the tick is single-goroutine anyway.

---
<sub>Authored by agent `wraith-backend-2` · branch `wraith-backend-2/t2d-b` → `main` · reviewed by niwa-gate and merged when this repo's checks pass.</sub>
