### PR TITLE
[split][wraith/ext-triage] PR #152 reject unknown send_message recipient instead of silent-accept — rebase on main, review, gate

### DIFF
--- a/features/split-wraith-ext-triage-pr-152-reject-unknown-send-message-recipient-instead-of-.md
+++ b/features/split-wraith-ext-triage-pr-152-reject-unknown-send-message-recipient-instead-of-.md
@@ -80,20 +80,27 @@ NITS (non-blocking):
 ## 3. Files changed
 
 ```
-internal/relay/ext_pr152_recipient_test.go |  81 ++++++++++++++
- internal/relay/handlers.go                 |  10 +-
- internal/relay/handlers_messaging.go       |  32 ++++++
- internal/relay/handlers_test.go            | 170 +++++++++++++++++++++++++++++
- internal/relay/suggest.go                  | 170 +++++++++++++++++++++++++++++
- 5 files changed, 461 insertions(+), 2 deletions(-)
+...t-unknown-send-message-recipient-instead-of-.md |  99 ++++++++++++
+ internal/relay/ext_pr152_recipient_test.go         |  81 ++++++++++
+ internal/relay/handlers.go                         |  10 +-
+ internal/relay/handlers_messaging.go               |  32 ++++
+ internal/relay/handlers_test.go                    | 170 +++++++++++++++++++++
+ internal/relay/suggest.go                          | 170 +++++++++++++++++++++
+ 6 files changed, 560 insertions(+), 2 deletions(-)
 ```
 
 ## 4. QA Log
 
-_(no review round yet)_
+### Round 1 — ✅ APPROVED by review-54ea39d8-1bbd-4efe-a363-b9792b5d0d61 @ `05d21398f`
+- 🟢 AC1: guard fires on GetAgent==nil or status==deleted, message row never inserted because error returns before insert path — evidence: handlers_messaging.go:122-141 early-returns toolResultError(unknownRecipientError(...)) before InsertMessageWithDeliveries; error names the recipient — test: TestSendMessageUnknownRecipientRejected internal/relay/handlers_test.go:404-415
+- 🟢 AC2: test asserts no IsError and a persisted message id for all four recipients, plus inbox delivery for broadcast/team — evidence: handlers_messaging.go:122 exempts to in {*, user, human, team:*}; human/user hit ResolveRecipients direct path, team: hits team-fanout branch — same as baseline d35ab8c — test: TestSendMessageKnownNonAgentRecipientsStillAccepted internal/relay/ext_pr152_recipient_test.go:13-58
+- 🟢 AC3: behavioral half pins project-scoped ListAgents (no cross-project leak); structural halves (scope + author + green build) verified at the gate — evidence: diff 4 PR source files + 1 added test file matches plan files: scope OK; original author Jérôme Chincarini preserved on 207b9b1; validate command green — test: TestExtPR152DiffScope internal/relay/ext_pr152_recipient_test.go:60-81 + go test ./internal/relay/... ./internal/db/... exit=0
 
 ## 5. Timeline
 
+- round 1 → **approve** (review-54ea39d8-1bbd-4efe-a363-b9792b5d0d61)
+
+**Approve-with-findings (follow-up):** go test -tags fts5 ./internal/relay/... ./internal/db/... green (819 passed); AC1 reject guard at handlers_messaging.go:122-141 pins TestSendMessageUnknownRecipientRejected; AC2 'human'+'user' exemption at handlers_messaging.go:122 + RecipientIsFleetExpected deferral at 132-135 pin TestSendMessageKnownNonAgentRecipientsStillAccepted (4 cases: *, team:dev, user, human) + TestSendMessageQueuesForFleetExpectedRecipient; AC3 unknownRecipientError project-scoped ListAgents pins TestExtPR152DiffScope cross-project leak; original author jchincarini preserved on 207b9b1; diff 4 PR source files + 1 added test file matches plan
 
 ---
 _Auto-assembled by the niwa scribe from the Q&A gate. Task `54ea39d8-1bbd-4efe-a363-b9792b5d0d61`._

