### PR TITLE
[wraith/console-v1][founder B] server-side alias dyson_type <-> sun_type so the v1 dyson picker works again; v1 assets untouched

### DIFF
--- a/features/wraith-console-v1-founder-b-server-side-alias-dyson-type-sun-type-so-the-v1-dyso.md
+++ b/features/wraith-console-v1-founder-b-server-side-alias-dyson-type-sun-type-so-the-v1-dyso.md
@@ -1,0 +1,69 @@
+# [wraith/console-v1][founder B] server-side alias dyson_type <-> sun_type so the v1 dyson picker works again; v1 assets untouched
+
+## Team : wraith-engine-2 (tsukumo)
+## Branch : wraith-engine-2/v1-dyson-alias (from main)
+## Relay task : 1ab761c2-d4d7-40dc-be5e-11cfdebf1fcd
+## Status : 🔵 SUBMITTED
+
+## 1. Product Brief
+
+### Acceptance Criteria
+- [ ] 1. AC1 TestDysonAliasPut: PUT {dyson_type:"off"} -> 200 and stored sun_type == "0"; PUT {dyson_type:"5"} -> stored sun_type == "5"; PUT {dyson_type:"auto"} -> sun_type cleared; PUT {dyson_type:"x"} -> 400 naming key dyson_type; body with both dyson_type and sun_type -> 400
+- [ ] 2. AC2 TestDysonAliasGet: flat GET /api/settings exposes dyson_type mapped auto/off/n from stored sun_type, and the v1 fields (sun_type default "1", linear_mode, linear{}) plus groups/settings stay byte-compatible
+- [ ] 3. AC3 TestV1AssetsUntouched: internal/web/static/js/main.js, index.html, style.css byte-identical to main; existing TestSettingsSpec*/TestV2ConfigPanel green; go test -tags fts5 ./internal/relay/... green
+
+## 2. Root cause & decisions
+
+# T1ab761c2 — server-side dyson_type ⇄ sun_type alias (founder ruling B)
+
+## Root cause
+v1 dyson picker (static/js/main.js) reads `settings.dyson_type` from GET and PUTs
+`dyson_type`, but the config surface was reshaped to the `sun_type` spec key (T2a).
+The legacy key was neither accepted on PUT nor emitted on GET → v1 picker inert.
+
+## Decision
+Founder ruling B (design record 6f73f179 rule e): keep the feature, bridge the key
+names SERVER-SIDE so v1 assets stay byte-identical. No v1/v2 asset edits.
+- PUT: translate `dyson_type` → `sun_type` BEFORE validation. auto/null→clear,
+  off→"0", "1".."7"→same, else→400(dyson_type). Both keys→400 (ambiguous).
+- GET: add flat `dyson_type` mirror of stored sun_type (""→auto, "0"→off, else raw).
+  Flat `sun_type` keeps "1" default unchanged.
+- settings_spec.go: sun_type Min "0" (0 = off) so the off state validates.
+
+## ACs → tests
+- AC1 PUT translation/errors → TestDysonAliasPut
+- AC2 GET flat mirror + v1 fields intact → TestDysonAliasGet
+- AC3 v1 assets untouched (picker key present, no server-only token leak) → TestV1AssetsUntouched
+
+## Rejected alternatives
+- Option A (edit main.js to speak sun_type): violates byte-identical v1 assets.
+- Client-side shim: same asset-edit problem; server bridge is the single source.
+
+## review-wraith verdict: SHIP
+Scope: internal/relay/api.go (settingsResponse + apiPutSetting alias), internal/relay/settings_spec.go (sun_type Min "0"), NEW internal/relay/console_v1_dyson_alias_test.go
+Gate: build -tags fts5 OK / vet OK / gofmt OK / test -tags fts5 OK (483 pass)
+
+BLOCKERS (must fix before merge):
+- none
+
+NITS (non-blocking):
+- dyson_type raw "0" → 400 by design (picker sends "off", never "0"); GET maps stored "0"→"off" so round-trip stays consistent.
+
+## 3. Files changed
+
+```
+internal/relay/api.go                         |  37 +++++++-
+ internal/relay/console_v1_dyson_alias_test.go | 123 ++++++++++++++++++++++++++
+ internal/relay/settings_spec.go               |   2 +-
+ 3 files changed, 160 insertions(+), 2 deletions(-)
+```
+
+## 4. QA Log
+
+_(no review round yet)_
+
+## 5. Timeline
+
+
+---
+_Auto-assembled by the niwa scribe from the Q&A gate. Task `1ab761c2-d4d7-40dc-be5e-11cfdebf1fcd`._

