### PR TITLE
[wraith/relay] T2d-c GET /api/settings normalises duration values on the source=setting path: echo Duration.String() (48h0m0s) not the raw stored string (48h)

### DIFF
--- a/features/wraith-relay-t2d-c-get-api-settings-normalises-duration-values-on-the-source-set.md
+++ b/features/wraith-relay-t2d-c-get-api-settings-normalises-duration-values-on-the-source-set.md
@@ -3,7 +3,7 @@
 ## Team : wraith-backend-2 (tsukumo)
 ## Branch : wraith-backend-2/t2d-c (from main)
 ## Relay task : ac5314a5-831a-43e8-9c15-41eece95a391
-## Status : 🔵 IN REVIEW
+## Status : 🔵 SUBMITTED
 
 ## 1. Product Brief
 
@@ -51,10 +51,10 @@ deliveries/inbox, auth, MCP registry, ingest/SSE, updater/release, api.go, clean
 ## 3. Files changed
 
 ```
-...normalises-duration-values-on-the-source-set.md | 67 ++++++++++++++++++++++
+...normalises-duration-values-on-the-source-set.md | 72 ++++++++++++++++++++++
  internal/relay/settings_spec.go                    | 22 ++++++-
- internal/relay/settings_spec_test.go               | 37 ++++++++++++
- 3 files changed, 125 insertions(+), 1 deletion(-)
+ internal/relay/settings_spec_test.go               | 37 +++++++++++
+ 3 files changed, 130 insertions(+), 1 deletion(-)
 ```
 
 ## 4. QA Log
@@ -67,6 +67,8 @@ deliveries/inbox, auth, MCP registry, ingest/SSE, updater/release, api.go, clean
 ## 5. Timeline
 
 - round 1 → **approve** (review-ac5314a5-831a-43e8-9c15-41eece95a391)
+
+**Approve-with-findings (follow-up):** go test -tags fts5 ./internal/relay/... 479 ok; new tests AC1/AC2 exercise real PUT+GET and DB-bypass+GET, would fail pre-fix
 
 ---
 _Auto-assembled by the niwa scribe from the Q&A gate. Task `ac5314a5-831a-43e8-9c15-41eece95a391`._

--- a/features/wraith-relay-t2d-c-get-api-settings-normalises-duration-values-on-the-source-set.md
+++ b/features/wraith-relay-t2d-c-get-api-settings-normalises-duration-values-on-the-source-set.md
@@ -1,0 +1,67 @@
+# [wraith/relay] T2d-c GET /api/settings normalises duration values on the source=setting path: echo Duration.String() (48h0m0s) not the raw stored string (48h)
+
+## Team : wraith-backend-2 (tsukumo)
+## Branch : wraith-backend-2/t2d-c (from main)
+## Relay task : ac5314a5-831a-43e8-9c15-41eece95a391
+## Status : 🔵 SUBMITTED
+
+## 1. Product Brief
+
+### Acceptance Criteria
+- [ ] 1. AC1 GET after PUT message_retention=48h returns value "48h0m0s" source=setting (test drives apiPutSetting then apiGetSettings via httptest and asserts the duration item)
+- [ ] 2. AC2 an unparseable stored duration (raw UPDATE settings SET value='garbage' through the test DB) is echoed raw with source=setting and GET still returns 200 (no panic, no 500)
+- [ ] 3. AC3 existing TestSettingsSpec* and TestV2ConfigPanel stay green; go test -tags fts5 ./internal/relay/... passes
+
+## 2. Root cause & decisions
+
+# T2d-c — GET /api/settings normalises stored duration/int values
+
+## ROOT_CAUSE
+`resolveSetting` (settings_spec.go) returned the raw stored string on the
+`source=setting` branch, while the env and default branches already yield
+canonical forms. So `PUT message_retention=48h` then `GET` returned `"48h"`
+whereas the default path returns `"168h0m0s"` — a client cannot compare/parse
+durations uniformly (breaks frozen contract 6f73f179 A1).
+
+## CHANGE (2 files, no behaviour change beyond the returned string form)
+- `internal/relay/settings_spec.go`: add `normalizeStoredValue(s settingSpec, raw string) string`
+  — kindDuration → `time.ParseDuration(raw).String()`, kindInt → `Atoi`/`Itoa`,
+  any other kind → raw; an unparseable value returns raw unchanged (GET never 500s).
+  The `source=setting` non-secret return now goes through it. Secret guard still
+  returns `""` first; env/default/code branches untouched; only settingsMetadata
+  (v2 array) calls resolveSetting — v1 flat fields, PUT validation, and storage
+  format are untouched.
+- `internal/relay/settings_spec_test.go`: AC1 `TestGetNormalisesStoredDurationValue`
+  (PUT 48h → GET value=="48h0m0s" source=="setting"); AC2
+  `TestGetEchoesUnparseableStoredDurationRaw` (garbage stored via DB SetSetting,
+  bypassing PUT → GET 200, value echoed raw, source=="setting", no panic/500).
+
+## review-wraith verdict: SHIP
+Scope: internal/relay/settings_spec.go, settings_spec_test.go (GET read-path value normalisation).
+Gate: build -tags fts5 OK / vet OK / gofmt OK / test -tags fts5 OK (479 pass, +2 new tests).
+
+BLOCKERS: none.
+NITS: none.
+
+Note: branch is off main pre-T2d-a (writableSettings removal not yet merged), so
+it shares settings_spec_test.go with T2d-a #190 — a 1-round rebase is expected
+once #190 lands. Not touched: sqlite writer/lock, schema, task transitions,
+deliveries/inbox, auth, MCP registry, ingest/SSE, updater/release, api.go, cleanup.go, settings.js.
+
+## 3. Files changed
+
+```
+internal/relay/settings_spec.go      | 22 ++++++++++++++++++++-
+ internal/relay/settings_spec_test.go | 37 ++++++++++++++++++++++++++++++++++++
+ 2 files changed, 58 insertions(+), 1 deletion(-)
+```
+
+## 4. QA Log
+
+_(no review round yet)_
+
+## 5. Timeline
+
+
+---
+_Auto-assembled by the niwa scribe from the Q&A gate. Task `ac5314a5-831a-43e8-9c15-41eece95a391`._

