### PR TITLE
[split][wraith/console-identity][founder P1] one operator identity end to end, server half: every guard/default that special-cases "user" also accepts "human"; "human" is the canonical operator

### DIFF
--- a/features/split-wraith-console-identity-founder-p1-one-operator-identity-end-to-end-server.md
+++ b/features/split-wraith-console-identity-founder-p1-one-operator-identity-end-to-end-server.md
@@ -1,0 +1,81 @@
+# [split][wraith/console-identity][founder P1] one operator identity end to end, server half: every guard/default that special-cases "user" also accepts "human"; "human" is the canonical operator
+
+## Team : wraith-backend-2 (tsukumo)
+## Branch : wraith-backend-2/operator-identity-server (from main)
+## Relay task : c5e67397-d09e-4d48-a0bd-a8f4a8b65904
+## Status : 🔵 SUBMITTED
+
+## 1. Product Brief
+
+### Acceptance Criteria
+- [ ] 1. AC1 TestOperatorReachableAsHuman: with teams configured in the project, POST /api/messages and MCP send_message from an agent to "human" succeed (message + delivery created) exactly like to "user"; to an unrelated agent still 403
+- [ ] 2. AC2 TestOperatorForcePathHuman: TransitionTask with agentName "human" bypasses validTransitions exactly like "user" (e.g. done -> in-progress allowed); a regular agent name is still refused
+- [ ] 3. AC3 TestOperatorDefaultsHuman: apiPostMemory without agent_name stores agent_name "human"; resolveTargets("human") == resolveTargets("user") unchanged; go test -tags fts5 ./internal/relay/... ./internal/db/... green; diff = exactly the 5 listed files
+
+## 2. Root cause & decisions
+
+# Decision — one operator identity, server half (task c5e67397)
+
+## ROOT_CAUSE
+#193 made the console SEND as "human", but the server still special-cased only
+"user" in three reachability/authority spots, so under the new identity: an agent
+could not answer the operator (direct-send reachability guards 403'd a send TO
+"human" when teams exist), and the console acting as "human" lost the admin
+force-path on task transitions. apiPostMemory also defaulted the writer to "user".
+
+## FIX (5 files, exactly the ticket files line)
+- internal/relay/api_messages.go: add `isOperator(name) = name=="user"||name=="human"`;
+  REST direct-send guard bypasses for either identity.
+- internal/relay/handlers_messaging.go: MCP send_message guard uses isOperator.
+- internal/db/tasks.go: `transitionTask` force-path granted to "human" too
+  (package db cannot import the relay helper, so the predicate is inlined).
+- internal/relay/api.go: apiPostMemory default agent_name "user" -> "human".
+- resolveTargets UNTOUCHED (already maps human/user -> ["user"], the read alias);
+  "user" kept everywhere. No schema, no migration, no asset change.
+
+## ACs
+- AC1 TestOperatorReachableAsHuman: teams configured; bot-a -> "human" via REST
+  POST /api/messages AND MCP send_message both succeed like "user"; -> unrelated 403.
+- AC2 TestOperatorForcePathHuman: force done->in-progress as "human" allowed like
+  "user"; a regular agent name refused.
+- AC3 TestOperatorDefaultsHuman: apiPostMemory with no agent_name stored under
+  "human"; resolveTargets("human")==resolveTargets("user").
+- verify green: `go test -tags fts5 ./internal/relay/... ./internal/db/...` = 811 pass.
+- diff = exactly the 5 listed files (rebased onto main 45090bf, no overlap).
+
+## review-wraith verdict: SHIP
+- Build bar: fts5/CGO suite green, 811 pass across relay+db.
+- Single-writer / lock discipline: no DB writer or lock change; transitionTask body
+  unchanged except widening the force-path predicate by one disjunct.
+- agentColumns<->scanAgent lockstep: untouched.
+- Task-transition TOCTOU / double-claim: force-path only skips validTransitions for
+  the operator identities (admin), same as the pre-existing "user" behaviour — no new
+  claim path, no CAS change.
+- Non-destructive inbox: unchanged.
+- Schema: no migration, no schema change.
+- Blast radius: 3 predicate widenings (2 reachability guards + 1 force-path) + 1
+  default flip; "user" preserved so no existing caller regresses; resolveTargets
+  alias keeps delivery routing identical.
+
+VERDICT: SHIP.
+
+## 3. Files changed
+
+```
+internal/db/tasks.go                     |  7 +++-
+ internal/relay/api.go                    |  2 +-
+ internal/relay/api_messages.go           | 10 ++++-
+ internal/relay/handlers_messaging.go     |  2 +-
+ internal/relay/operator_identity_test.go | 70 ++++++++++++++++++++++++++++++++
+ 5 files changed, 86 insertions(+), 5 deletions(-)
+```
+
+## 4. QA Log
+
+_(no review round yet)_
+
+## 5. Timeline
+
+
+---
+_Auto-assembled by the niwa scribe from the Q&A gate. Task `c5e67397-d09e-4d48-a0bd-a8f4a8b65904`._

