### PR TITLE
[wraith/console][founder bug] console send identity: /api/user-response stores from_agent "user", UI/filters expect "human" — make the server send as human

### DIFF
--- a/features/wraith-console-founder-bug-console-send-identity-api-user-response-stores-from-a.md
+++ b/features/wraith-console-founder-bug-console-send-identity-api-user-response-stores-from-a.md
@@ -1,0 +1,75 @@
+# [wraith/console][founder bug] console send identity: /api/user-response stores from_agent "user", UI/filters expect "human" — make the server send as human
+
+## Team : wraith-backend-2 (tsukumo)
+## Branch : wraith-backend-2/console-human (from main)
+## Relay task : 83396f2f-44c3-4c07-8711-caea59008f35
+## Status : 🔵 SUBMITTED
+
+## 1. Product Brief
+
+### Acceptance Criteria
+- [ ] 1. AC1 TestUserResponseSenderIsHuman: POST /api/user-response -> stored message from_agent == "human" and a delivery row exists for the target agent
+- [ ] 2. AC2 TestUserAliasStillRouted: a message addressed to "user" and one addressed to "human" resolve to the same inbox target (notifications target resolution) and isAgent("human") == false unchanged
+- [ ] 3. AC3 TestV1V2AssetsUntouched: internal/web/static/js/api-client.js, js/main.js, v2/api.js byte-identical to main; go test -tags fts5 ./internal/relay/... green
+
+## 2. Root cause & decisions
+
+# Decision — console send identity (task 83396f2f)
+
+## ROOT_CAUSE
+`apiPostUserResponse` (internal/relay/api.go) hard-coded the sender as `"user"`
+at both the `InsertMessageWithDeliveries` insert and the `Registry.Notify` push.
+The console's human-profile filter and the v2 UI key off `from == "human"`, so a
+message the founder typed in the console arrived tagged `user` and fell outside
+the human profile. The client sends NO sender field (server-authoritative), so
+the fix is server-side only: emit `"human"` at both call sites.
+
+## FIX
+- api.go apiPostUserResponse: sender arg `"user"` -> `"human"` at the
+  InsertMessageWithDeliveries call and the Registry.Notify call. Nothing else.
+- `resolveTargets` already maps both `"human"` and `"user"` -> `["user"]`
+  (notifications.go:520), so routing/wake is unchanged — no notifications.go edit.
+
+## SCOPE
+2 files: internal/relay/api.go, internal/relay/console_identity_human_test.go.
+Client assets (static/js/*, static/v2/*) untouched — pinned by AC3.
+
+## AC3 note
+Recorded plan asserted all THREE assets contain `/api/user-response`. main.js
+does NOT reference the endpoint (it routes through api-client.js); asserting it
+would false-fail. AC3 implemented to intent: the two real callers
+(static/js/api-client.js, static/v2/api.js) still POST `/api/user-response` and
+send no `sender`; main.js pinned present+non-empty. Byte-identity still enforced
+by the gate diff-scope check.
+
+## review-wraith verdict: SHIP
+- Build bar: `go test -tags fts5 ./internal/relay/...` green — 483 pass (480 -> +3).
+- Single-writer / lock discipline: no DB-layer change; insert path unchanged
+  except the literal sender value. No new writer.
+- agentColumns<->scanAgent lockstep: untouched.
+- Task-transition TOCTOU / double-claim: N/A (no task lifecycle change).
+- Non-destructive inbox: unchanged (same InsertMessageWithDeliveries call, one
+  arg value flipped).
+- Schema: no migration, no schema change.
+- Blast radius: one string literal at two call sites on the console reply path;
+  `resolveTargets` alias keeps `human`==`user` routing.
+
+VERDICT: SHIP.
+
+## 3. Files changed
+
+```
+internal/relay/api.go                         |  4 +-
+ internal/relay/console_identity_human_test.go | 96 +++++++++++++++++++++++++++
+ 2 files changed, 98 insertions(+), 2 deletions(-)
+```
+
+## 4. QA Log
+
+_(no review round yet)_
+
+## 5. Timeline
+
+
+---
+_Auto-assembled by the niwa scribe from the Q&A gate. Task `83396f2f-44c3-4c07-8711-caea59008f35`._

--- a/internal/relay/api.go
+++ b/internal/relay/api.go
@@ -955,7 +955,7 @@ func (r *Relay) apiPostUserResponse(w http.ResponseWriter, req *http.Request) {
 
 	replyTo := optionalString(body.ReplyTo)
 
-	msg, dedupHit, err := r.DB.InsertMessageWithDeliveries(body.Project, "user", body.To, "response", "User response", body.Content, "{}", "P1", 3600, replyTo, nil, []string{body.To}, "")
+	msg, dedupHit, err := r.DB.InsertMessageWithDeliveries(body.Project, "human", body.To, "response", "User response", body.Content, "{}", "P1", 3600, replyTo, nil, []string{body.To}, "")
 	if err != nil {
 		http.Error(w, `{"error":"failed to send response"}`, http.StatusInternalServerError)
 		return
@@ -967,7 +967,7 @@ func (r *Relay) apiPostUserResponse(w http.ResponseWriter, req *http.Request) {
 	// the 7th and last of InsertMessageWithDeliveries' 7 callers to close it).
 	if !dedupHit {
 		// Push notification to the target agent
-		r.Registry.Notify(body.Project, body.To, "user", "User response", msg.ID)
+		r.Registry.Notify(body.Project, body.To, "human", "User response", msg.ID)
 	}
 
 	writeJSON(w, map[string]any{"ok": true, "message_id": msg.ID})

--- a/internal/relay/console_identity_human_test.go
+++ b/internal/relay/console_identity_human_test.go
@@ -1,0 +1,96 @@
+package relay
+
+import (
+	"strings"
+	"testing"
+
+	"agent-relay/internal/db"
+	"agent-relay/internal/web"
+)
+
+// Founder bug (console send identity): a message sent from the web console via
+// POST /api/user-response was stored with from_agent "user", but the console's
+// human-profile filter and the v2 UI expect "human". The server is the sole
+// authority for the sender (the client sends no sender field), so the fix lives
+// in apiPostUserResponse. Each test below maps to one acceptance criterion.
+
+// AC1: a console send lands in the target agent's inbox tagged from "human".
+func TestUserResponseSenderIsHuman(t *testing.T) {
+	r := testRelay(t)
+
+	if _, _, err := r.DB.RegisterAgent("p1", "bot-a", "dev", "", nil, nil, false, nil, "[]", 0, db.RegisterOptions{}); err != nil {
+		t.Fatalf("register agent: %v", err)
+	}
+
+	w := doAPI(r, "POST", "/user-response", `{"project":"p1","to":"bot-a","content":"hello from the console"}`)
+	if w.Code != 200 {
+		t.Fatalf("user-response status = %d, body %s", w.Code, w.Body.String())
+	}
+
+	msgs, err := r.DB.GetInboxViaDeliveries("p1", "bot-a", false, 50)
+	if err != nil {
+		t.Fatalf("get inbox: %v", err)
+	}
+
+	var found bool
+	for _, m := range msgs {
+		if m.Content == "hello from the console" {
+			found = true
+			if m.From != "human" {
+				t.Fatalf("inbox message from = %q, want %q", m.From, "human")
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("console message not delivered to bot-a inbox (%d msgs)", len(msgs))
+	}
+}
+
+// AC2: "human" and the legacy "user" alias still resolve to the same notify
+// target, so the sender rename does not reroute or drop the wake.
+func TestUserAliasStillRouted(t *testing.T) {
+	n := &Notifier{}
+
+	human := n.resolveTargets("p1", "human", nil)
+	user := n.resolveTargets("p1", "user", nil)
+
+	if len(human) != 1 || human[0] != "user" {
+		t.Fatalf(`resolveTargets("human") = %v, want ["user"]`, human)
+	}
+	if len(user) != 1 || user[0] != "user" {
+		t.Fatalf(`resolveTargets("user") = %v, want ["user"]`, user)
+	}
+}
+
+// AC3: the v1 and v2 client assets are untouched by this server-side fix — they
+// still POST to /api/user-response and still send NO sender field (the server is
+// authoritative). Byte-identity is enforced by the gate's diff-scope check; this
+// pins the load-bearing behaviour at the source level.
+func TestV1V2AssetsUntouched(t *testing.T) {
+	// The two clients that actually call the endpoint.
+	for _, name := range []string{"static/js/api-client.js", "static/v2/api.js"} {
+		b, err := web.StaticFiles.ReadFile(name)
+		if err != nil {
+			t.Fatalf("read %s: %v", name, err)
+		}
+		src := string(b)
+		if len(src) == 0 {
+			t.Fatalf("%s is empty", name)
+		}
+		if !strings.Contains(src, "/api/user-response") {
+			t.Fatalf("%s no longer POSTs /api/user-response", name)
+		}
+		if strings.Contains(src, "sender") {
+			t.Fatalf("%s now sends a sender field; the server must stay authoritative", name)
+		}
+	}
+
+	// main.js is a v1 asset in the same bundle: present and non-empty, untouched.
+	b, err := web.StaticFiles.ReadFile("static/js/main.js")
+	if err != nil {
+		t.Fatalf("read static/js/main.js: %v", err)
+	}
+	if len(b) == 0 {
+		t.Fatalf("static/js/main.js is empty")
+	}
+}


### PR DESCRIPTION
### niwa Q&A gate

An adversarial reviewer is reading this diff right now. Its verdict lands on this PR as a review (or a comment when the gate and the author share one GitHub account), and the merge waits for this repository's own checks to go green.

*Opened automatically — a rejected round comes back to the author, who pushes fixes to the same branch.*

## What & why

- **docs(scribe): provenance for wraith-console-founder-bug-console-send-identity-api-user-response-stores-from-a**
- **fix: [wraith/relay] console send identity — /api/user-response sends as human**
  <details><summary>details</summary>

  apiPostUserResponse hard-coded sender "user" at both the
  InsertMessageWithDeliveries insert and the Registry.Notify push, so a
  message typed in the web console arrived tagged from_agent="user" and fell
  outside the console human-profile filter (and the v2 UI, which keys on
  from=="human"). Emit "human" at both call sites; the client sends no sender
  (server-authoritative). resolveTargets already maps human/user -> [user], so
  routing and wake are unchanged.
  
  Tests: TestUserResponseSenderIsHuman, TestUserAliasStillRouted,
  TestV1V2AssetsUntouched. go test -tags fts5 ./internal/relay/... green (483).
  
  Claude-Session: https://claude.ai/code/session_01PrKgY1PpQX9DTAF7HGAsAB

  </details>

## Changes

<details><summary>Files changed (git diff --stat)</summary>

```
...end-identity-api-user-response-stores-from-a.md | 75 +++++++++++++++++
 internal/relay/api.go                              |  4 +-
 internal/relay/console_identity_human_test.go      | 96 ++++++++++++++++++++++
 3 files changed, 173 insertions(+), 2 deletions(-)
```

</details>

## Module graph

```mermaid
graph TD
  n0["features/wraith-console-founder-bug-console-send-identity-api-user-response-stores-from-a.md"]
  n1["internal/relay"]
```

## Acceptance criteria

- [x] AC1 TestUserResponseSenderIsHuman: POST /api/user-response -> stored message from_agent == "human" and a delivery row exists for the target agent
- [x] AC2 TestUserAliasStillRouted: a message addressed to "user" and one addressed to "human" resolve to the same inbox target (notifications target resolution) and isAgent("human") == false unchanged
- [x] AC3 TestV1V2AssetsUntouched: internal/web/static/js/api-client.js, js/main.js, v2/api.js byte-identical to main; go test -tags fts5 ./internal/relay/... green
## Provenance

📄 [Root cause, decisions &amp; QA log — `features/wraith-console-founder-bug-console-send-identity-api-user-response-stores-from-a.md`](https://github.com/TsukumoHQ/WRAI.TH/blob/wraith-backend-2/console-human/features/wraith-console-founder-bug-console-send-identity-api-user-response-stores-from-a.md)

## Gate verdict

**✅ APPROVED** · round 1 · reviewer `review-83396f2f-44c3-4c07-8711-caea59008f35`

## review-wraith verdict: SHIP
- Build bar: `go test -tags fts5 ./internal/relay/...` green — 483 pass (480 -> +3).
- Single-writer / lock discipline: no DB-layer change; insert path unchanged
  except the literal sender value. No new writer.
- agentColumns<->scanAgent lockstep: untouched.
- Task-transition TOCTOU / double-claim: N/A (no task lifecycle change).
- Non-destructive inbox: unchanged (same InsertMessageWithDeliveries call, one
  arg value flipped).
- Schema: no migration, no schema change.
- Blast radius: one string literal at two call sites on the console reply path;
  `resolveTargets` alias keeps `human`==`user` routing.

VERDICT: SHIP.
## review-wraith verdict: SHIP
- Build bar: `go test -tags fts5 ./internal/relay/...` green — 483 pass (480 -> +3).
- Single-writer / lock discipline: no DB-layer change; insert path unchanged
  except the literal sender value. No new writer.
- agentColumns<->scanAgent lockstep: untouched.
- Task-transition TOCTOU / double-claim: N/A (no task lifecycle change).
- Non-destructive inbox: unchanged (same InsertMessageWithDeliveries call, one
  arg value flipped).
- Schema: no migration, no schema change.
- Blast radius: one string literal at two call sites on the console reply path;
  `resolveTargets` alias keeps `human`==`user` routing.

VERDICT: SHIP.

---
<sub>Authored by agent `wraith-backend-2` · branch `wraith-backend-2/console-human` → `main` · reviewed by niwa-gate and merged when this repo's checks pass.</sub>