--- a/features/wraith-console-v1-founder-b-server-side-alias-dyson-type-sun-type-so-the-v1-dyso.md
+++ b/features/wraith-console-v1-founder-b-server-side-alias-dyson-type-sun-type-so-the-v1-dyso.md
@@ -52,18 +52,25 @@ NITS (non-blocking):
 ## 3. Files changed
 
 ```
-internal/relay/api.go                         |  37 +++++++-
- internal/relay/console_v1_dyson_alias_test.go | 123 ++++++++++++++++++++++++++
- internal/relay/settings_spec.go               |   2 +-
- 3 files changed, 160 insertions(+), 2 deletions(-)
+...ide-alias-dyson-type-sun-type-so-the-v1-dyso.md |  69 ++++++++++++
+ internal/relay/api.go                              |  37 ++++++-
+ internal/relay/console_v1_dyson_alias_test.go      | 123 +++++++++++++++++++++
+ internal/relay/settings_spec.go                    |   2 +-
+ 4 files changed, 229 insertions(+), 2 deletions(-)
 ```
 
 ## 4. QA Log
 
-_(no review round yet)_
+### Round 1 — ✅ APPROVED by review-1ab761c2-d4d7-40dc-be5e-11cfdebf1fcd @ `d694219a2`
+- 🟢 AC1: alias added server-side; off/auto/1..7 paths and dup-key reject each pinned by observed DB read or 400 body inspection — evidence: internal/relay/api.go:481-505 translation runs before validateSettings; sun_type Min lowered to 0 in settings_spec.go:64 so off->0 passes bounds — test: TestDysonAliasPut internal/relay/console_v1_dyson_alias_test.go:18 — all 5 sub-cases PUT through HTTP, then reads r.DB.GetSetting
+- 🟢 AC2: flat mirror plus v1 byte-compat fields exercised end-to-end — evidence: internal/relay/api.go:430-444 settingsResponse maps storedSun -> dysonType (auto/off/n) and keeps sun_type default 1 plus linear_mode/linear/groups/settings — test: TestDysonAliasGet internal/relay/console_v1_dyson_alias_test.go:73 — 3 GET calls against 3 DB states; v1 field presence asserted
+- 🟢 AC3: byte-identical verified by tree diff and by test scanning for the 3 server-only error strings — evidence: git diff origin/main...HEAD -- internal/web/ is empty (internal/web/static/{js/main.js,index.html,style.css} unchanged); full suite 483/483 ok including TestSettingsSpec* + TestV2ConfigPanel — test: TestV1AssetsUntouched internal/relay/console_v1_dyson_alias_test.go:97 reads static/js/main.js, index.html, style.css via web.StaticFiles and asserts no server-only token leaked
 
 ## 5. Timeline
 
+- round 1 → **approve** (review-1ab761c2-d4d7-40dc-be5e-11cfdebf1fcd)
+
+**Approve-with-findings (follow-up):** go test -tags fts5 ./internal/relay/... 483/483 ok; TestDysonAliasPut/Get/V1AssetsUntouched + TestSettingsSpec*/TestV2ConfigPanel green; v1 assets byte-identical (git diff origin/main...HEAD -- internal/web/ empty); AC1 AC2 AC3 verified by named tests at internal/relay/console_v1_dyson_alias_test.go:18,73,97
 
 ---
 _Auto-assembled by the niwa scribe from the Q&A gate. Task `1ab761c2-d4d7-40dc-be5e-11cfdebf1fcd`._