--- a/internal/db/tasks.go
+++ b/internal/db/tasks.go
@@ -590,8 +590,11 @@ func (d *DB) transitionTask(taskID, agentName, project, newStatus string, result
 		return nil, fmt.Errorf("task not found: %s", taskID)
 	}
 
-	// Validate transition (skip for user — admin can force any move)
-	if agentName != "user" {
+	// Validate transition (skip for the operator — admin can force any move).
+	// The operator identity is "human" (canonical) or "user" (legacy alias);
+	// both keep the console's admin force-path. Package db cannot import the
+	// relay helper, so the predicate is inlined.
+	if agentName != "user" && agentName != "human" {
 		allowed := validTransitions[task.Status]
 		valid := false
 		for _, s := range allowed {

--- a/internal/relay/api.go
+++ b/internal/relay/api.go
@@ -1083,7 +1083,7 @@ func (r *Relay) apiPostMemory(w http.ResponseWriter, req *http.Request) {
 		body.Project = "default"
 	}
 	if body.AgentName == "" {
-		body.AgentName = "user"
+		body.AgentName = "human"
 	}
 	if body.Scope == "" {
 		body.Scope = "project"

--- a/internal/relay/api_messages.go
+++ b/internal/relay/api_messages.go
@@ -10,6 +10,14 @@ import (
 	"agent-relay/internal/db"
 )
 
+// isOperator reports whether name is the human operator under either identity:
+// the canonical "human" or the legacy "user" alias. Both are always reachable
+// (they bypass the teams CanMessage gate), so an agent can answer the operator
+// regardless of which identity the console last used.
+func isOperator(name string) bool {
+	return name == "user" || name == "human"
+}
+
 // apiListQuotas returns the per-agent quotas for a project. Path: GET /api/quotas
 func (r *Relay) apiListQuotas(w http.ResponseWriter, req *http.Request) {
 	project := req.URL.Query().Get("project")
@@ -193,7 +201,7 @@ func (r *Relay) apiPostMessage(w http.ResponseWriter, req *http.Request) {
 	}
 	// Permission: when teams are configured, a direct send needs a path
 	// (shared team / reports_to / notify channel). "user" + broadcast + team: handled below.
-	if to != "*" && to != "user" && !strings.HasPrefix(to, "team:") {
+	if to != "*" && !isOperator(to) && !strings.HasPrefix(to, "team:") {
 		if hasTeams, _ := r.DB.HasTeams(project); hasTeams {
 			if allowed, _ := r.DB.CanMessage(project, from, to); !allowed {
 				jsonError(w, http.StatusForbidden, "not authorized to message '"+to+"' (no shared team / reports_to / notify channel)")

--- a/internal/relay/handlers_messaging.go
+++ b/internal/relay/handlers_messaging.go
@@ -109,7 +109,7 @@ func (h *Handlers) HandleSendMessage(ctx context.Context, req mcp.CallToolReques
 	}
 
 	// Permission check: only enforce when teams are configured (bypass for "user" — always reachable)
-	if conversationID == nil && to != "*" && to != "user" && !strings.HasPrefix(to, "team:") {
+	if conversationID == nil && to != "*" && !isOperator(to) && !strings.HasPrefix(to, "team:") {
 		hasTeams, _ := h.db.HasTeams(project)
 		if hasTeams {
 			allowed, err := h.db.CanMessage(project, from, to)

--- a/internal/relay/operator_identity_test.go
+++ b/internal/relay/operator_identity_test.go
@@ -1,0 +1,70 @@
+package relay
+
+import (
+	"testing"
+
+	"agent-relay/internal/db"
+)
+
+// One operator identity end to end (founder P1): the human operator is reachable
+// and admin-privileged under the canonical "human" as well as the legacy "user".
+// One test per acceptance criterion.
+
+// AC1: with teams configured, an agent reaches "human" via both the REST and MCP
+// send paths exactly like "user"; a send to an unrelated agent still 403s.
+func TestOperatorReachableAsHuman(t *testing.T) {
+	r := testRelay(t)
+	_, _, _ = r.DB.RegisterAgent("p1", "bot-a", "dev", "", nil, nil, false, nil, "[]", 0, db.RegisterOptions{})
+	_, _ = r.DB.CreateTeam("ops", "ops", "p1", "", "", nil, nil) // HasTeams => guard engages
+	for _, to := range []string{"human", "user"} {
+		if w := doAPI(r, "POST", "/messages", `{"project":"p1","from":"bot-a","to":"`+to+`","content":"hi"}`); w.Code != 200 {
+			t.Fatalf("REST bot-a->%s = %d %s", to, w.Code, w.Body.String())
+		}
+		if res, _ := r.Handlers.HandleSendMessage(ctx, call(map[string]any{"project": "p1", "as": "bot-a", "to": to, "content": "hi"})); res.IsError {
+			t.Fatalf("MCP bot-a->%s errored: %s", to, expectError(t, res))
+		}
+	}
+	if w := doAPI(r, "POST", "/messages", `{"project":"p1","from":"bot-a","to":"bot-z","content":"hi"}`); w.Code != 403 {
+		t.Fatalf("bot-a->unrelated should 403, got %d", w.Code)
+	}
+}
+
+// AC2: a transition driven by "human" takes the admin force-path (an otherwise
+// invalid done->in-progress move is allowed) exactly like "user"; a regular
+// agent name is still refused.
+func TestOperatorForcePathHuman(t *testing.T) {
+	r := testRelay(t)
+	task, err := r.DB.DispatchTask("p1", "dev", "boss", "t", "", "P2", nil, nil, db.TypedTicket{}, false, nil)
+	if err != nil {
+		t.Fatalf("dispatch: %v", err)
+	}
+	if _, err := r.DB.CompleteTask(task.ID, "human", "p1", nil); err != nil { // force -> done
+		t.Fatalf("human force to done: %v", err)
+	}
+	if _, err := r.DB.StartTask(task.ID, "human", "p1"); err != nil { // done -> in-progress (invalid, forced)
+		t.Fatalf("human force done->in-progress: %v", err)
+	}
+	if _, err := r.DB.CompleteTask(task.ID, "human", "p1", nil); err != nil {
+		t.Fatalf("reset to done: %v", err)
+	}
+	if _, err := r.DB.StartTask(task.ID, "bot-a", "p1"); err == nil {
+		t.Fatalf("regular agent done->in-progress must be refused")
+	}
+}
+
+// AC3: apiPostMemory with no agent_name defaults to "human"; resolveTargets keeps
+// "human" and "user" pointed at the same delivery target.
+func TestOperatorDefaultsHuman(t *testing.T) {
+	r := testRelay(t)
+	if w := doAPI(r, "POST", "/memories", `{"project":"p1","key":"k1","value":"v1"}`); w.Code != 200 {
+		t.Fatalf("post memory = %d %s", w.Code, w.Body.String())
+	}
+	got, err := r.DB.GetMemory("p1", "human", "k1", "project")
+	if err != nil || len(got) == 0 {
+		t.Fatalf("memory not stored under human (err=%v n=%d)", err, len(got))
+	}
+	n := &Notifier{}
+	if h, u := n.resolveTargets("p1", "human", nil), n.resolveTargets("p1", "user", nil); len(h) != 1 || len(u) != 1 || h[0] != u[0] {
+		t.Fatalf("resolveTargets human=%v user=%v, want equal single target", h, u)
+	}
+}


### PR DESCRIPTION
### niwa Q&A gate

An adversarial reviewer is reading this diff right now. Its verdict lands on this PR as a review (or a comment when the gate and the author share one GitHub account), and the merge waits for this repository's own checks to go green.

*Opened automatically — a rejected round comes back to the author, who pushes fixes to the same branch.*

## What & why

- **docs(scribe): provenance for split-wraith-console-identity-founder-p1-one-operator-identity-end-to-end-server**
- **fix: [wraith/relay+db] operator identity — guards/defaults accept "human" not just "user"**
  <details><summary>details</summary>

  Founder P1: the console now sends as "human" (#193), but several server
  guards/defaults still special-cased only "user", so under the new identity an
  agent could not answer the operator and the console lost its admin force-path.
  
  - internal/relay/api_messages.go: add isOperator(name) = user|human; REST direct-
    send reachability guard bypasses for either identity.
  - internal/relay/handlers_messaging.go: MCP send_message guard uses isOperator.
  - internal/db/tasks.go: transitionTask force-path (admin can force any move) now
    granted to "human" as well as "user" (pkg db, predicate inlined).
  - internal/relay/api.go: apiPostMemory default agent_name "user" -> "human".
  - resolveTargets untouched (already maps human/user -> [user]); "user" kept
    everywhere. No schema, no migration, no asset change.
  
  Tests: TestOperatorReachableAsHuman, TestOperatorForcePathHuman,
  TestOperatorDefaultsHuman. go test -tags fts5 ./internal/relay/... ./internal/db/...
  green (811).
  
  Claude-Session: https://claude.ai/code/session_01PrKgY1PpQX9DTAF7HGAsAB

  </details>

## Changes

<details><summary>Files changed (git diff --stat)</summary>

```
...r-p1-one-operator-identity-end-to-end-server.md | 81 ++++++++++++++++++++++
 internal/db/tasks.go                               |  7 +-
 internal/relay/api.go                              |  2 +-
 internal/relay/api_messages.go                     | 10 ++-
 internal/relay/handlers_messaging.go               |  2 +-
 internal/relay/operator_identity_test.go           | 70 +++++++++++++++++++
 6 files changed, 167 insertions(+), 5 deletions(-)
```

</details>

## Module graph

```mermaid
graph TD
  n0["features/split-wraith-console-identity-founder-p1-one-operator-identity-end-to-end-server.md"]
  n1["internal/db"]
  n2["internal/relay"]
  n1 --- n2
```

## Acceptance criteria

- [x] AC1 TestOperatorReachableAsHuman: with teams configured in the project, POST /api/messages and MCP send_message from an agent to "human" succeed (message + delivery created) exactly like to "user"; to an unrelated agent still 403
- [x] AC2 TestOperatorForcePathHuman: TransitionTask with agentName "human" bypasses validTransitions exactly like "user" (e.g. done -> in-progress allowed); a regular agent name is still refused
- [x] AC3 TestOperatorDefaultsHuman: apiPostMemory without agent_name stores agent_name "human"; resolveTargets("human") == resolveTargets("user") unchanged; go test -tags fts5 ./internal/relay/... ./internal/db/... green; diff = exactly the 5 listed files
## Provenance

📄 [Root cause, decisions &amp; QA log — `features/split-wraith-console-identity-founder-p1-one-operator-identity-end-to-end-server.md`](https://github.com/TsukumoHQ/WRAI.TH/blob/wraith-backend-2/operator-identity-server/features/split-wraith-console-identity-founder-p1-one-operator-identity-end-to-end-server.md)

## Gate verdict

**✅ APPROVED** · round 1 · reviewer `review-c5e67397-d09e-4d48-a0bd-a8f4a8b65904`

## review-wraith verdict: SHIP
- Build bar: fts5/CGO suite green, 811 pass across relay+db.
- Single-writer / lock discipline: no DB writer or lock change; transitionTask body
  unchanged except widening the force-path predicate by one disjunct.
- agentColumns<->scanAgent lockstep: untouched.
- Task-transition TOCTOU / double-claim: force-path only skips validTransitions for
  the operator identities (admin), same as the pre-existing "user" behaviour — no new
  claim path, no CAS change.
- Non-destructive inbox: unchanged.
- Schema: no migration, no schema change.
- Blast radius: 3 predicate widenings (2 reachability guards + 1 force-path) + 1
  default flip; "user" preserved so no existing caller regresses; resolveTargets
  alias keeps delivery routing identical.

VERDICT: SHIP.
## review-wraith verdict: SHIP
- Build bar: fts5/CGO suite green, 811 pass across relay+db.
- Single-writer / lock discipline: no DB writer or lock change; transitionTask body
  unchanged except widening the force-path predicate by one disjunct.
- agentColumns<->scanAgent lockstep: untouched.
- Task-transition TOCTOU / double-claim: force-path only skips validTransitions for
  the operator identities (admin), same as the pre-existing "user" behaviour — no new
  claim path, no CAS change.
- Non-destructive inbox: unchanged.
- Schema: no migration, no schema change.
- Blast radius: 3 predicate widenings (2 reachability guards + 1 force-path) + 1
  default flip; "user" preserved so no existing caller regresses; resolveTargets
  alias keeps delivery routing identical.

VERDICT: SHIP.

---
<sub>Authored by agent `wraith-backend-2` · branch `wraith-backend-2/operator-identity-server` → `main` · reviewed by niwa-gate and merged when this repo's checks pass.</sub>