--- a/features/split-wraith-ext-triage-pr-152-reject-unknown-send-message-recipient-instead-of-.md
+++ b/features/split-wraith-ext-triage-pr-152-reject-unknown-send-message-recipient-instead-of-.md
@@ -1,0 +1,99 @@
+# [split][wraith/ext-triage] PR #152 reject unknown send_message recipient instead of silent-accept — rebase on main, review, gate
+
+## Team : wraith-engine-2 (tsukumo)
+## Branch : wraith-engine-2/ext-152 (from main)
+## Relay task : 54ea39d8-1bbd-4efe-a363-b9792b5d0d61
+## Status : 🔵 SUBMITTED
+
+## 1. Product Brief
+
+### Acceptance Criteria
+- [ ] 1. AC1 TestSendMessageUnknownRecipientRejected: send_message to a name that is neither an agent, a team, '*', 'human'/'user' nor a federation peer in the project returns an error naming the recipient and inserts no message row
+- [ ] 2. AC2 TestSendMessageKnownNonAgentRecipientsStillAccepted: '*' broadcast, an existing team name, 'human' and 'user' each still create the message + deliveries exactly as on main d35ab8c
+- [ ] 3. AC3 TestExtPR152DiffScope: go test -tags fts5 ./internal/relay/... ./internal/db/... green; diff limited to the PR's files (+ one test file); original author kept as commit author
+
+## 2. Root cause & decisions
+
+# T54ea39d8 — ext-triage PR #152: reject unknown send_message recipient
+
+## Root cause
+send_message accepted ANY `to`: a name nobody registered returned a message-id,
+zero deliveries were written, nobody was ever alerted — a silent black hole
+(the CTO's live incident). External PR #152 (author Jérôme Chincarini) adds an
+up-front guard that rejects an unknown recipient with a suggestion.
+
+## Decision
+Rebase PR #152 onto main 45090bf, keep the author's commit + authorship, resolve
+the one handlers.go conflict, then fix two regressions the guard introduced and
+add the missing AC coverage — all in a SEPARATE commit on top of the author's.
+
+Conflict (handlers.go sendCrossProject): main renamed mcp.NewToolResultError →
+the canonical `toolResultError` envelope; kept the PR's richer guard
+(unknownCrossProjectRecipientError + soft-deleted check) expressed via that helper.
+
+Regressions fixed (my commit 8e4b8b1, on top of the author's 207b9b1):
+1. `human`: the console operator inbox, twin of `user` (resolveTargets maps both
+   to the same target). The unconditional guard rejected it — now exempted like
+   `user`. (Aligns with the incoming operator-identity work, task ea0cc293.)
+2. Fleet-expected boot-race: a name dispatched a task (profile_slug=name) before
+   it registers must QUEUE, not be rejected (task 0464d6cb) — the guard now
+   defers to RecipientIsFleetExpected before rejecting a nil row, mirroring the
+   permission block below. This restored the pre-existing
+   TestSendMessageQueuesForFleetExpectedRecipient which the blanket reject broke.
+3. Envelope consistency: the author's new guard used raw mcp.NewToolResultError,
+   bypassing the canonical typed error envelope every other path uses
+   (errors.go) — routed through toolResultError.
+
+## Requirement review (task-mandated, messaging surface)
+- (i) unknown recipient rejected, error names it + suggestion — YES (guard + suggest.go).
+- (ii) non-agent recipients still work: `*`, `team:<slug>`, `user`, `human`,
+  fleet-expected boot-race — YES (exemptions + fleet-expected fix), pinned by
+  TestSendMessageKnownNonAgentRecipientsStillAccepted.
+- (iii) "did you mean" never leaks another project's roster — YES:
+  unknownRecipientError uses ListAgents(caller project),
+  unknownCrossProjectRecipientError uses ListAgents(target project); pinned by
+  TestExtPR152DiffScope.
+
+## Original failing check
+The PR's one red check was goimports/gofmt drift on migrate_projects_test.go
+under go1.25 (fixed by the author's 2nd commit f48538c). That gofmt change is
+already upstream on main, so the rebase DROPPED that commit ("patch contents
+already upstream"); migrate_projects_test.go is untouched here.
+
+## ACs → tests
+- AC1 unknown rejected, names recipient, no row → TestSendMessageUnknownRecipientRejected (author's)
+- AC2 *, team, user, human still accepted → TestSendMessageKnownNonAgentRecipientsStillAccepted
+- AC3 build+test green, scope, author kept, no cross-project leak → TestExtPR152DiffScope
+
+## review-wraith verdict: SHIP
+Scope: internal/relay/handlers.go, handlers_messaging.go, handlers_test.go, suggest.go, NEW ext_pr152_recipient_test.go
+Gate: build -tags fts5 OK / vet OK / gofmt OK / test -tags fts5 relay+db OK (819 pass)
+
+BLOCKERS (must fix before merge):
+- none
+
+NITS (non-blocking):
+- Federation-peer / bare-role (`cto`/`founder`) recipients: not delivered through this
+  bare-`to` path in current code, so unaffected by the guard; not separately tested.
+  Flagged to cto — if a future path addresses them literally, revisit the exemption set.
+
+## 3. Files changed
+
+```
+internal/relay/ext_pr152_recipient_test.go |  81 ++++++++++++++
+ internal/relay/handlers.go                 |  10 +-
+ internal/relay/handlers_messaging.go       |  32 ++++++
+ internal/relay/handlers_test.go            | 170 +++++++++++++++++++++++++++++
+ internal/relay/suggest.go                  | 170 +++++++++++++++++++++++++++++
+ 5 files changed, 461 insertions(+), 2 deletions(-)
+```
+
+## 4. QA Log
+
+_(no review round yet)_
+
+## 5. Timeline
+
+
+---
+_Auto-assembled by the niwa scribe from the Q&A gate. Task `54ea39d8-1bbd-4efe-a363-b9792b5d0d61`._

--- a/internal/relay/ext_pr152_recipient_test.go
+++ b/internal/relay/ext_pr152_recipient_test.go
@@ -1,0 +1,81 @@
+package relay
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestSendMessageKnownNonAgentRecipientsStillAccepted backs AC2: the unknown-
+// recipient guard must NOT swallow the recipients that are valid today without
+// being agent rows — '*' broadcast, a team channel, and the console operator
+// inbox addressed as either "user" or its twin "human". Each must still create
+// the message (and its deliveries), exactly as before the guard.
+func TestSendMessageKnownNonAgentRecipientsStillAccepted(t *testing.T) {
+	h := testHandlers(t)
+	// is_executive so the sender may broadcast ('*' needs admin-team membership);
+	// the unknown-recipient guard under test is orthogonal to that permission.
+	_, _ = h.HandleRegisterAgent(ctx, call(map[string]any{"project": "p1", "name": "sender", "is_executive": true}))
+	_, _ = h.HandleRegisterAgent(ctx, call(map[string]any{"project": "p1", "name": "peer"}))
+	_, _ = h.HandleCreateTeam(ctx, call(map[string]any{"project": "p1", "name": "Dev Team", "slug": "dev"}))
+	_, _ = h.HandleAddTeamMember(ctx, call(map[string]any{"project": "p1", "team": "dev", "agent_name": "peer"}))
+
+	cases := []struct {
+		name string
+		to   string
+	}{
+		{"broadcast", "*"},
+		{"team", "team:dev"},
+		{"user", "user"},
+		{"human", "human"},
+	}
+	for _, c := range cases {
+		res, _ := h.HandleSendMessage(ctx, call(map[string]any{
+			"project": "p1", "as": "sender", "to": c.to, "content": "hi " + c.name,
+		}))
+		if res.IsError {
+			t.Fatalf("send to %q (%s) must be accepted, got error: %s", c.to, c.name, expectError(t, res))
+		}
+		msg := parseJSON(t, res)
+		if msg["id"] == nil || msg["id"] == "" {
+			t.Fatalf("send to %q must return a persisted message id, got %v", c.to, msg)
+		}
+	}
+
+	// The broadcast actually reached the registered peer (a delivery was made).
+	inbox, _ := h.HandleGetInbox(ctx, call(map[string]any{"project": "p1", "as": "peer", "format": "json"}))
+	data := parseJSON(t, inbox)
+	if msgs, _ := data["messages"].([]any); len(msgs) == 0 {
+		t.Fatalf("broadcast + team send should have delivered to 'peer', inbox empty: %v", data)
+	}
+}
+
+// TestExtPR152DiffScope backs AC3. The build/diff-scope/author-preserved half is
+// enforced at the gate; the testable half is requirement (iii): the "did you
+// mean" suggestion on an unknown recipient must be drawn from the CALLER's
+// project roster only, never leaking agents registered in another project.
+func TestExtPR152DiffScope(t *testing.T) {
+	h := testHandlers(t)
+	// Sender + an executive so hasTeams is set and the guard path is live.
+	_, _ = h.HandleRegisterAgent(ctx, call(map[string]any{"project": "p1", "name": "cto", "is_executive": true}))
+	_, _ = h.HandleRegisterAgent(ctx, call(map[string]any{"project": "p1", "name": "sender"}))
+	// A distinctively named agent that exists ONLY in another project. p1 holds
+	// no name within Levenshtein 2 of it, so a correct, project-scoped
+	// suggestion yields NO "Did you mean" clause — but if suggestions wrongly
+	// drew from p2's roster, this exact name (distance 0) would be offered.
+	const foreign = "zzforeignpeer"
+	_, _ = h.HandleRegisterAgent(ctx, call(map[string]any{"project": "p2", "name": foreign}))
+
+	res, _ := h.HandleSendMessage(ctx, call(map[string]any{
+		"project": "p1", "as": "sender", "to": foreign, "content": "leak?",
+	}))
+	if !res.IsError {
+		t.Fatalf("send to a recipient that exists only in another project must be rejected in p1")
+	}
+	errStr := expectError(t, res)
+	if !strings.Contains(errStr, foreign) {
+		t.Fatalf("rejection should name the unknown recipient %q, got: %s", foreign, errStr)
+	}
+	if strings.Contains(errStr, "Did you mean") {
+		t.Fatalf("cross-project leak: p1 rejection offered a suggestion drawn from p2's roster: %s", errStr)
+	}
+}

--- a/internal/relay/handlers.go
+++ b/internal/relay/handlers.go
@@ -348,8 +348,14 @@ func (h *Handlers) sendCrossProject(ctx context.Context, srcProject, from, dstPr
 
 	// Validate target exists and is executive
 	target, err := h.db.GetAgent(dstProject, to)
-	if err != nil || target == nil {
-		return toolResultError(fmt.Sprintf("target '%s' not found in project '%s'", to, dstProject)), nil
+	if err != nil {
+		return toolResultError(fmt.Sprintf("failed to resolve target '%s' in project '%s': %v", to, dstProject, err)), nil
+	}
+	// Same guard as the local send path: a target that was never registered
+	// (or was soft-deleted) in the destination project is rejected rather than
+	// silently accepted — see unknownCrossProjectRecipientError.
+	if target == nil || target.Status == "deleted" {
+		return toolResultError(h.unknownCrossProjectRecipientError(dstProject, to)), nil
 	}
 	if !target.IsExecutive {
 		return toolResultError(fmt.Sprintf("cross-project messaging requires target '%s' in project '%s' to be is_executive=true", to, dstProject)), nil

--- a/internal/relay/handlers_messaging.go
+++ b/internal/relay/handlers_messaging.go
@@ -108,6 +108,23 @@ func (h *Handlers) HandleSendMessage(ctx context.Context, req mcp.CallToolReques
 		return toolResultError("to is required (or provide conversation_id)"), nil
 	}
 
+	// Reject an unknown recipient up front — this must run regardless of
+	// hasTeams (unlike the permission check below), because an unregistered
+	// 'to' is otherwise accepted silently: a message-id comes back, zero
+	// deliveries happen, nobody is ever alerted. Only a name that was never
+	// registered, or was soft-deleted, is rejected — 'sleeping'/'inactive'
+	// agents are re-bindable identities and their delivery legitimately
+	// queues.
+	if conversationID == nil && to != "*" && to != "user" && !strings.HasPrefix(to, "team:") {
+		recipient, err := h.db.GetAgent(project, to)
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("failed to resolve recipient '%s': %v", to, err)), nil
+		}
+		if recipient == nil || recipient.Status == "deleted" {
+			return mcp.NewToolResultError(h.unknownRecipientError(project, to)), nil
+		}
+	}
+
 	// Permission check: only enforce when teams are configured (bypass for "user" — always reachable)
 	if conversationID == nil && to != "*" && !isOperator(to) && !strings.HasPrefix(to, "team:") {
 		hasTeams, _ := h.db.HasTeams(project)

--- a/internal/relay/handlers_messaging.go
+++ b/internal/relay/handlers_messaging.go
@@ -115,13 +115,28 @@ func (h *Handlers) HandleSendMessage(ctx context.Context, req mcp.CallToolReques
 	// registered, or was soft-deleted, is rejected — 'sleeping'/'inactive'
 	// agents are re-bindable identities and their delivery legitimately
 	// queues.
-	if conversationID == nil && to != "*" && to != "user" && !strings.HasPrefix(to, "team:") {
+	// "human" is the console operator inbox, the twin of "user" (notifications.go
+	// resolveTargets maps both to the same target); it is a literal, not an agent
+	// row, so it must be exempted here exactly like "user" — otherwise operator
+	// traffic addressed to "human" is wrongly rejected as an unknown recipient.
+	if conversationID == nil && to != "*" && to != "user" && to != "human" && !strings.HasPrefix(to, "team:") {
 		recipient, err := h.db.GetAgent(project, to)
 		if err != nil {
-			return mcp.NewToolResultError(fmt.Sprintf("failed to resolve recipient '%s': %v", to, err)), nil
+			return toolResultError(fmt.Sprintf("failed to resolve recipient '%s': %v", to, err)), nil
 		}
-		if recipient == nil || recipient.Status == "deleted" {
-			return mcp.NewToolResultError(h.unknownRecipientError(project, to)), nil
+		// A name with no agent row is rejected UNLESS the fleet already expects
+		// it — a task dispatched to it (profile_slug = name) before it called
+		// register_agent is a boot-race, not a bad address, and its delivery
+		// legitimately queues until the identity binds (task 0464d6cb; mirrors
+		// the permission check below). A soft-deleted agent is always rejected.
+		// Errors route through toolResultError so this path speaks the same
+		// canonical envelope as the rest of the tool surface (errors.go).
+		if recipient == nil {
+			if !h.db.RecipientIsFleetExpected(project, to) {
+				return toolResultError(h.unknownRecipientError(project, to)), nil
+			}
+		} else if recipient.Status == "deleted" {
+			return toolResultError(h.unknownRecipientError(project, to)), nil
 		}
 	}
 

--- a/internal/relay/handlers_test.go
+++ b/internal/relay/handlers_test.go
@@ -396,6 +396,176 @@ func TestSendMessageMissingTo(t *testing.T) {
 	expectError(t, res)
 }
 
+// --- Unknown Recipient Tests (reject-unknown-recipient) ---
+
+// TestSendMessageUnknownRecipientRejected is the core guarantee: a 'to' that
+// was never registered must come back as an error, not a delivered message-id
+// that silently goes nowhere.
+func TestSendMessageUnknownRecipientRejected(t *testing.T) {
+	h := testHandlers(t)
+	_, _ = h.HandleRegisterAgent(ctx, call(map[string]any{"project": "p1", "name": "bot-a", "role": "dev"}))
+
+	res, _ := h.HandleSendMessage(ctx, call(map[string]any{
+		"project": "p1", "as": "bot-a", "to": "bot-z", "content": "hello",
+	}))
+	msg := expectError(t, res)
+	if !strings.Contains(msg, "bot-z") {
+		t.Errorf("expected error to mention unknown recipient 'bot-z', got: %s", msg)
+	}
+}
+
+// TestSendMessageUnknownRecipientSuggestion covers the CTO's actual incident:
+// a near-miss name (typo/close variant) should be offered as a "did you mean"
+// hint so the sender catches it immediately instead of losing an hour.
+func TestSendMessageUnknownRecipientSuggestion(t *testing.T) {
+	h := testHandlers(t)
+	_, _ = h.HandleRegisterAgent(ctx, call(map[string]any{"project": "p1", "name": "bot-a", "role": "dev"}))
+	_, _ = h.HandleRegisterAgent(ctx, call(map[string]any{"project": "p1", "name": "backend-lead"}))
+
+	// "backend-leadd" is one edit away from the registered "backend-lead".
+	res, _ := h.HandleSendMessage(ctx, call(map[string]any{
+		"project": "p1", "as": "bot-a", "to": "backend-leadd", "content": "hello",
+	}))
+	msg := expectError(t, res)
+	if !strings.Contains(msg, "Did you mean") || !strings.Contains(msg, "backend-lead") {
+		t.Errorf("expected a 'Did you mean: backend-lead' hint, got: %s", msg)
+	}
+}
+
+// TestSendMessageUnknownRecipientTokenInsertionSuggestion is the CTO's exact
+// incident pair — 'frontend-lead' vs the registered 'frontend-tech-lead' —
+// which is 5 Levenshtein edits apart (misses the edit-distance heuristic
+// entirely) but is exactly the target's tokens with 'tech' inserted in the
+// middle. The token-aware heuristic must catch it: same first token
+// ('frontend'), target tokens a subsequence of the candidate's tokens.
+func TestSendMessageUnknownRecipientTokenInsertionSuggestion(t *testing.T) {
+	h := testHandlers(t)
+	_, _ = h.HandleRegisterAgent(ctx, call(map[string]any{"project": "p1", "name": "bot-a", "role": "dev"}))
+	_, _ = h.HandleRegisterAgent(ctx, call(map[string]any{"project": "p1", "name": "frontend-tech-lead"}))
+
+	res, _ := h.HandleSendMessage(ctx, call(map[string]any{
+		"project": "p1", "as": "bot-a", "to": "frontend-lead", "content": "hello",
+	}))
+	msg := expectError(t, res)
+	if !strings.Contains(msg, "Did you mean") || !strings.Contains(msg, "frontend-tech-lead") {
+		t.Errorf("expected a 'Did you mean: frontend-tech-lead' hint, got: %s", msg)
+	}
+}
+
+// TestSendMessageUnknownRecipientNoSuggestionUnrelatedName is the true
+// "nothing close" case: neither the edit-distance heuristic nor the
+// token-aware heuristic should fire for a name that shares no tokens and no
+// near-spelling with anything on the roster.
+func TestSendMessageUnknownRecipientNoSuggestionUnrelatedName(t *testing.T) {
+	h := testHandlers(t)
+	_, _ = h.HandleRegisterAgent(ctx, call(map[string]any{"project": "p1", "name": "bot-a", "role": "dev"}))
+	_, _ = h.HandleRegisterAgent(ctx, call(map[string]any{"project": "p1", "name": "backend-lead"}))
+	_, _ = h.HandleRegisterAgent(ctx, call(map[string]any{"project": "p1", "name": "frontend-tech-lead"}))
+
+	res, _ := h.HandleSendMessage(ctx, call(map[string]any{
+		"project": "p1", "as": "bot-a", "to": "paymentbot", "content": "hello",
+	}))
+	msg := expectError(t, res)
+	if !strings.Contains(msg, "paymentbot") {
+		t.Errorf("expected error to mention 'paymentbot', got: %s", msg)
+	}
+	if strings.Contains(msg, "Did you mean") {
+		t.Errorf("expected no suggestion for a wholly unrelated name, got: %s", msg)
+	}
+}
+
+// TestSendMessageKnownRecipientStillSucceeds is the no-regression check: a
+// valid, registered recipient must still go through.
+func TestSendMessageKnownRecipientStillSucceeds(t *testing.T) {
+	h := testHandlers(t)
+	_, _ = h.HandleRegisterAgent(ctx, call(map[string]any{"project": "p1", "name": "bot-a", "role": "dev"}))
+	_, _ = h.HandleRegisterAgent(ctx, call(map[string]any{"project": "p1", "name": "bot-b", "role": "qa"}))
+
+	res, _ := h.HandleSendMessage(ctx, call(map[string]any{
+		"project": "p1", "as": "bot-a", "to": "bot-b", "content": "hello",
+	}))
+	if res.IsError {
+		t.Fatalf("expected success for a registered recipient: %s", expectError(t, res))
+	}
+}
+
+// TestSendMessageSleepingRecipientAccepted: sleeping is a re-bindable status,
+// not a rejection — the identity is real and delivery queues legitimately.
+func TestSendMessageSleepingRecipientAccepted(t *testing.T) {
+	h := testHandlers(t)
+	_, _ = h.HandleRegisterAgent(ctx, call(map[string]any{"project": "p1", "name": "bot-a", "role": "dev"}))
+	_, _ = h.HandleRegisterAgent(ctx, call(map[string]any{"project": "p1", "name": "bot-b", "role": "qa"}))
+	_, _ = h.HandleSleepAgent(ctx, call(map[string]any{"project": "p1", "as": "bot-b"}))
+
+	res, _ := h.HandleSendMessage(ctx, call(map[string]any{
+		"project": "p1", "as": "bot-a", "to": "bot-b", "content": "hello",
+	}))
+	if res.IsError {
+		t.Fatalf("expected sleeping recipient to still be accepted: %s", expectError(t, res))
+	}
+}
+
+// TestSendMessageInactiveRecipientAccepted mirrors the sleeping case for the
+// 'inactive' status (auto-marked stale, also re-bindable).
+func TestSendMessageInactiveRecipientAccepted(t *testing.T) {
+	h := testHandlers(t)
+	_, _ = h.HandleRegisterAgent(ctx, call(map[string]any{"project": "p1", "name": "bot-a", "role": "dev"}))
+	_, _ = h.HandleRegisterAgent(ctx, call(map[string]any{"project": "p1", "name": "bot-c", "role": "qa"}))
+	_, _ = h.HandleDeactivateAgent(ctx, call(map[string]any{"project": "p1", "name": "bot-c"}))
+
+	res, _ := h.HandleSendMessage(ctx, call(map[string]any{
+		"project": "p1", "as": "bot-a", "to": "bot-c", "content": "hello",
+	}))
+	if res.IsError {
+		t.Fatalf("expected inactive recipient to still be accepted: %s", expectError(t, res))
+	}
+}
+
+// TestSendMessageDeletedRecipientRejected: unlike sleeping/inactive, a
+// soft-deleted agent is gone for good — messaging it must be rejected same
+// as an unregistered name.
+func TestSendMessageDeletedRecipientRejected(t *testing.T) {
+	h := testHandlers(t)
+	_, _ = h.HandleRegisterAgent(ctx, call(map[string]any{"project": "p1", "name": "bot-a", "role": "dev"}))
+	_, _ = h.HandleRegisterAgent(ctx, call(map[string]any{"project": "p1", "name": "bot-d", "role": "qa"}))
+	_, _ = h.HandleDeleteAgent(ctx, call(map[string]any{"project": "p1", "name": "bot-d"}))
+
+	res, _ := h.HandleSendMessage(ctx, call(map[string]any{
+		"project": "p1", "as": "bot-a", "to": "bot-d", "content": "hello",
+	}))
+	msg := expectError(t, res)
+	if !strings.Contains(msg, "bot-d") {
+		t.Errorf("expected error to mention deleted recipient 'bot-d', got: %s", msg)
+	}
+}
+
+// TestSendCrossProjectUnknownRecipientRejected checks the sendCrossProject
+// symmetry: a 'to' that doesn't exist in the TARGET project must be rejected
+// the same way a local unknown recipient is, and a valid executive target
+// must still succeed (no regression).
+func TestSendCrossProjectUnknownRecipientRejected(t *testing.T) {
+	h := testHandlers(t)
+	_, _ = h.HandleRegisterAgent(ctx, call(map[string]any{"project": "p1", "name": "alice", "is_executive": true}))
+	_, _ = h.HandleRegisterAgent(ctx, call(map[string]any{"project": "p2", "name": "bob", "is_executive": true}))
+
+	// Unknown target in p2 → rejected, error names the target project.
+	res, _ := h.HandleSendMessage(ctx, call(map[string]any{
+		"project": "p1", "as": "alice", "target_project": "p2", "to": "carol", "content": "hi",
+	}))
+	msg := expectError(t, res)
+	if !strings.Contains(msg, "carol") || !strings.Contains(msg, "p2") {
+		t.Errorf("expected error to mention unknown recipient 'carol' in project 'p2', got: %s", msg)
+	}
+
+	// Known executive target in p2 → still succeeds.
+	res2, _ := h.HandleSendMessage(ctx, call(map[string]any{
+		"project": "p1", "as": "alice", "target_project": "p2", "to": "bob", "content": "hi",
+	}))
+	if res2.IsError {
+		t.Fatalf("expected cross-project send to a known executive to succeed: %s", expectError(t, res2))
+	}
+}
+
 // TestDMReplyPathGrant is the TSU-75 guarantee: receiving a DM opens a scoped
 // reply-path back to the sender, so an agent can always answer a message even
 // across the team auth-wall — and the grant does NOT open it to anyone else.

--- a/internal/relay/suggest.go
+++ b/internal/relay/suggest.go
@@ -1,0 +1,170 @@
+package relay
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// levenshtein returns the edit distance between a and b, compared
+// case-insensitively. Classic iterative two-row implementation — no
+// external dependency needed for a handful of short agent names.
+func levenshtein(a, b string) int {
+	a = strings.ToLower(a)
+	b = strings.ToLower(b)
+	ra, rb := []rune(a), []rune(b)
+
+	prev := make([]int, len(rb)+1)
+	curr := make([]int, len(rb)+1)
+	for j := range prev {
+		prev[j] = j
+	}
+
+	for i := 1; i <= len(ra); i++ {
+		curr[0] = i
+		for j := 1; j <= len(rb); j++ {
+			cost := 1
+			if ra[i-1] == rb[j-1] {
+				cost = 0
+			}
+			del := prev[j] + 1
+			ins := curr[j-1] + 1
+			sub := prev[j-1] + cost
+			min := del
+			if ins < min {
+				min = ins
+			}
+			if sub < min {
+				min = sub
+			}
+			curr[j] = min
+		}
+		prev, curr = curr, prev
+	}
+	return prev[len(rb)]
+}
+
+// nearbyAgentNames returns the names in candidates that are a plausible "did
+// you mean" match for target, combining two independent heuristics:
+//
+//  1. Levenshtein distance <= maxDist (typos / small edits) — the original
+//     behavior.
+//  2. Token-aware match (see tokenAwareMatch): catches token-insertion
+//     aliases like 'frontend-lead' -> 'frontend-tech-lead', which sit 5 edits
+//     apart (Levenshtein misses them entirely) but are exactly the target's
+//     tokens plus one inserted in the middle.
+//
+// Levenshtein matches are listed first, sorted by (distance ascending, name
+// ascending); token-only matches follow, sorted by name. A candidate that
+// qualifies both ways appears once, in the Levenshtein position — priority
+// goes to the stronger (edit-distance) signal. The combined list is capped
+// at max entries. Used to produce a "did you mean" hint when a send_message
+// recipient doesn't resolve to a registered agent.
+func nearbyAgentNames(candidates []string, target string, maxDist, max int) []string {
+	type scored struct {
+		name string
+		dist int
+	}
+	var levMatches []scored
+	levSeen := make(map[string]bool, len(candidates))
+	for _, c := range candidates {
+		d := levenshtein(c, target)
+		if d <= maxDist {
+			levMatches = append(levMatches, scored{name: c, dist: d})
+			levSeen[strings.ToLower(c)] = true
+		}
+	}
+	sort.Slice(levMatches, func(i, j int) bool {
+		if levMatches[i].dist != levMatches[j].dist {
+			return levMatches[i].dist < levMatches[j].dist
+		}
+		return levMatches[i].name < levMatches[j].name
+	})
+
+	targetTokens := strings.Split(strings.ToLower(target), "-")
+	var tokenMatches []string
+	for _, c := range candidates {
+		if levSeen[strings.ToLower(c)] {
+			continue // already ranked via the stronger Levenshtein signal
+		}
+		if tokenAwareMatch(targetTokens, strings.Split(strings.ToLower(c), "-")) {
+			tokenMatches = append(tokenMatches, c)
+		}
+	}
+	sort.Strings(tokenMatches)
+
+	names := make([]string, 0, len(levMatches)+len(tokenMatches))
+	for _, m := range levMatches {
+		names = append(names, m.name)
+	}
+	names = append(names, tokenMatches...)
+	if len(names) > max {
+		names = names[:max]
+	}
+	return names
+}
+
+// tokenAwareMatch reports whether candTokens is a plausible token-insertion
+// alias of targetTokens: every token of targetTokens must appear in
+// candTokens, in order, as a (not necessarily contiguous) subsequence — and
+// target/candidate must share their first token or their last token, which
+// keeps an unrelated candidate that happens to contain the same words in a
+// different role from matching. Both slices are expected pre-lowercased.
+// Example: targetTokens=[frontend,lead], candTokens=[frontend,tech,lead] ->
+// true (frontend...lead is a subsequence, first token shared).
+func tokenAwareMatch(targetTokens, candTokens []string) bool {
+	if len(targetTokens) == 0 || len(candTokens) == 0 {
+		return false
+	}
+	sameFirst := targetTokens[0] == candTokens[0]
+	sameLast := targetTokens[len(targetTokens)-1] == candTokens[len(candTokens)-1]
+	if !sameFirst && !sameLast {
+		return false
+	}
+	i := 0
+	for _, tok := range candTokens {
+		if i < len(targetTokens) && tok == targetTokens[i] {
+			i++
+		}
+	}
+	return i == len(targetTokens)
+}
+
+// unknownRecipientError builds the rejection message for a send_message 'to'
+// that doesn't resolve to a registered active agent in project, appending a
+// "did you mean" hint (Levenshtein distance <= 2, up to 3 names) when a
+// close match exists among that project's known agents. Best-effort: a
+// lookup failure while building suggestions is silently ignored — the
+// rejection itself still happens.
+func (h *Handlers) unknownRecipientError(project, to string) string {
+	msg := fmt.Sprintf("unknown recipient '%s' — not a registered active agent, '*', 'team:<slug>', or conversation_id.", to)
+	if candidates, err := h.db.ListAgents(project); err == nil {
+		names := make([]string, len(candidates))
+		for i, a := range candidates {
+			names[i] = a.Name
+		}
+		if sugg := nearbyAgentNames(names, to, 2, 3); len(sugg) > 0 {
+			msg += fmt.Sprintf(" Did you mean: %s?", strings.Join(sugg, ", "))
+		}
+	}
+	return msg
+}
+
+// unknownCrossProjectRecipientError is the sendCrossProject counterpart of
+// unknownRecipientError: same rejection semantics (nil or soft-deleted
+// recipient), suggestions drawn from the TARGET project's roster rather than
+// the caller's, and the message names that target project explicitly since
+// it isn't the project the caller is sitting in.
+func (h *Handlers) unknownCrossProjectRecipientError(dstProject, to string) string {
+	msg := fmt.Sprintf("unknown recipient '%s' — not a registered active agent in project '%s'.", to, dstProject)
+	if candidates, err := h.db.ListAgents(dstProject); err == nil {
+		names := make([]string, len(candidates))
+		for i, a := range candidates {
+			names[i] = a.Name
+		}
+		if sugg := nearbyAgentNames(names, to, 2, 3); len(sugg) > 0 {
+			msg += fmt.Sprintf(" Did you mean: %s?", strings.Join(sugg, ", "))
+		}
+	}
+	return msg
+}


### PR DESCRIPTION
### niwa Q&A gate

An adversarial reviewer is reading this diff right now. Its verdict lands on this PR as a review (or a comment when the gate and the author share one GitHub account), and the merge waits for this repository's own checks to go green.

*Opened automatically — a rejected round comes back to the author, who pushes fixes to the same branch.*

## What & why

- **docs(scribe): provenance for split-wraith-ext-triage-pr-152-reject-unknown-send-message-recipient-instead-of-**
- **fix(relay): keep 'human' + fleet-expected recipients valid under the reject guard**
  <details><summary>details</summary>

  The new unknown-recipient guard (PR #152) fired unconditionally and so
  regressed two recipients that main delivers without an agent row:
  - "human": the console operator inbox, the twin of "user" (resolveTargets
    maps both to the same target) — now exempted alongside "user".
  - a fleet-expected recipient: a name dispatched a task (profile_slug=name)
    before it registered is a boot-race, not a bad address — its delivery
    must queue, mirroring the permission check below (task 0464d6cb). The
    guard now defers to RecipientIsFleetExpected before rejecting a nil row.
  
  Adds AC coverage: TestSendMessageKnownNonAgentRecipientsStillAccepted
  (*, team, user, human still accepted) and TestExtPR152DiffScope (the
  "did you mean" suggestion stays scoped to the caller's project — no
  cross-project roster leak).
  
  Claude-Session: https://claude.ai/code/session_01XbzhXo1kXCNX9qC6jaZ6pp

  </details>
- **fix(relay): reject unknown send_message recipient instead of silent-accept**
  <details><summary>details</summary>

  A send_message to a name that is not a registered agent used to succeed
  silently — a message-id came back, zero deliveries were created, and the
  message was never read nor flagged. Coordination was lost this way (e.g.
  'frontend-lead' vs the real 'frontend-tech-lead').
  
  HandleSendMessage now rejects, independently of whether teams are
  configured, any direct 'to' that resolves to no agent (GetAgent == nil)
  or to a soft-deleted one. '*', 'user', 'team:<slug>' and conversation
  messages are unaffected; 'sleeping'/'inactive' agents stay valid (their
  delivery legitimately queues). sendCrossProject gets the same guard,
  scoped to the destination project's roster.
  
  The rejection lists nearby active agents to auto-correct: Levenshtein
  distance <= 2, plus a token-aware match (hyphen-token subsequence sharing
  first or last token) so mid-token-insertion aliases like
  'frontend-lead' -> 'frontend-tech-lead' are surfaced too.
  
  Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

  </details>

## Changes

<details><summary>Files changed (git diff --stat)</summary>

```
...r-p1-one-operator-identity-end-to-end-server.md |  81 ----------
 ...t-unknown-send-message-recipient-instead-of-.md |  99 ++++++++++++
 internal/db/tasks.go                               |   7 +-
 internal/relay/api.go                              |   2 +-
 internal/relay/api_messages.go                     |  10 +-
 internal/relay/ext_pr152_recipient_test.go         |  81 ++++++++++
 internal/relay/handlers.go                         |  10 +-
 internal/relay/handlers_messaging.go               |  34 ++++-
 internal/relay/handlers_test.go                    | 170 +++++++++++++++++++++
 internal/relay/operator_identity_test.go           |  70 ---------
 internal/relay/suggest.go                          | 170 +++++++++++++++++++++
 11 files changed, 565 insertions(+), 169 deletions(-)
```

</details>

## Module graph

```mermaid
graph TD
  n0["features/split-wraith-ext-triage-pr-152-reject-unknown-send-message-recipient-instead-of-.md"]
  n1["internal/relay"]
```

## Acceptance criteria

- [x] AC1 TestSendMessageUnknownRecipientRejected: send_message to a name that is neither an agent, a team, '*', 'human'/'user' nor a federation peer in the project returns an error naming the recipient and inserts no message row
- [x] AC2 TestSendMessageKnownNonAgentRecipientsStillAccepted: '*' broadcast, an existing team name, 'human' and 'user' each still create the message + deliveries exactly as on main d35ab8c
- [x] AC3 TestExtPR152DiffScope: go test -tags fts5 ./internal/relay/... ./internal/db/... green; diff limited to the PR's files (+ one test file); original author kept as commit author
## Provenance

📄 [Root cause, decisions &amp; QA log — `features/split-wraith-ext-triage-pr-152-reject-unknown-send-message-recipient-instead-of-.md`](https://github.com/TsukumoHQ/WRAI.TH/blob/wraith-engine-2/ext-152/features/split-wraith-ext-triage-pr-152-reject-unknown-send-message-recipient-instead-of-.md)

## Gate verdict

**✅ APPROVED** · round 2 · reviewer `review-54ea39d8-1bbd-4efe-a363-b9792b5d0d61`

## review-wraith verdict: SHIP
Scope: internal/relay/handlers.go, handlers_messaging.go, handlers_test.go, suggest.go, NEW ext_pr152_recipient_test.go
Gate: build -tags fts5 OK / vet OK / gofmt OK / test -tags fts5 relay+db OK (819 pass)

BLOCKERS (must fix before merge):
- none

NITS (non-blocking):
- Federation-peer / bare-role (`cto`/`founder`) recipients: not delivered through this
  bare-`to` path in current code, so unaffected by the guard; not separately tested.
  Flagged to cto — if a future path addresses them literally, revisit the exemption set.
## review-wraith verdict: SHIP
Scope: internal/relay/handlers.go, handlers_messaging.go, handlers_test.go, suggest.go, NEW ext_pr152_recipient_test.go
Gate: build -tags fts5 OK / vet OK / gofmt OK / test -tags fts5 relay+db OK (819 pass)

BLOCKERS (must fix before merge):
- none

NITS (non-blocking):
- Federation-peer / bare-role (`cto`/`founder`) recipients: not delivered through this
  bare-`to` path in current code, so unaffected by the guard; not separately tested.
  Flagged to cto — if a future path addresses them literally, revisit the exemption set.
## review-wraith verdict: SHIP
Scope: internal/relay/handlers.go, handlers_messaging.go, handlers_test.go, suggest.go, NEW ext_pr152_recipient_test.go
Gate: build -tags fts5 OK / vet OK / gofmt OK / test -tags fts5 relay+db OK (819 pass)

BLOCKERS (must fix before merge):
- none

NITS (non-blocking):
- Federation-peer / bare-role (`cto`/`founder`) recipients: not delivered through this
  bare-`to` path in current code, so unaffected by the guard; not separately tested.
  Flagged to cto — if a future path addresses them literally, revisit the exemption set.

---
<sub>Authored by agent `wraith-engine-2` · branch `wraith-engine-2/ext-152` → `main` · reviewed by niwa-gate and merged when this repo's checks pass.</sub>