--- a/internal/relay/api.go
+++ b/internal/relay/api.go
@@ -427,9 +427,16 @@ func (r *Relay) apiGetSettings(w http.ResponseWriter) {
 // untouched (T2c) — plus the frozen v2 shape (`groups` + `settings`, design
 // record 6f73f179) ADDED alongside.
 func (r *Relay) settingsResponse() map[string]any {
-	sunType := r.DB.GetSetting("sun_type")
+	storedSun := r.DB.GetSetting("sun_type")
+	sunType := storedSun
 	if sunType == "" {
 		sunType = "1"
+	}
+	dysonType := "auto"
+	if storedSun == "0" {
+		dysonType = "off"
+	} else if storedSun != "" {
+		dysonType = storedSun
 	}
 	apiKey, teamKey, enabled, interval, source := r.effectiveLinearConfig()
 	masked := ""
@@ -441,6 +448,7 @@ func (r *Relay) settingsResponse() map[string]any {
 	}
 	return map[string]any{
 		"sun_type":    sunType,
+		"dyson_type":  dysonType,
 		"linear_mode": enabled,
 		"mode":        modeString(enabled),
 		"linear": map[string]any{
@@ -469,6 +477,33 @@ func (r *Relay) apiPutSetting(w http.ResponseWriter, req *http.Request) {
 	if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
 		http.Error(w, `{"error":"invalid json"}`, http.StatusBadRequest)
 		return
+	}
+	// v1 compat: the v1 dyson picker (static/js/main.js) PUTs the legacy key
+	// dyson_type; translate it to the sun_type spec key BEFORE validation so v1
+	// assets stay byte-identical (founder ruling B). "auto"/null -> clear,
+	// "off" -> "0", "1".."7" -> same; anything else -> 400 naming dyson_type; a
+	// body carrying both keys is ambiguous -> 400.
+	if dv, ok := body["dyson_type"]; ok {
+		if _, dup := body["sun_type"]; dup {
+			eb, _ := json.Marshal(map[string]string{"error": "invalid value: dyson_type", "key": "dyson_type", "detail": "send dyson_type or sun_type, not both"})
+			http.Error(w, string(eb), http.StatusBadRequest)
+			return
+		}
+		delete(body, "dyson_type")
+		switch {
+		case dv == nil || *dv == "auto":
+			body["sun_type"] = nil
+		case *dv == "off":
+			z := "0"
+			body["sun_type"] = &z
+		case len(*dv) == 1 && (*dv)[0] >= '1' && (*dv)[0] <= '7':
+			v := *dv
+			body["sun_type"] = &v
+		default:
+			eb, _ := json.Marshal(map[string]string{"error": "invalid value: dyson_type", "key": "dyson_type", "detail": "must be auto, off, or 1..7"})
+			http.Error(w, string(eb), http.StatusBadRequest)
+			return
+		}
 	}
 	// Whole-request validation BEFORE any write: 403 {error:"not writable",key}
 	// for unknown/non-writable keys, 400 {error:"invalid value",key,detail} for

--- a/internal/relay/console_v1_dyson_alias_test.go
+++ b/internal/relay/console_v1_dyson_alias_test.go
@@ -1,0 +1,123 @@
+package relay
+
+import (
+	"strings"
+	"testing"
+
+	"agent-relay/internal/web"
+)
+
+// TestDysonAlias* — founder ruling B (design record 6f73f179 rule e): the v1
+// dyson picker (static/js/main.js) speaks the legacy key `dyson_type`; the
+// server aliases it to the `sun_type` spec key SERVER-SIDE so the v1 assets stay
+// byte-identical. Each test maps to exactly one acceptance criterion.
+
+// AC1: PUT /api/settings translates dyson_type -> sun_type before validation.
+func TestDysonAliasPut(t *testing.T) {
+	r := testRelay(t)
+
+	// "off" -> sun_type "0"
+	if w := doAPI(r, "PUT", "/settings", `{"dyson_type":"off"}`); w.Code != 200 {
+		t.Fatalf(`dyson_type=off: want 200, got %d: %s`, w.Code, w.Body.String())
+	}
+	if got := r.DB.GetSetting("sun_type"); got != "0" {
+		t.Fatalf(`dyson_type=off: sun_type = %q, want "0"`, got)
+	}
+
+	// "5" -> sun_type "5"
+	if w := doAPI(r, "PUT", "/settings", `{"dyson_type":"5"}`); w.Code != 200 {
+		t.Fatalf(`dyson_type=5: want 200, got %d: %s`, w.Code, w.Body.String())
+	}
+	if got := r.DB.GetSetting("sun_type"); got != "5" {
+		t.Fatalf(`dyson_type=5: sun_type = %q, want "5"`, got)
+	}
+
+	// "auto" -> clear (sun_type back to "")
+	r.DB.SetSetting("sun_type", "3")
+	if w := doAPI(r, "PUT", "/settings", `{"dyson_type":"auto"}`); w.Code != 200 {
+		t.Fatalf(`dyson_type=auto: want 200, got %d: %s`, w.Code, w.Body.String())
+	}
+	if got := r.DB.GetSetting("sun_type"); got != "" {
+		t.Fatalf(`dyson_type=auto: sun_type = %q, want "" (cleared)`, got)
+	}
+
+	// bad value -> 400 naming dyson_type
+	w := doAPI(r, "PUT", "/settings", `{"dyson_type":"x"}`)
+	if w.Code != 400 {
+		t.Fatalf(`dyson_type=x: want 400, got %d: %s`, w.Code, w.Body.String())
+	}
+	body := decodeJSON(t, w)
+	if body["key"] != "dyson_type" {
+		t.Fatalf(`dyson_type=x: key = %v, want "dyson_type"`, body["key"])
+	}
+	if body["error"] != "invalid value: dyson_type" {
+		t.Fatalf(`dyson_type=x: error = %v, want "invalid value: dyson_type"`, body["error"])
+	}
+
+	// both keys -> ambiguous 400
+	if w := doAPI(r, "PUT", "/settings", `{"dyson_type":"1","sun_type":"2"}`); w.Code != 400 {
+		t.Fatalf(`dyson_type+sun_type: want 400 (ambiguous), got %d: %s`, w.Code, w.Body.String())
+	}
+}
+
+// AC2: GET /api/settings exposes the flat dyson_type mirror while keeping every
+// v1 field (sun_type default "1", linear_mode, linear, groups, settings).
+func TestDysonAliasGet(t *testing.T) {
+	r := testRelay(t)
+
+	resp := decodeJSON(t, doAPI(r, "GET", "/settings", ""))
+	if resp["dyson_type"] != "auto" {
+		t.Fatalf(`unset: dyson_type = %v, want "auto"`, resp["dyson_type"])
+	}
+	if resp["sun_type"] != "1" {
+		t.Fatalf(`unset: sun_type = %v, want "1"`, resp["sun_type"])
+	}
+	for _, k := range []string{"linear_mode", "linear", "groups", "settings"} {
+		if _, ok := resp[k]; !ok {
+			t.Fatalf("GET /settings missing v1-compatible field %q", k)
+		}
+	}
+
+	r.DB.SetSetting("sun_type", "0")
+	resp = decodeJSON(t, doAPI(r, "GET", "/settings", ""))
+	if resp["dyson_type"] != "off" {
+		t.Fatalf(`sun_type=0: dyson_type = %v, want "off"`, resp["dyson_type"])
+	}
+
+	r.DB.SetSetting("sun_type", "6")
+	resp = decodeJSON(t, doAPI(r, "GET", "/settings", ""))
+	if resp["dyson_type"] != "6" {
+		t.Fatalf(`sun_type=6: dyson_type = %v, want "6"`, resp["dyson_type"])
+	}
+}
+
+// AC3: v1 assets stay byte-identical — the alias is server-side only. The v1
+// picker string is still present in main.js (untouched), and none of the 3 v1
+// assets carries any server-only token from this change.
+func TestV1AssetsUntouched(t *testing.T) {
+	mainJS, err := web.StaticFiles.ReadFile("static/js/main.js")
+	if err != nil {
+		t.Fatalf("read static/js/main.js: %v", err)
+	}
+	if !strings.Contains(string(mainJS), "dyson_type") {
+		t.Fatal("static/js/main.js no longer contains the v1 dyson_type picker key")
+	}
+
+	// The server-only alias error strings must never leak into a shipped asset.
+	serverOnly := []string{
+		"invalid value: dyson_type",
+		"send dyson_type or sun_type, not both",
+		"must be auto, off, or 1..7",
+	}
+	for _, name := range []string{"static/js/main.js", "static/index.html", "static/style.css"} {
+		b, err := web.StaticFiles.ReadFile(name)
+		if err != nil {
+			t.Fatalf("read %s: %v", name, err)
+		}
+		for _, tok := range serverOnly {
+			if strings.Contains(string(b), tok) {
+				t.Fatalf("v1 asset %s leaked server-only token %q", name, tok)
+			}
+		}
+	}
+}

--- a/internal/relay/settings_spec.go
+++ b/internal/relay/settings_spec.go
@@ -61,7 +61,7 @@ func dur(d time.Duration) string { return d.String() }
 // Durations are encoded via time.Duration.String(); ints as decimal strings.
 var settingSpecs = []settingSpec{
 	// ---- Console ----
-	{Key: "sun_type", Group: groupConsole, Kind: kindInt, Source: "db", Writable: true, Min: "1", Default: "1", Note: "console sun/dyson variant index"},
+	{Key: "sun_type", Group: groupConsole, Kind: kindInt, Source: "db", Writable: true, Min: "0", Default: "1", Note: "console sun/dyson variant index (0 = off)"},
 
 	// ---- Linear (7 writable + the RO webhook secret) ----
 	{Key: "linear_enabled", Group: groupLinear, Kind: kindBool, Source: "env", EnvName: "RELAY_LINEAR_MODE", Writable: true, Default: "0"},


### PR DESCRIPTION
### niwa Q&A gate

An adversarial reviewer is reading this diff right now. Its verdict lands on this PR as a review (or a comment when the gate and the author share one GitHub account), and the merge waits for this repository's own checks to go green.

*Opened automatically — a rejected round comes back to the author, who pushes fixes to the same branch.*

## What & why

- **docs(scribe): provenance for wraith-console-v1-founder-b-server-side-alias-dyson-type-sun-type-so-the-v1-dyso**
- **feat: [wraith/relay] T1ab761c2 server-side dyson_type <-> sun_type alias (founder B)**
  <details><summary>details</summary>

  v1 dyson picker (static/js/main.js) speaks the legacy key dyson_type; bridge it
  to the sun_type spec key SERVER-SIDE so v1 assets stay byte-identical.
  
  - apiPutSetting: translate dyson_type -> sun_type before validation.
    auto/null clear, off -> "0", "1".."7" same; bad value -> 400(dyson_type);
    both keys -> 400 (ambiguous).
  - settingsResponse: add flat dyson_type mirror ("" -> auto, "0" -> off, else raw);
    flat sun_type keeps "1" default unchanged.
  - settings_spec.go: sun_type Min "0" (0 = off) so the off state validates.
  
  Tests: TestDysonAliasPut/Get/V1AssetsUntouched (3 ACs). go test -tags fts5 green.
  
  Claude-Session: https://claude.ai/code/session_01XbzhXo1kXCNX9qC6jaZ6pp

  </details>

## Changes

<details><summary>Files changed (git diff --stat)</summary>

```
...ide-alias-dyson-type-sun-type-so-the-v1-dyso.md |  69 ++++++++++++
 internal/relay/api.go                              |  37 ++++++-
 internal/relay/console_v1_dyson_alias_test.go      | 123 +++++++++++++++++++++
 internal/relay/settings_spec.go                    |   2 +-
 4 files changed, 229 insertions(+), 2 deletions(-)
```

</details>

## Module graph

```mermaid
graph TD
  n0["features/wraith-console-v1-founder-b-server-side-alias-dyson-type-sun-type-so-the-v1-dyso.md"]
  n1["internal/relay"]
```

## Acceptance criteria

- [x] AC1 TestDysonAliasPut: PUT {dyson_type:"off"} -> 200 and stored sun_type == "0"; PUT {dyson_type:"5"} -> stored sun_type == "5"; PUT {dyson_type:"auto"} -> sun_type cleared; PUT {dyson_type:"x"} -> 400 naming key dyson_type; body with both dyson_type and sun_type -> 400
- [x] AC2 TestDysonAliasGet: flat GET /api/settings exposes dyson_type mapped auto/off/n from stored sun_type, and the v1 fields (sun_type default "1", linear_mode, linear{}) plus groups/settings stay byte-compatible
- [x] AC3 TestV1AssetsUntouched: internal/web/static/js/main.js, index.html, style.css byte-identical to main; existing TestSettingsSpec*/TestV2ConfigPanel green; go test -tags fts5 ./internal/relay/... green
## Provenance

📄 [Root cause, decisions &amp; QA log — `features/wraith-console-v1-founder-b-server-side-alias-dyson-type-sun-type-so-the-v1-dyso.md`](https://github.com/TsukumoHQ/WRAI.TH/blob/wraith-engine-2/v1-dyson-alias/features/wraith-console-v1-founder-b-server-side-alias-dyson-type-sun-type-so-the-v1-dyso.md)

## Gate verdict

**✅ APPROVED** · round 2 · reviewer `review-1ab761c2-d4d7-40dc-be5e-11cfdebf1fcd`

## review-wraith verdict: SHIP
Scope: internal/relay/api.go (settingsResponse + apiPutSetting alias), internal/relay/settings_spec.go (sun_type Min "0"), NEW internal/relay/console_v1_dyson_alias_test.go
Gate: build -tags fts5 OK / vet OK / gofmt OK / test -tags fts5 OK (483 pass)

BLOCKERS (must fix before merge):
- none

NITS (non-blocking):
- dyson_type raw "0" → 400 by design (picker sends "off", never "0"); GET maps stored "0"→"off" so round-trip stays consistent.
## review-wraith verdict: SHIP
Scope: internal/relay/api.go (settingsResponse + apiPutSetting alias), internal/relay/settings_spec.go (sun_type Min "0"), NEW internal/relay/console_v1_dyson_alias_test.go
Gate: build -tags fts5 OK / vet OK / gofmt OK / test -tags fts5 OK (483 pass)

BLOCKERS (must fix before merge):
- none

NITS (non-blocking):
- dyson_type raw "0" → 400 by design (picker sends "off", never "0"); GET maps stored "0"→"off" so round-trip stays consistent.
## review-wraith verdict: SHIP
Scope: internal/relay/api.go (settingsResponse + apiPutSetting alias), internal/relay/settings_spec.go (sun_type Min "0"), NEW internal/relay/console_v1_dyson_alias_test.go
Gate: build -tags fts5 OK / vet OK / gofmt OK / test -tags fts5 OK (483 pass)

BLOCKERS (must fix before merge):
- none

NITS (non-blocking):
- dyson_type raw "0" → 400 by design (picker sends "off", never "0"); GET maps stored "0"→"off" so round-trip stays consistent.

---
<sub>Authored by agent `wraith-engine-2` · branch `wraith-engine-2/v1-dyson-alias` → `main` · reviewed by niwa-gate and merged when this repo's checks pass.</sub>

## Schéma

```mermaid
flowchart TD
    A["HTTP PUT\nbody: {dyson_type}"] --> B["apiPutSetting"]
    B --> C["Parse JSON"]
    C --> D{dyson_type\nin body?}
    D -->|No| E["Use as-is"]
    D -->|Yes| F{sun_type also\nin body?}
    F -->|Both| G["400 error\nambiguous"]
    F -->|Only dyson_type| H["Translate\nto sun_type"]
    H --> I{dyson_type\nvalue?}
    I -->|auto/null| J["sun_type = nil"]
    I -->|off| K["sun_type = '0'"]
    I -->|1..7| L["sun_type = value"]
    I -->|else| M["400 error\ninvalid"]
    E --> N["validateSettings"]
    J --> N
    K --> N
    L --> N
    N --> O["DB.SetSetting"]
    G --> P["Error response"]
    M --> P
    O --> Q["200 OK"]
```

```mermaid
flowchart TD
    A["HTTP GET\n/api/settings"] --> B["apiGetSettings"]
    B --> C["settingsResponse"]
    C --> D["storedSun =\nDB.GetSetting"]
    D --> E{storedSun\nvalue}
    E -->|empty| F["dyson_type: auto\nsun_type: 1"]
    E -->|0| G["dyson_type: off\nsun_type: 0"]
    E -->|1..7| H["dyson_type: value\nsun_type: value"]
    F --> I["Response map:\ndyson_type +\nsun_type +\nlinear_mode..."]
    G --> I
    H --> I
    I --> J["200 OK"]
```