--- a/features/wraith-relay-t2d-c-get-api-settings-normalises-duration-values-on-the-source-set.md
+++ b/features/wraith-relay-t2d-c-get-api-settings-normalises-duration-values-on-the-source-set.md
@@ -3,7 +3,7 @@
 ## Team : wraith-backend-2 (tsukumo)
 ## Branch : wraith-backend-2/t2d-c (from main)
 ## Relay task : ac5314a5-831a-43e8-9c15-41eece95a391
-## Status : 🔵 SUBMITTED
+## Status : 🔵 IN REVIEW
 
 ## 1. Product Brief
 
@@ -51,17 +51,22 @@ deliveries/inbox, auth, MCP registry, ingest/SSE, updater/release, api.go, clean
 ## 3. Files changed
 
 ```
-internal/relay/settings_spec.go      | 22 ++++++++++++++++++++-
- internal/relay/settings_spec_test.go | 37 ++++++++++++++++++++++++++++++++++++
- 2 files changed, 58 insertions(+), 1 deletion(-)
+...normalises-duration-values-on-the-source-set.md | 67 ++++++++++++++++++++++
+ internal/relay/settings_spec.go                    | 22 ++++++-
+ internal/relay/settings_spec_test.go               | 37 ++++++++++++
+ 3 files changed, 125 insertions(+), 1 deletion(-)
 ```
 
 ## 4. QA Log
 
-_(no review round yet)_
+### Round 1 — ✅ APPROVED by review-ac5314a5-831a-43e8-9c15-41eece95a391 @ `d32ce7783`
+- 🟢 AC1: Real httptest PUT then GET, observable output asserted, not mock — evidence: settings_spec.go:208 routes source=setting non-secret through normalizeStoredValue; settings_spec.go:225-227 time.ParseDuration(raw).String() — test: TestGetNormalisesStoredDurationValue settings_spec_test.go:313 (PUT 48h → GET asserts 48h0m0s/setting; pre-fix returns raw 48h → would fail)
+- 🟢 AC2: Hits the parse-error fall-through branch via real handler; no panic/500 verified by status==200 — evidence: settings_spec.go:222-233; kindDuration parse-error returns raw unchanged; no panic — test: TestGetEchoesUnparseableStoredDurationRaw settings_spec_test.go:331 (DB.SetSetting garbage → GET 200, value=garbage, source=setting)
+- 🟢 AC3: Suite green; no test deleted or weakened — evidence: go test -tags fts5 ./internal/relay/... = 479 passed including TestV2ConfigPanel and existing TestSettingsSpec* — test: TestV2ConfigPanel and TestSettingsSpec* (pre-existing, all green)
 
 ## 5. Timeline
 
+- round 1 → **approve** (review-ac5314a5-831a-43e8-9c15-41eece95a391)
 
 ---
 _Auto-assembled by the niwa scribe from the Q&A gate. Task `ac5314a5-831a-43e8-9c15-41eece95a391`._

--- a/internal/relay/settings_spec.go
+++ b/internal/relay/settings_spec.go
@@ -189,12 +189,32 @@ func (r *Relay) resolveSetting(s settingSpec) (value string, set bool, source st
 		if s.Secret {
 			return "", true, "setting"
 		}
-		return dv, true, "setting"
+		return normalizeStoredValue(s, dv), true, "setting"
 	}
 	if s.Secret {
 		return "", false, "default"
 	}
 	return s.Default, false, "default"
+}
+
+// normalizeStoredValue canonicalises a raw stored value for the GET
+// /api/settings source=setting path so a duration echoes Go's
+// time.Duration.String() form (48h -> 48h0m0s) and an int its decimal form,
+// matching the env/default branches (frozen contract 6f73f179 A1). A value that
+// fails to parse (hand-SQL garbage) is returned unchanged so GET never 500s.
+// Storage format and PUT validation are untouched.
+func normalizeStoredValue(s settingSpec, raw string) string {
+	switch s.Kind {
+	case kindDuration:
+		if d, err := time.ParseDuration(raw); err == nil {
+			return d.String()
+		}
+	case kindInt:
+		if n, err := strconv.Atoi(raw); err == nil {
+			return strconv.Itoa(n)
+		}
+	}
+	return raw
 }
 
 // validateValue checks a single non-null value against its spec's kind + bounds.

--- a/internal/relay/settings_spec_test.go
+++ b/internal/relay/settings_spec_test.go
@@ -314,3 +314,40 @@ func TestNoWritableSettingsIdentifierInSource(t *testing.T) {
 		}
 	}
 }
+
+// TestGetNormalisesStoredDurationValue (T2d-c AC1): after PUT message_retention=48h,
+// GET /api/settings echoes the value in Go time.Duration.String() form (48h0m0s),
+// not the raw stored string, on the source=setting path.
+func TestGetNormalisesStoredDurationValue(t *testing.T) {
+	r := testRelay(t)
+	if w := doAPI(r, http.MethodPut, "/settings", `{"message_retention":"48h"}`); w.Code != http.StatusOK {
+		t.Fatalf("PUT message_retention=48h: status %d\nbody: %s", w.Code, w.Body.String())
+	}
+	e, ok := getSettingEntry(t, decodeJSON(t, doAPI(r, http.MethodGet, "/settings", "")), "message_retention")
+	if !ok {
+		t.Fatal("message_retention entry missing")
+	}
+	if e["value"] != "48h0m0s" || e["source"] != "setting" {
+		t.Errorf("message_retention = {value:%v source:%v}, want {48h0m0s, setting}", e["value"], e["source"])
+	}
+}
+
+// TestGetEchoesUnparseableStoredDurationRaw (T2d-c AC2): a stored duration that
+// does not parse (hand-SQL garbage written straight to the DB, bypassing PUT
+// validation) is echoed raw with source=setting and GET still returns 200 — no
+// panic, no 500.
+func TestGetEchoesUnparseableStoredDurationRaw(t *testing.T) {
+	r := testRelay(t)
+	r.DB.SetSetting("message_retention", "garbage")
+	w := doAPI(r, http.MethodGet, "/settings", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("GET with garbage stored duration: status %d, want 200 (no 500)\nbody: %s", w.Code, w.Body.String())
+	}
+	e, ok := getSettingEntry(t, decodeJSON(t, w), "message_retention")
+	if !ok {
+		t.Fatal("message_retention entry missing")
+	}
+	if e["value"] != "garbage" || e["source"] != "setting" {
+		t.Errorf("garbage stored = {value:%v source:%v}, want {garbage, setting}", e["value"], e["source"])
+	}
+}


### PR DESCRIPTION
### niwa Q&A gate

An adversarial reviewer is reading this diff right now. Its verdict lands on this PR as a review (or a comment when the gate and the author share one GitHub account), and the merge waits for this repository's own checks to go green.

*Opened automatically — a rejected round comes back to the author, who pushes fixes to the same branch.*

## What & why

- **docs(scribe): provenance for wraith-relay-t2d-c-get-api-settings-normalises-duration-values-on-the-source-set**
- **chore: [wraith/relay] T2d-c GET /api/settings normalises stored duration/int values**
  <details><summary>details</summary>

  resolveSetting returned the raw stored string on the source=setting branch, so
  PUT message_retention=48h then GET echoed "48h" while the default path returns
  "168h0m0s" (frozen contract 6f73f179 A1: durations should always be Go
  time.Duration.String() form). Add normalizeStoredValue(s, raw): kindDuration ->
  ParseDuration.String(), kindInt -> Atoi/Itoa, other kinds and unparseable values
  returned raw so GET never 500s. Only the source=setting non-secret return is
  routed through it; secret/env/default/code branches, PUT validation, storage
  format, api.go and the v1 flat fields are untouched (resolveSetting feeds only
  the v2 settingsMetadata array).
  
  Tests: TestGetNormalisesStoredDurationValue (PUT 48h -> GET 48h0m0s source=setting);
  TestGetEchoesUnparseableStoredDurationRaw (garbage stored via DB, GET 200, echoed raw).
  
  Claude-Session: https://claude.ai/code/session_01PrKgY1PpQX9DTAF7HGAsAB

  </details>

## Changes

<details><summary>Files changed (git diff --stat)</summary>

```
...blesettings-legacy-9-key-panel-allowlist-spe.md |  86 -----------------
 ...normalises-duration-values-on-the-source-set.md |  67 +++++++++++++
 internal/relay/api.go                              |   7 +-
 internal/relay/settings_spec.go                    |  40 +++++++-
 internal/relay/settings_spec_test.go               | 105 +++++++++++++--------
 5 files changed, 176 insertions(+), 129 deletions(-)
```

</details>

## Module graph

```mermaid
graph TD
  n0["features/wraith-relay-t2d-c-get-api-settings-normalises-duration-values-on-the-source-set.md"]
  n1["internal/relay"]
```

## Acceptance criteria

- [x] AC1 GET after PUT message_retention=48h returns value "48h0m0s" source=setting (test drives apiPutSetting then apiGetSettings via httptest and asserts the duration item)
- [x] AC2 an unparseable stored duration (raw UPDATE settings SET value='garbage' through the test DB) is echoed raw with source=setting and GET still returns 200 (no panic, no 500)
- [x] AC3 existing TestSettingsSpec* and TestV2ConfigPanel stay green; go test -tags fts5 ./internal/relay/... passes
## Provenance

📄 [Root cause, decisions &amp; QA log — `features/wraith-relay-t2d-c-get-api-settings-normalises-duration-values-on-the-source-set.md`](https://github.com/TsukumoHQ/WRAI.TH/blob/wraith-backend-2/t2d-c/features/wraith-relay-t2d-c-get-api-settings-normalises-duration-values-on-the-source-set.md)

## Gate verdict

**✅ APPROVED** · round 2 · reviewer `review-ac5314a5-831a-43e8-9c15-41eece95a391`

## review-wraith verdict: SHIP
Scope: internal/relay/settings_spec.go, settings_spec_test.go (GET read-path value normalisation).
Gate: build -tags fts5 OK / vet OK / gofmt OK / test -tags fts5 OK (479 pass, +2 new tests).

BLOCKERS: none.
NITS: none.

Note: branch is off main pre-T2d-a (writableSettings removal not yet merged), so
it shares settings_spec_test.go with T2d-a #190 — a 1-round rebase is expected
once #190 lands. Not touched: sqlite writer/lock, schema, task transitions,
deliveries/inbox, auth, MCP registry, ingest/SSE, updater/release, api.go, cleanup.go, settings.js.
## review-wraith verdict: SHIP
Scope: internal/relay/settings_spec.go, settings_spec_test.go (GET read-path value normalisation).
Gate: build -tags fts5 OK / vet OK / gofmt OK / test -tags fts5 OK (479 pass, +2 new tests).

BLOCKERS: none.
NITS: none.

Note: branch is off main pre-T2d-a (writableSettings removal not yet merged), so
it shares settings_spec_test.go with T2d-a #190 — a 1-round rebase is expected
once #190 lands. Not touched: sqlite writer/lock, schema, task transitions,
deliveries/inbox, auth, MCP registry, ingest/SSE, updater/release, api.go, cleanup.go, settings.js.
## review-wraith verdict: SHIP
Scope: internal/relay/settings_spec.go, settings_spec_test.go (GET read-path value normalisation).
Gate: build -tags fts5 OK / vet OK / gofmt OK / test -tags fts5 OK (479 pass, +2 new tests).

BLOCKERS: none.
NITS: none.

Note: branch is off main pre-T2d-a (writableSettings removal not yet merged), so
it shares settings_spec_test.go with T2d-a #190 — a 1-round rebase is expected
once #190 lands. Not touched: sqlite writer/lock, schema, task transitions,
deliveries/inbox, auth, MCP registry, ingest/SSE, updater/release, api.go, cleanup.go, settings.js.

---
<sub>Authored by agent `wraith-backend-2` · branch `wraith-backend-2/t2d-c` → `main` · reviewed by niwa-gate and merged when this repo's checks pass.</sub>
